### PR TITLE
docs: add NPM version badge to README's

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # WordPress Headless Framework (PREVIEW/ALPHA)
 
+[![Version](https://img.shields.io/npm/v/@wpengine/headless.svg)](https://npmjs.org/package/@wpengine/headless)
+
 NOTE: This project is in the early stages of development, but it does contain useful functionallity for headless WordPress sites like plugins and npm packages that assist in authentication and previews.
 
 ## Features

--- a/packages/headless/README.md
+++ b/packages/headless/README.md
@@ -1,5 +1,7 @@
 # WordPress Headless Framework
 
+[![Version](https://img.shields.io/npm/v/@wpengine/headless.svg)](https://npmjs.org/package/@wpengine/headless)
+
 NOTE: This project is in the early stages of development, but it does contain useful functionallity for headless WordPress sites like authenticationa nd post previews. Be sure to install the [WordPress plugin](https://github.com/wpengine/headless-framework) that enables the functionality in this package.
 
 [Documentation](https://github.com/wpengine/headless-framework)


### PR DESCRIPTION
# Summary

Add NPM version badges to main README and README for the `@wpengine/headless` package.