### PR TITLE
refactor: Enabled client-side and SSR authenticated requests and servers that aren't Next

### DIFF
--- a/examples/preview/pages/[[...page]].tsx
+++ b/examples/preview/pages/[[...page]].tsx
@@ -1,12 +1,15 @@
 /* eslint-disable react/jsx-props-no-spreading */
 import React from 'react';
-import { useUriInfo, initializeHeadlessProps } from '@wpengine/headless';
+import {
+  useNextUriInfo,
+  initializeNextServerSideProps,
+} from '@wpengine/headless';
 import { GetServerSidePropsContext } from 'next';
 import Posts from '../lib/components/Posts';
 import Post from '../lib/components/Post';
 
 export default function Page() {
-  const pageInfo = useUriInfo();
+  const pageInfo = useNextUriInfo();
 
   if (!pageInfo) {
     return <></>;
@@ -19,6 +22,6 @@ export default function Page() {
   return <Post />;
 }
 
-export async function getServerSideProps(context: GetServerSidePropsContext) {
-  return initializeHeadlessProps(context);
+export function getServerSideProps(context: GetServerSidePropsContext) {
+  return initializeNextServerSideProps(context);
 }

--- a/examples/preview/pages/_app.tsx
+++ b/examples/preview/pages/_app.tsx
@@ -2,10 +2,6 @@ import React from 'react';
 import { AppContext, AppInitialProps } from 'next/app';
 import { HeadlessProvider, headlessConfig } from '@wpengine/headless';
 
-headlessConfig({
-  uriPrefix: '/blog',
-});
-
 /* eslint-disable react/jsx-props-no-spreading */
 export default function App({
   Component,

--- a/examples/preview/pages/api/authorize.ts
+++ b/examples/preview/pages/api/authorize.ts
@@ -1,0 +1,3 @@
+import { authorizeHandler } from '@wpengine/headless';
+
+export default authorizeHandler;

--- a/packages/headless/package.json
+++ b/packages/headless/package.json
@@ -28,7 +28,6 @@
   "dependencies": {
     "deepmerge": "^4.2.2",
     "isomorphic-fetch": "^3.0.0",
-    "moize": "^5.4.7",
     "universal-cookie": "^4.0.4"
   },
   "peerDependencies": {

--- a/packages/headless/src/api/index.ts
+++ b/packages/headless/src/api/index.ts
@@ -1,3 +1,3 @@
 export * from './hooks';
 export * from './services';
-export * from './load';
+export * from './initializeNextServerSideProps';

--- a/packages/headless/src/auth/authorize.ts
+++ b/packages/headless/src/auth/authorize.ts
@@ -2,7 +2,6 @@ import { ApolloClient, NormalizedCacheObject } from '@apollo/client';
 import { ServerResponse } from 'http';
 import { Redirect } from 'next';
 import { ParsedUrlQuery } from 'querystring';
-import { addAuthorization } from '../provider';
 import { isServerSide, trimTrailingSlash } from '../utils';
 import { getAccessToken, storeAccessToken } from './cookie';
 
@@ -62,10 +61,6 @@ export async function ensureAuthorization(
       accessToken = result.access_token;
       storeAccessToken(accessToken, res);
 
-      if (accessToken) {
-        addAuthorization(client, accessToken);
-      }
-
       return {
         redirect: {
           permanent: false,
@@ -94,8 +89,6 @@ export async function ensureAuthorization(
       },
     };
   }
-
-  addAuthorization(client, accessToken);
 
   return {};
 }

--- a/packages/headless/src/auth/authorize.ts
+++ b/packages/headless/src/auth/authorize.ts
@@ -1,13 +1,20 @@
-import { ApolloClient, NormalizedCacheObject } from '@apollo/client';
-import { ServerResponse } from 'http';
-import { Redirect } from 'next';
-import { ParsedUrlQuery } from 'querystring';
-import { isServerSide, trimTrailingSlash } from '../utils';
-import { getAccessToken, storeAccessToken } from './cookie';
+import {
+  isServerSide,
+  parseUrl,
+  trimLeadingSlashes,
+  trimTrailingSlash,
+} from '../utils';
+import { getAccessToken } from './cookie';
 
 const WP_URL = trimTrailingSlash(
   process.env.NEXT_PUBLIC_WORDPRESS_URL || process.env.WORDPRESS_URL,
 );
+const AUTH_URL = trimTrailingSlash(
+  process.env.NEXT_PUBLIC_AUTHORIZATION_URL ||
+    process.env.AUTHORIZATION_URL ||
+    '/api/auth/wpe-headless',
+);
+
 const API_CLIENT_SECRET = process.env.WPE_HEADLESS_SECRET;
 
 if (!API_CLIENT_SECRET && isServerSide()) {
@@ -45,50 +52,28 @@ export async function authorize(code: string) {
 }
 
 // eslint-disable-next-line consistent-return
-export async function ensureAuthorization(
-  client: ApolloClient<NormalizedCacheObject>,
+export function ensureAuthorization<T>(
   url: string,
-  query: ParsedUrlQuery,
-  res: ServerResponse,
-): Promise<{ redirect?: Redirect }> {
-  let accessToken = getAccessToken();
-  const { code } = query;
-  const http = /localhost/.test(url) ? 'http' : 'https';
+): string | { redirect: string } {
+  const accessToken = getAccessToken();
 
-  if (typeof code === 'string') {
-    try {
-      const result = await authorize(code);
-      accessToken = result.access_token;
-      storeAccessToken(accessToken, res);
-
-      return {
-        redirect: {
-          permanent: false,
-          destination: `${http}://${url.replace(
-            /(&?code(=[^&]*)?(?=&|$)|^foo(=[^&]*)?)(&|$)/,
-            '',
-          )}`,
-        },
-      };
-    } catch (e) {
-      console.log('Something went wrong');
-      console.log(e);
-
-      storeAccessToken(undefined, res);
-      return {};
-    }
+  if (!!accessToken && accessToken.length > 0) {
+    return accessToken;
   }
 
-  if (!accessToken || accessToken.length === 0) {
-    return {
-      redirect: {
-        permanent: false,
-        destination: `${
-          WP_URL as string
-        }/generate?redirect_uri=${encodeURIComponent(`${http}://${url}`)}`,
-      },
-    };
+  const parsedUrl = parseUrl(url);
+
+  if (!parsedUrl) {
+    throw new Error('Invalid url for authorization');
   }
 
-  return {};
+  const { baseUrl } = parsedUrl;
+
+  return {
+    redirect: `${WP_URL as string}/generate?redirect_uri=${encodeURIComponent(
+      `${baseUrl}/${
+        trimLeadingSlashes(AUTH_URL as string) as string
+      }?redirect_uri=${encodeURIComponent(url)}`,
+    )}`,
+  };
 }

--- a/packages/headless/src/auth/cookie.ts
+++ b/packages/headless/src/auth/cookie.ts
@@ -32,7 +32,10 @@ export function storeAccessToken(
     cookies.remove(TOKEN_KEY);
     const yesterday = new Date();
     yesterday.setDate(yesterday.getDate() - 1);
-    res.setHeader('Set-Cookie', `${TOKEN_KEY}=; expires=${yesterday.toUTCString()}`);
+    res.setHeader(
+      'Set-Cookie',
+      `${TOKEN_KEY}=; expires=${yesterday.toUTCString()}; path=/`,
+    );
 
     return;
   }
@@ -40,5 +43,8 @@ export function storeAccessToken(
   const encodedToken = base64Encode(token);
 
   cookies.set(TOKEN_KEY, encodedToken);
-  res.setHeader('Set-Cookie', `${TOKEN_KEY}=${encodedToken}; Max-Age=2592000`);
+  res.setHeader(
+    'Set-Cookie',
+    `${TOKEN_KEY}=${encodedToken}; Max-Age=2592000; path=/`,
+  );
 }

--- a/packages/headless/src/auth/index.ts
+++ b/packages/headless/src/auth/index.ts
@@ -1,1 +1,3 @@
 export * from './cookie';
+export * from './middleware';
+export * from './authorize';

--- a/packages/headless/src/auth/middleware.ts
+++ b/packages/headless/src/auth/middleware.ts
@@ -1,0 +1,31 @@
+import { IncomingMessage, ServerResponse } from 'http';
+import { authorize } from './authorize';
+import { storeAccessToken } from './cookie';
+import { getQueryParam } from '../utils';
+
+export async function authorizeHandler(
+  req: IncomingMessage,
+  res: ServerResponse,
+) {
+  try {
+    const url = req.url as string;
+    const code = getQueryParam(url, 'code');
+    const redirectUri = getQueryParam(url, 'redirect_uri');
+
+    if (!code || !redirectUri) {
+      res.statusCode = 401;
+      res.end();
+
+      return;
+    }
+
+    const result = await authorize(code);
+    storeAccessToken(result.access_token, res);
+    res.statusCode = 302;
+    res.setHeader('Location', redirectUri);
+    res.end();
+  } catch (e) {
+    res.statusCode = 500;
+    res.end();
+  }
+}

--- a/packages/headless/src/provider/apolloClient.ts
+++ b/packages/headless/src/provider/apolloClient.ts
@@ -136,20 +136,6 @@ export function addApolloState(
   return pageProps;
 }
 
-export function addAuthorization(
-  client: ApolloClient<any>,
-  accessToken: string,
-) {
-  client.setLink(
-    new HttpLink({
-      uri: `${WP_URL as string}/graphql`,
-      headers: {
-        Authorization: `Bearer ${accessToken}`,
-      },
-    }),
-  );
-}
-
 /**
  * React Hook to use the Apollo client. This is used by <WPGraphQLProvider>
  *

--- a/packages/headless/src/utils/convert.ts
+++ b/packages/headless/src/utils/convert.ts
@@ -114,7 +114,7 @@ export function getUrlPath(url?: string) {
     return '/';
   }
 
-  return parsedUrl?.pathname;
+  return `${parsedUrl?.pathname || '/'}${parsedUrl?.search || ''}`;
 }
 
 export function resolvePrefixedUrlPath(url: string, prefix?: string) {


### PR DESCRIPTION
@claygriffiths asked us to make the previews work with SSR, and there was some confusion on how it should work. It ended up only working with Next and only working on the server. We refactored the code to work with a generic Node server when exchanging a access code for an access token and added generic React support for retrieving post(s).