### PR TITLE
chore: change "Wordpress" to "WordPress"

### DIFF
--- a/packages/headless/package.json
+++ b/packages/headless/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@wpengine/headless",
   "version": "0.0.1-alpha.1",
-  "description": "This module helps you use Wordpress as a Headless CMS",
+  "description": "This module helps you use WordPress as a Headless CMS",
   "main": "dist/index.js",
   "scripts": {
     "build": "run-s clean ts",

--- a/packages/headless/src/api/hooks.ts
+++ b/packages/headless/src/api/hooks.ts
@@ -22,7 +22,7 @@ import { headlessConfig } from '../config';
 import { getUrlPath, isServerSide, resolvePrefixedUrlPath } from '../utils';
 
 /**
- * React Hook for retrieving a list of posts from your Wordpress site
+ * React Hook for retrieving a list of posts from your WordPress site
  *
  * @example
  * ```ts

--- a/packages/headless/src/types.ts
+++ b/packages/headless/src/types.ts
@@ -1,6 +1,6 @@
 export interface HeadlessConfig {
   /**
-   * This is a prefix URI path that we will use as the base URL for your Wordpress posts.
+   * This is a prefix URI path that we will use as the base URL for your WordPress posts.
    * By default we will assume that your site is configured with no blog-specific URI.
    *
    * @example /blog


### PR DESCRIPTION
# Summary

Update a few instances of `Wordpress` to `WordPress`

https://developer.wordpress.org/reference/functions/capital_p_dangit/ 😃