### PR TITLE
chore: Remove themes submenu from the Appearance menu

### DIFF
--- a/plugins/wpe-headless/includes/admin-menus/callbacks.php
+++ b/plugins/wpe-headless/includes/admin-menus/callbacks.php
@@ -60,5 +60,6 @@ function wpe_headless_remove_admin_bar_items() {
 	 */
 	global $wp_admin_bar;
 	$wp_admin_bar->remove_menu( 'customize' );
+	$wp_admin_bar->remove_node( 'themes' );
 	$wp_admin_bar->remove_node( 'widgets' );
 }

--- a/plugins/wpe-headless/includes/admin-menus/callbacks.php
+++ b/plugins/wpe-headless/includes/admin-menus/callbacks.php
@@ -63,3 +63,18 @@ function wpe_headless_remove_admin_bar_items() {
 	$wp_admin_bar->remove_node( 'themes' );
 	$wp_admin_bar->remove_node( 'widgets' );
 }
+
+add_action( 'current_screen', 'wpe_headless_prevent_admin_page_access' );
+/**
+ * Prevents access to named pages by redirecting to the admin root.
+ *
+ * @return void
+ */
+function wpe_headless_prevent_admin_page_access() {
+	$screen = get_current_screen();
+
+	if ( is_object( $screen ) && 'themes' === $screen->id ) {
+		wp_safe_redirect( admin_url() );
+		exit;
+	}
+}

--- a/plugins/wpe-headless/includes/admin-menus/callbacks.php
+++ b/plugins/wpe-headless/includes/admin-menus/callbacks.php
@@ -20,6 +20,9 @@ function wpe_headless_remove_admin_menu_pages() {
 	 */
 	global $submenu;
 
+	// Remove Appearance > Themes.
+	remove_submenu_page( 'themes.php', 'themes.php' );
+
 	// Remove Appearance > Theme Editor.
 	remove_submenu_page( 'themes.php', 'theme-editor.php' );
 


### PR DESCRIPTION
For https://wpengine.atlassian.net/browse/BH-791.

## Acceptance Criteria
- Remove Themes and all related items from the WP navigation
- Prevent navigation directly to theme pages

## Notes
Changing themes is still possible via WP-CLI or by manually entering the Customizer URL ( `http://example.com/wp-admin/customize.php` ) and clicking “Change” next to “Active theme” in the Customizer root.

Not sure we need to block the Customizer theme page since we also remove Customizer links by default, but noting in case.