### PR TITLE
feat: Rewrite term links to point to headless front-end URL.

### DIFF
--- a/plugins/wpe-headless/includes/replacement/callbacks.php
+++ b/plugins/wpe-headless/includes/replacement/callbacks.php
@@ -100,6 +100,7 @@ function wpe_headless_post_link( $permalink, $post, $leavename ) {
 	return $permalink;
 }
 
+add_filter( 'term_link', 'wpe_headless_term_link' );
 /**
  * Rewrites term links to point to the specified front-end URL.
  *
@@ -119,4 +120,3 @@ function wpe_headless_term_link( $term_link ) {
 
 	return str_replace( $site_url, $frontend_uri, $term_link );
 }
-add_filter( 'term_link', 'wpe_headless_term_link' );


### PR DESCRIPTION
Rewrites post and term links to point to headless URL.

Branched from `deny-public-access`, which was branched from `ryanmeier/BH-735-update-plugin-syntax`.

Does not touch preview links, as that's being handled in `ryanmeier/BH-735-update-plugin-syntax`.
