### PR TITLE
feat: add support for Next.js SSG + Previewing

### DIFF
--- a/examples/preview/pages/404.tsx
+++ b/examples/preview/pages/404.tsx
@@ -1,0 +1,6 @@
+/* eslint-disable react/jsx-props-no-spreading */
+import React from 'react';
+
+export default function Page404() {
+  return <h1>404</h1>;
+}

--- a/examples/preview/pages/[[...page]].tsx
+++ b/examples/preview/pages/[[...page]].tsx
@@ -1,10 +1,6 @@
 /* eslint-disable react/jsx-props-no-spreading */
 import React from 'react';
-import {
-  useNextUriInfo,
-  initializeNextServerSideProps,
-} from '@wpengine/headless';
-import { GetServerSidePropsContext } from 'next';
+import { useNextUriInfo, initializeNextStaticProps } from '@wpengine/headless';
 import Posts from '../lib/components/Posts';
 import Post from '../lib/components/Post';
 
@@ -22,6 +18,17 @@ export default function Page() {
   return <Post />;
 }
 
-export function getServerSideProps(context: GetServerSidePropsContext) {
-  return initializeNextServerSideProps(context);
+/**
+ * @todo Show how to switch between static and SSR
+ */
+
+export function getStaticProps(context: any) {
+  return initializeNextStaticProps(context);
+}
+
+export function getStaticPaths() {
+  return {
+    paths: ['/'],
+    fallback: true,
+  };
 }

--- a/examples/preview/pages/api/auth/wpe-headless.ts
+++ b/examples/preview/pages/api/auth/wpe-headless.ts
@@ -1,3 +1,3 @@
-import { authorizeHandler } from '@wpengine/headless';
+import { nextAuthorizeHandler } from '@wpengine/headless';
 
-export default authorizeHandler;
+export default nextAuthorizeHandler;

--- a/packages/headless/src/api/hooks.ts
+++ b/packages/headless/src/api/hooks.ts
@@ -20,6 +20,7 @@ import {
 } from './services';
 import { headlessConfig } from '../config';
 import { getUrlPath, isServerSide, resolvePrefixedUrlPath } from '../utils';
+import {isPreviewPath} from "../utils/preview";
 
 /**
  * React Hook for retrieving a list of posts from your WordPress site
@@ -413,7 +414,7 @@ export function usePost(
               client as ApolloClient<NormalizedCacheObject>,
               pageInfo.uriPath,
               ContentNodeIdType.URI,
-              pageInfo.isPreview,
+              isPreviewPath(window.location.href),
             );
           }
 

--- a/packages/headless/src/api/index.ts
+++ b/packages/headless/src/api/index.ts
@@ -1,3 +1,4 @@
 export * from './hooks';
 export * from './services';
 export * from './initializeNextServerSideProps';
+export * from './initializeNextStaticProps';

--- a/packages/headless/src/api/initializeNextServerSideProps.ts
+++ b/packages/headless/src/api/initializeNextServerSideProps.ts
@@ -1,37 +1,39 @@
 import { GetServerSidePropsContext, GetServerSidePropsResult } from 'next';
 import { getUriInfo, getPosts, getContentNode } from './services';
 import { initializeApollo, addApolloState } from '../provider';
-import { initializeServerCookie, storeAccessToken } from '../auth';
-import { ensureAuthorization } from '../auth/authorize';
 import { headlessConfig } from '../config';
 import { ContentNodeIdType, UriInfo } from '../types';
 import { resolvePrefixedUrlPath } from '../utils';
+import getCurrentPath from '../utils/getCurrentPath';
+import { ensureAuthorization } from '../auth';
+import {isPreview, isPreviewPath} from "../utils/preview";
 
 /**
  * Must be called from getServerSideProps within a Next app in order to support SSR. It will
  * initialized cookies and prefetch/cache the page content and bundle it with the page for
  * rehydration on the frontend.
  *
- * @async
- * @export
  * @param {GetServerSidePropsContext} context The Next SSR context
- * @returns {Promise<GetServerSidePropsResult<unknown>>}
  */
 export async function initializeNextServerSideProps(
   context: GetServerSidePropsContext,
 ): Promise<GetServerSidePropsResult<unknown>> {
   const apolloClient = initializeApollo();
 
-  initializeServerCookie(context.req.headers.cookie);
-
   const wpeConfig = headlessConfig();
+
   const currentUrlPath = resolvePrefixedUrlPath(
-    context.resolvedUrl ?? '',
+    getCurrentPath(context),
     wpeConfig.uriPrefix,
   );
-  const pageInfo = (await getUriInfo(apolloClient, currentUrlPath)) as UriInfo;
 
-  if (pageInfo.isPreview) {
+  const pageInfo = (await getUriInfo(
+    apolloClient,
+    currentUrlPath,
+    isPreview(context),
+  )) as UriInfo;
+
+  if (isPreview(context)) {
     const host = context.req.headers.host as string;
     const protocol = /localhost/.test(host) ? 'http:' : 'https:';
     const response = ensureAuthorization(
@@ -40,7 +42,7 @@ export async function initializeNextServerSideProps(
       }`,
     );
 
-    if (typeof response !== 'string' && typeof response.redirect === 'string') {
+    if (typeof response !== 'string' && response?.redirect) {
       return {
         redirect: {
           permanent: false,
@@ -48,26 +50,25 @@ export async function initializeNextServerSideProps(
         },
       };
     }
+  } else if (isPreviewPath(context)) {
+    return {
+      notFound: true,
+      props: {},
+    };
   }
 
-  try {
-    if (pageInfo.isPostsPage) {
-      await getPosts(apolloClient);
-    } else {
-      await getContentNode(
-        apolloClient,
-        pageInfo.uriPath,
-        ContentNodeIdType.URI,
-        pageInfo.isPreview,
-      );
-    }
-  } catch (e) {
-    storeAccessToken(undefined, context.res);
+  if (pageInfo.isPostsPage) {
+    await getPosts(apolloClient);
+  } else {
+    await getContentNode(
+      apolloClient,
+      pageInfo.uriPath,
+      ContentNodeIdType.URI,
+      isPreview(context),
+    );
   }
 
   return addApolloState(apolloClient, {
     props: { preview: context.preview ?? false },
-  }) as {
-    props: unknown;
-  };
+  });
 }

--- a/packages/headless/src/api/initializeNextStaticProps.ts
+++ b/packages/headless/src/api/initializeNextStaticProps.ts
@@ -1,0 +1,78 @@
+import { GetServerSidePropsResult, GetStaticPropsContext } from 'next';
+import { getUriInfo, getPosts, getContentNode } from './services';
+import { initializeApollo, addApolloState } from '../provider';
+import { headlessConfig } from '../config';
+import { ContentNodeIdType, UriInfo } from '../types';
+import { resolvePrefixedUrlPath } from '../utils';
+import getCurrentPath from '../utils/getCurrentPath';
+import { ensureAuthorization } from '../auth';
+import { isPreview, isPreviewPath } from '../utils/preview';
+
+/**
+ * Must be called from getServerSideProps within a Next app in order to support SSR. It will
+ * initialized cookies and prefetch/cache the page content and bundle it with the page for
+ * rehydration on the frontend.
+ *
+ * @param {GetStaticPropsContext} context The Next SSR context
+ */
+export async function initializeNextStaticProps(
+  context: GetStaticPropsContext,
+): Promise<GetServerSidePropsResult<unknown>> {
+  const apolloClient = initializeApollo();
+
+  const wpeConfig = headlessConfig();
+
+  const currentUrlPath = resolvePrefixedUrlPath(
+    getCurrentPath(context),
+    wpeConfig.uriPrefix,
+  );
+
+  const pageInfo = (await getUriInfo(
+    apolloClient,
+    currentUrlPath,
+    isPreview(context),
+  )) as UriInfo;
+
+  if (isPreview(context)) {
+    const path = Array.isArray(context.params?.page)
+      ? context.params?.page ?? []
+      : [context.params?.page];
+
+    /**
+     * @todo make this host dynamic... unfortunately it's not available in static
+     */
+    const response = ensureAuthorization(
+      `http://localhost:3000/${path.join('/') ?? ''}`,
+    );
+
+    if (typeof response !== 'string' && response?.redirect) {
+      return {
+        redirect: {
+          permanent: false,
+          destination: response.redirect,
+        },
+      };
+    }
+  } else if (isPreviewPath(context)) {
+    return {
+      notFound: true,
+      props: {},
+    };
+  }
+
+  if (pageInfo.isPostsPage) {
+    await getPosts(apolloClient);
+  } else {
+    await getContentNode(
+      apolloClient,
+      pageInfo.uriPath,
+      ContentNodeIdType.URI,
+      isPreview(context),
+    );
+  }
+
+  return addApolloState(apolloClient, {
+    props: { preview: context.preview ?? false },
+    revalidate: 1,
+  });
+}

--- a/packages/headless/src/api/services.ts
+++ b/packages/headless/src/api/services.ts
@@ -267,19 +267,20 @@ export async function getGeneralSettings(
  * @export
  * @param {ApolloClient<NormalizedCacheObject>} client
  * @param {string} uriPath The path for the URI (e.g. '/hello-world')
+ * @param {boolean} [isPreview] Whether or not the page being displayed is in preview mode or not.
  * @returns {(Promise<UriInfo | void>)}
  */
 export async function getUriInfo(
   client: ApolloClient<NormalizedCacheObject>,
   uriPath: string,
+  isPreview?: boolean,
 ): Promise<UriInfo | void> {
   const urlPath = utils.getUrlPath(uriPath);
-  const isPreview = /preview=true/.test(uriPath);
 
   if (isPreview && !isServerSide()) {
     const response = ensureAuthorization(window.location.href);
 
-    if (typeof response !== 'string' && typeof response.redirect === 'string') {
+    if (typeof response !== 'string' && response?.redirect) {
       window.location.replace(response.redirect);
       return;
     }

--- a/packages/headless/src/auth/authorize.ts
+++ b/packages/headless/src/auth/authorize.ts
@@ -68,22 +68,26 @@ export async function authorize(
  * an object containing a redirect URI to send the client to for authorization.
  *
  * @export
- * @param {string} url
+ * @param {string} redirectUri
  * @returns {(string | { redirect: string })}
  */
 export function ensureAuthorization(
-  url: string,
-): string | { redirect: string } {
+  redirectUri: string,
+): string | { redirect: string } | undefined {
   const accessToken = getAccessToken();
+
+  if (!WP_URL) {
+    return undefined;
+  }
 
   if (!!accessToken && accessToken.length > 0) {
     return accessToken;
   }
 
-  const parsedUrl = parseUrl(url);
+  const parsedUrl = parseUrl(redirectUri);
 
   if (!parsedUrl) {
-    throw new Error('Invalid url for authorization');
+    throw new Error('Invalid redirectUri for authorization');
   }
 
   const { baseUrl } = parsedUrl;
@@ -92,7 +96,7 @@ export function ensureAuthorization(
     redirect: `${WP_URL as string}/generate?redirect_uri=${encodeURIComponent(
       `${baseUrl}/${
         trimLeadingSlash(AUTH_URL as string) as string
-      }?redirect_uri=${encodeURIComponent(url)}`,
+      }?redirect_uri=${encodeURIComponent(redirectUri)}`,
     )}`,
   };
 }

--- a/packages/headless/src/auth/cookie.ts
+++ b/packages/headless/src/auth/cookie.ts
@@ -2,15 +2,11 @@ import { ServerResponse } from 'http';
 import Cookies from 'universal-cookie';
 import { base64Decode, base64Encode, trimTrailingSlash } from '../utils';
 
-let cookies = new Cookies();
+const cookies = new Cookies();
 const WP_URL = trimTrailingSlash(
   process.env.NEXT_PUBLIC_WORDPRESS_URL || process.env.WORDPRESS_URL,
 );
 const TOKEN_KEY = `${WP_URL as string}-at`;
-
-export function initializeServerCookie(cookie: string | undefined) {
-  cookies = new Cookies(cookie);
-}
 
 /* eslint-disable consistent-return */
 /**

--- a/packages/headless/src/auth/middleware.ts
+++ b/packages/headless/src/auth/middleware.ts
@@ -1,26 +1,36 @@
-import { IncomingMessage, ServerResponse } from 'http';
-import { authorize } from './authorize';
+import { NextApiRequest, NextApiResponse } from 'next';
+import { authorize, ensureAuthorization } from './authorize';
 import { storeAccessToken } from './cookie';
-import { getQueryParam } from '../utils';
 
 /**
  * A Node handler for processing incomming requests to exchange an Authorization Code
  * for an Access Token using the WordPress API. Once the code is exchanged, this
  * handler stores the Access Token on the cookie and redirects to the frontend.
- *
- * @export
- * @param {IncomingMessage} req
- * @param {ServerResponse} res
- * @returns
  */
-export async function authorizeHandler(
-  req: IncomingMessage,
-  res: ServerResponse,
+export async function nextAuthorizeHandler(
+  req: NextApiRequest,
+  res: NextApiResponse,
 ) {
   try {
-    const url = req.url as string;
-    const code = getQueryParam(url, 'code');
-    const redirectUri = getQueryParam(url, 'redirect_uri');
+    const { code, redirect_uri: redirectUri } = req.query;
+
+    /**
+     * If missing code, this is a request that's meant to trigger authorizationo such as a preview.
+     */
+    if (!code && redirectUri) {
+      const host = req.headers.host ?? '';
+      const protocol = /localhost/.test(host) ? 'http:' : 'https:';
+
+      const response = ensureAuthorization(
+        `${protocol}//${host}/${(redirectUri as string) ?? ''}`,
+      );
+
+      if (typeof response !== 'string' && response?.redirect) {
+        res.redirect(response.redirect);
+
+        return;
+      }
+    }
 
     if (!code || !redirectUri) {
       res.statusCode = 401;
@@ -29,12 +39,20 @@ export async function authorizeHandler(
       return;
     }
 
-    const result = await authorize(code);
+    const result = await authorize(code as string);
     storeAccessToken(result.access_token, res);
-    res.statusCode = 302;
-    res.setHeader('Location', redirectUri);
-    res.end();
+
+    /**
+     * Set cookie to enable previewing.
+     */
+    console.debug('Setting Next.js Preview Data');
+    res.setPreviewData({});
+
+    res.redirect(302, redirectUri as string);
   } catch (e) {
+    console.debug('Clearing Next.js Preview Data');
+    res.clearPreviewData();
+
     res.statusCode = 500;
     res.end();
   }

--- a/packages/headless/src/provider/apolloClient.ts
+++ b/packages/headless/src/provider/apolloClient.ts
@@ -10,6 +10,7 @@ import {
 } from '@apollo/client';
 import merge from 'deepmerge';
 import { isServerSide, trimTrailingSlash } from '../utils';
+import {GetServerSidePropsResult, GetStaticPropsResult} from "next";
 
 export const APOLLO_STATE_PROP_NAME = '__APOLLO_STATE__';
 
@@ -123,13 +124,15 @@ export function initializeApollo(
 export function addApolloState(
   client: ApolloClient<any>,
   pageProps: { [prop: string]: any },
-) {
+) : GetServerSidePropsResult<any> | GetStaticPropsResult<any> {
   if (pageProps?.props) {
     // eslint-disable-next-line no-param-reassign
     pageProps.props[APOLLO_STATE_PROP_NAME] = client.cache.extract();
   }
 
-  return pageProps;
+  return pageProps as {
+    props: unknown;
+  };
 }
 
 /**

--- a/packages/headless/src/provider/apolloClient.ts
+++ b/packages/headless/src/provider/apolloClient.ts
@@ -20,11 +20,7 @@ const WP_URL = trimTrailingSlash(
 if (!WP_URL) {
   if (isServerSide()) {
     throw new Error(
-      'NEXT_PUBLIC_WORDPRESS_URL environment variable is not set. Please set it to your WPGraphQL endpoint if you wish to use client-side requests.',
-    );
-  } else {
-    throw new Error(
-      'WORDPRESS_URL and NEXT_PUBLIC_WORDPRESS_URL environment variables are not set. Please set WORDPRESS_URL (or NEXT_PUBLIC_WORDPRESS_URL if you wish to also use client-side requests) to your WPGraphQL endpoint.',
+      'WORDPRESS_URL and NEXT_PUBLIC_WORDPRESS_URL environment variables are not set. Please set WORDPRESS_URL (or NEXT_PUBLIC_WORDPRESS_URL if you wish to also use client-side requests) to your WPGraphQL endpoint.'
     );
   }
 }
@@ -35,9 +31,9 @@ if (!WP_URL) {
 function createApolloClient(): ApolloClient<NormalizedCacheObject> {
   return new ApolloClient({
     ssrMode: isServerSide(),
-    link: new HttpLink({
+    link:  WP_URL ? new HttpLink({
       uri: `${WP_URL as string}/graphql`,
-    }),
+    }) : undefined,
     cache: new InMemoryCache(),
   });
 }

--- a/packages/headless/src/utils/convert.ts
+++ b/packages/headless/src/utils/convert.ts
@@ -108,43 +108,6 @@ export function parseUrl(url: string | undefined): ParsedUrlInfo | undefined {
 /* eslint-enable consistent-return */
 
 /**
- * Gets query parameters from a url or search string
- *
- * @export
- * @param {string} url
- * @param {string} param
- * @returns {string}
- */
-export function getQueryParam(url: string, param: string) {
-  if (!url || url.length === 0) {
-    return '';
-  }
-
-  const parsedUrl = parseUrl(url);
-
-  if (!parsedUrl) {
-    return '';
-  }
-
-  let query = parsedUrl.search;
-
-  if (query[0] === '?') {
-    query = query.substring(1);
-  }
-
-  const params = query.split('&');
-
-  for (let i = 0; i < params.length; i += 1) {
-    const pair = params[i].split('=');
-    if (decodeURIComponent(pair[0]) === param) {
-      return decodeURIComponent(pair[1]);
-    }
-  }
-
-  return '';
-}
-
-/**
  * Gets the path without the protocol/host/port from a full URL string
  *
  * @export
@@ -174,6 +137,16 @@ export function resolvePrefixedUrlPath(url: string, prefix?: string) {
 
   if (prefix) {
     resolvedUrl = url.replace(prefix, '');
+  }
+
+  const splitUrl = resolvedUrl.split('/');
+
+  /**
+   * Remove preview and preview ID if provided as WP GraphQL will not be able to resolve queries such as nodeByUri
+   * properly.
+   */
+  if (splitUrl?.[splitUrl.length - 2] === 'preview') {
+    resolvedUrl = splitUrl.slice(0, splitUrl.length - 2).join('/');
   }
 
   if (resolvedUrl === '') {

--- a/packages/headless/src/utils/getCurrentPath.ts
+++ b/packages/headless/src/utils/getCurrentPath.ts
@@ -1,0 +1,26 @@
+import { GetServerSidePropsContext, GetStaticPropsContext } from 'next';
+import { isPreviewPath } from './preview';
+
+export default function getCurrentPath(
+  context: GetServerSidePropsContext | GetStaticPropsContext,
+): string {
+  let url: string;
+
+  if (context.params?.page && Array.isArray(context.params?.page)) {
+    let pagePath: string[] = context.params?.page;
+
+    /**
+     * Remove preview and preview ID if provided as WP GraphQL will not be able to resolve queries such as nodeByUri
+     * properly.
+     */
+    if (isPreviewPath(context)) {
+      pagePath = pagePath.slice(0, pagePath.length - 2);
+    }
+
+    url = `/${pagePath.join('/')}`;
+  } else {
+    url = `/${(context.params?.page as string) ?? ''}`;
+  }
+
+  return url;
+}

--- a/packages/headless/src/utils/preview.ts
+++ b/packages/headless/src/utils/preview.ts
@@ -1,0 +1,35 @@
+import { GetServerSidePropsContext, GetStaticPropsContext } from 'next';
+
+export function isPreviewPath(
+  contextOrUrl: GetServerSidePropsContext | GetStaticPropsContext | string,
+): boolean {
+  if (typeof contextOrUrl === 'string') {
+    const urlSplit = contextOrUrl.split('/');
+
+    return urlSplit?.[urlSplit.length - 2] === 'preview';
+  }
+
+  if (contextOrUrl.params?.page && Array.isArray(contextOrUrl.params?.page)) {
+    const { page } = contextOrUrl.params;
+
+    /**
+     * Remove preview and preview ID if provided as WP GraphQL will not be able to resolve queries such as nodeByUri
+     * properly.
+     */
+    if (page?.[page.length - 2] === 'preview') {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+export function isPreview(
+  context: GetServerSidePropsContext | GetStaticPropsContext,
+): boolean {
+  if (!context.preview) {
+    return false;
+  }
+
+  return isPreviewPath(context);
+}

--- a/plugins/wpe-headless/includes/graphql/callbacks.php
+++ b/plugins/wpe-headless/includes/graphql/callbacks.php
@@ -53,10 +53,10 @@ function wpe_headless_register_templates_field() {
 /**
  * Resolver for getting the templates that will be loaded on a given node
  *
- * @param $root
- * @param $args
- * @param AppContext $context
- * @param ResolveInfo $info
+ * @param array       $root  GraphQL Root Object.
+ * @param array       $args  Args passed to query.
+ * @param AppContext  $context The context of the query to pass along.
+ * @param ResolveInfo $info The ResolveInfo object.
  *
  * @return array|string[]
  */
@@ -177,10 +177,10 @@ function wpe_headless_register_conditional_tags_field() {
 /**
  * Resolver for conditionalTags field.
  *
- * @param $root
- * @param $args
- * @param AppContext $context
- * @param ResolveInfo $info
+ * @param array       $root  GraphQL Root Object.
+ * @param array       $args  Args passed to query.
+ * @param AppContext  $context The context of the query to pass along.
+ * @param ResolveInfo $info The ResolveInfo object.
  *
  * @return array
  */

--- a/plugins/wpe-headless/includes/replacement/callbacks.php
+++ b/plugins/wpe-headless/includes/replacement/callbacks.php
@@ -17,7 +17,6 @@ add_filter( 'the_content', 'wpe_headless_content_replacement' );
  *
  * @return string The post content.
  * @todo Needs work...
- *
  */
 function wpe_headless_content_replacement( $content ) {
 	if ( ! wpe_headless_domain_replacement_enabled() ) {
@@ -59,7 +58,7 @@ function wpe_headless_post_preview_link( $link ) {
 		 */
 		$link = str_replace( $home_url, $frontend_uri, $link );
 
-		$args       = wp_parse_args( parse_url( $link, PHP_URL_QUERY ) );
+		$args       = wp_parse_args( wp_parse_url( $link, PHP_URL_QUERY ) );
 		$preview_id = $args['preview_id'];
 
 		/**
@@ -78,9 +77,12 @@ function wpe_headless_post_preview_link( $link ) {
 		 */
 		$path = trailingslashit( $path ) . 'preview/' . $preview_id;
 
-		$link = add_query_arg( array(
-			'redirect_uri' => urlencode( $path ),
-		), $frontend_uri . 'api/auth/wpe-headless' );
+		$link = add_query_arg(
+			array(
+				'redirect_uri' => rawurlencode( $path ),
+			),
+			$frontend_uri . 'api/auth/wpe-headless'
+		);
 	}
 
 	return $link;
@@ -99,7 +101,6 @@ add_filter( 'post_link', 'wpe_headless_post_link', 10 );
  * @return string URL used for the post.
  * @todo Should this always be enabled?
  * @todo Page links
- *
  */
 function wpe_headless_post_link( $link ) {
 	$frontend_uri = wpe_headless_get_setting( 'frontend_uri' );

--- a/plugins/wpe-headless/includes/replacement/callbacks.php
+++ b/plugins/wpe-headless/includes/replacement/callbacks.php
@@ -13,11 +13,11 @@ add_filter( 'the_content', 'wpe_headless_content_replacement' );
 /**
  * Callback for WordPress 'the_content' filter.
  *
- * @todo Needs work...
- *
  * @param string $content The post content.
  *
  * @return string The post content.
+ * @todo Needs work...
+ *
  */
 function wpe_headless_content_replacement( $content ) {
 	if ( ! wpe_headless_domain_replacement_enabled() ) {
@@ -32,23 +32,74 @@ function wpe_headless_content_replacement( $content ) {
 	}
 
 	$content = str_replace( "href=\"{$site_url}", "href=\"{$replacement}", $content );
+
 	return str_replace( 'href="//', 'href="/', $content );
 }
 
-add_filter( 'preview_post_link', 'wpe_headless_post_link', 10 );
+add_filter( 'preview_post_link', 'wpe_headless_post_preview_link', 10 );
+/**
+ * Callback for WordPress 'preview_post_link' filter.
+ *
+ * Swap the post preview link for headless front-end and to use the API entry to support Next.js preview mode.
+ *
+ * @param string $link URL used for the post preview.
+ *
+ * @return string URL used for the post preview.
+ */
+function wpe_headless_post_preview_link( $link ) {
+	$frontend_uri = wpe_headless_get_setting( 'frontend_uri' );
+
+	if ( $frontend_uri ) {
+		$home_url     = trailingslashit( get_home_url() );
+		$frontend_uri = trailingslashit( $frontend_uri );
+
+		/**
+		 * This should already be handled by wpe_headless_post_link, but it's here for verbosity's sake and if the
+		 * other filter changes for any reason.
+		 */
+		$link = str_replace( $home_url, $frontend_uri, $link );
+
+		$args       = wp_parse_args( parse_url( $link, PHP_URL_QUERY ) );
+		$preview_id = $args['preview_id'];
+
+		/**
+		 * Remove query vars as Next.js cannot read query params in SSG
+		 */
+		$link = remove_query_arg( array( 'preview_id', 'preview_nonce', 'preview' ), $link );
+
+		/**
+		 * Replace the path with a query param
+		 */
+		$link_split = explode( '/', $link );
+		$path       = join( '/', array_slice( $link_split, 3 ) );
+
+		/**
+		 * Add preview and preview ID back to path to support Next.js preview mode
+		 */
+		$path = trailingslashit( $path ) . 'preview/' . $preview_id;
+
+		$link = add_query_arg( array(
+			'redirect_uri' => urlencode( $path ),
+		), $frontend_uri . 'api/auth/wpe-headless' );
+	}
+
+	return $link;
+}
+
+
 add_filter( 'post_link', 'wpe_headless_post_link', 10 );
 
 /**
- * Callback for WordPress 'preview_post_link' filter and 'post_link' filter. For now, we use the same callback for both.
+ * Callback for WordPress  'post_link' filter.
  *
- * Swap the post preview link and post links in admin for headless front-end.
+ * Swap post links in admin for headless front-end.
  *
+ * @param string $link URL used for the post.
+ *
+ * @return string URL used for the post.
  * @todo Should this always be enabled?
  * @todo Page links
  *
- * @param string $link URL used for the post preview and/or post.
- *
- * @return string URL used for the post preview.
  */
 function wpe_headless_post_link( $link ) {
 	$frontend_uri = wpe_headless_get_setting( 'frontend_uri' );


### PR DESCRIPTION
# Summary

This PR adds support for Next.js Static Site Generation (SSG) + WordPress Previewing. All of the changes are compatible with our existing previewing examples/articles that utilize server-side rendering (SSR).

Because SSG is superior in terms of performance and the recommended Data Fetching paradigm for Next.js, the preview example in `examples/preview` has been updated to utilize SSG.

# Technical

* Allow `WORDPRESS_URL` environment variable to only be set for server-side if desired
* Register `conditionalTags` and `templates` fields to the `ContentNode` type in WP GraphQL. Previously, we only registered it on `UniformResourceIdentifiable`
* Add new `wpe_headless_post_preview_link` callback to the WordPress plugin which handles redirecting to `api/auth/wpe-headless` by default rather than the permalink on the frontend. This is required as visiting a statically rendered page on Next.js doesn't provide an opportunity to set Next.js `previewMode` cookies. 
* Update `initializeNextServerSideProps` to use Next.js preview mode much like `initializeNextStaticProps`