### PR TITLE
docs: fix graphql import path

### DIFF
--- a/packages/headless/src/graphql/WPGraphQLProvider.tsx
+++ b/packages/headless/src/graphql/WPGraphQLProvider.tsx
@@ -14,7 +14,7 @@ interface Props {
  *
  * @example
  * ```ts
- * import {WPGraphQLProvider} from '@wpengine/next-source-wpgraphql'
+ * import {WPGraphQLProvider} from '@wpengine/headless/graphql'
  *
  * function MyApp({Component, pageProps}) {
  *     return (


### PR DESCRIPTION
Fixes documented import path.

The package was moved in https://github.com/wpengine/headless-framework/pull/12, but I missed the docs link in that review.