### PR TITLE
feat: add <TemplateLoader />

### DIFF
--- a/examples/preview/pages/[[...page]].tsx
+++ b/examples/preview/pages/[[...page]].tsx
@@ -4,7 +4,7 @@ import { TemplateLoader, initializeNextStaticProps } from '@wpengine/headless';
 /**
  * @todo make conditionalTags available
  */
-export default function Page({ ...props }) {
+export default function Page() {
   return <TemplateLoader />;
 }
 

--- a/examples/preview/pages/[[...page]].tsx
+++ b/examples/preview/pages/[[...page]].tsx
@@ -1,21 +1,11 @@
-/* eslint-disable react/jsx-props-no-spreading */
 import React from 'react';
-import { useNextUriInfo, initializeNextStaticProps } from '@wpengine/headless';
-import Posts from '../lib/components/Posts';
-import Post from '../lib/components/Post';
+import { TemplateLoader, initializeNextStaticProps } from '@wpengine/headless';
 
-export default function Page() {
-  const pageInfo = useNextUriInfo();
-
-  if (!pageInfo) {
-    return <></>;
-  }
-
-  if (pageInfo.isPostsPage) {
-    return <Posts />;
-  }
-
-  return <Post />;
+/**
+ * @todo make conditionalTags available
+ */
+export default function Page({ ...props }) {
+  return <TemplateLoader />;
 }
 
 /**

--- a/examples/preview/theme/index.tsx
+++ b/examples/preview/theme/index.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import Link from 'next/link';
 import { usePosts } from '@wpengine/headless';
 
-export default function Posts() {
+export default function Index() {
   const posts = usePosts();
 
   return (

--- a/examples/preview/theme/single.tsx
+++ b/examples/preview/theme/single.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { usePost } from '@wpengine/headless';
 
-export default function Post() {
+export default function Single() {
   const post = usePost();
 
   return (

--- a/packages/headless/package-lock.json
+++ b/packages/headless/package-lock.json
@@ -1751,6 +1751,12 @@
         "source-map": "^0.6.0"
       }
     },
+    "@types/webpack-env": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@types/webpack-env/-/webpack-env-1.16.0.tgz",
+      "integrity": "sha512-Fx+NpfOO0CpeYX2g9bkvX8O5qh9wrU1sOF4g8sft4Mu7z+qfe387YlyY8w8daDyDsKY5vUxM0yxkAYnbkRbZEw==",
+      "dev": true
+    },
     "@types/webpack-sources": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@types/webpack-sources/-/webpack-sources-2.0.0.tgz",

--- a/packages/headless/package.json
+++ b/packages/headless/package.json
@@ -50,6 +50,7 @@
     "@types/jest": "^26.0.16",
     "@types/node": "^14.14.10",
     "@types/react": "^17.0.0",
+    "@types/webpack-env": "^1.16.0",
     "@typescript-eslint/eslint-plugin": "^4.9.1",
     "@typescript-eslint/parser": "^4.9.1",
     "clean-webpack-plugin": "^3.0.0",

--- a/packages/headless/src/api/services.ts
+++ b/packages/headless/src/api/services.ts
@@ -257,6 +257,7 @@ export async function getUriInfo(
       query($uri: String!) {
         nodeByUri(uri: $uri) {
           id
+          templates
           ... on ContentType {
             isFrontPage
             isPostsPage
@@ -285,7 +286,7 @@ export async function getUriInfo(
     };
   }
 
-  const { isPostsPage, isFrontPage, id } = result;
+  const { isPostsPage, isFrontPage, id, templates } = result;
 
   return {
     isPostsPage,
@@ -293,6 +294,7 @@ export async function getUriInfo(
     id,
     isPreview,
     uriPath,
+    templates,
   };
 }
 /* eslint-enable consistent-return */

--- a/packages/headless/src/components/TemplateLoader.tsx
+++ b/packages/headless/src/components/TemplateLoader.tsx
@@ -1,0 +1,37 @@
+import dynamic, { LoaderComponent } from 'next/dynamic';
+import React from 'react';
+import { useNextUriInfo } from '../api';
+
+export default function TemplateLoader() {
+  const pageInfo = useNextUriInfo();
+
+  const Component = dynamic(async () => {
+    if (!pageInfo || !pageInfo.templates) {
+      return import(`./theme/index`);
+    }
+
+    // eslint-disable-next-line no-restricted-syntax
+    for (const template of pageInfo.templates) {
+      /**
+       * @todo make this relative to project root
+       */
+      try {
+        // eslint-disable-next-line no-await-in-loop
+        const importedTemplate: LoaderComponent = await import(
+          `./theme/${template}`
+        );
+
+        // eslint-disable-next-line no-await-in-loop
+        if (await importedTemplate) {
+          return importedTemplate;
+        }
+      } catch (e) {
+        console.debug('Template not found.', e);
+      }
+    }
+
+    return import(`./theme/index`);
+  });
+
+  return <Component />;
+}

--- a/packages/headless/src/components/TemplateLoader.tsx
+++ b/packages/headless/src/components/TemplateLoader.tsx
@@ -1,37 +1,40 @@
-import dynamic, { LoaderComponent } from 'next/dynamic';
 import React from 'react';
 import { useNextUriInfo } from '../api';
+import { UriInfo } from '../types';
 
-export default function TemplateLoader() {
+function resolveTemplate(
+  pageInfo: UriInfo | undefined,
+): React.FunctionComponent {
+  /**
+   * List out files in main project using Webpack.
+   */
+  const context = require.context('theme', false, /.*/);
+
+  if (!pageInfo || !pageInfo.templates) {
+    return context(`./index`).default as React.FunctionComponent;
+  }
+
+  // eslint-disable-next-line no-restricted-syntax
+  for (const template of pageInfo.templates) {
+    try {
+      const importedTemplate = context(`./${template}`);
+
+      if (importedTemplate) {
+        return importedTemplate.default as React.FunctionComponent;
+      }
+    } catch (e) {
+      // eslint-disable-next-line no-console
+      console.debug('Template not found.', e);
+    }
+  }
+
+  return context(`./index`).default as React.FunctionComponent;
+}
+
+export default function TemplateLoader(): JSX.Element {
   const pageInfo = useNextUriInfo();
 
-  const Component = dynamic(async () => {
-    if (!pageInfo || !pageInfo.templates) {
-      return import(`./theme/index`);
-    }
-
-    // eslint-disable-next-line no-restricted-syntax
-    for (const template of pageInfo.templates) {
-      /**
-       * @todo make this relative to project root
-       */
-      try {
-        // eslint-disable-next-line no-await-in-loop
-        const importedTemplate: LoaderComponent = await import(
-          `./theme/${template}`
-        );
-
-        // eslint-disable-next-line no-await-in-loop
-        if (await importedTemplate) {
-          return importedTemplate;
-        }
-      } catch (e) {
-        console.debug('Template not found.', e);
-      }
-    }
-
-    return import(`./theme/index`);
-  });
+  const Component = resolveTemplate(pageInfo);
 
   return <Component />;
 }

--- a/packages/headless/src/components/index.ts
+++ b/packages/headless/src/components/index.ts
@@ -1,4 +1,5 @@
-import Menu from "./menu/Menu";
-import MenuItem from "./menu/MenuItemInterface";
+import Menu from './menu/Menu';
+import MenuItem from './menu/MenuItemInterface';
+import TemplateLoader from './TemplateLoader';
 
-export { Menu, MenuItem };
+export { Menu, MenuItem, TemplateLoader };

--- a/packages/headless/src/types.ts
+++ b/packages/headless/src/types.ts
@@ -83,6 +83,7 @@ export interface UriInfo {
   isPreview?: boolean;
   is404?: boolean;
   uriPath: string;
+  templates?: string[];
 }
 
 /**


### PR DESCRIPTION
Add new `<TemplateLoader />` component that's meant to be used as the only component in Next.js pages (specifically, `pages/[[...page]].tsx`).

This component handles loading in components/templates in the projects `themes` directory according to WordPress [template hierarchy](https://developer.wordpress.org/themes/basics/template-hierarchy/) for a given page.