### PR TITLE
WordPress Plugin Feature Toggling

### DIFF
--- a/plugins/wpe-headless/includes/admin-menus/callbacks.php
+++ b/plugins/wpe-headless/includes/admin-menus/callbacks.php
@@ -14,6 +14,7 @@ add_action( 'admin_menu', 'wpe_headless_remove_admin_menu_pages', 1000 );
  * Remove wp-admin menu items not needed in a headless environment.
  *
  * @global $submenu
+ *
  * @return void
  */
 function wpe_headless_remove_admin_menu_pages() {
@@ -23,6 +24,12 @@ function wpe_headless_remove_admin_menu_pages() {
 	 * @var array
 	 */
 	global $submenu;
+
+	$disable_theme = wpe_headless_get_setting( 'disable_theme', false );
+
+	if ( ! $disable_theme ) {
+		return;
+	}
 
 	// Remove Appearance > Themes.
 	remove_submenu_page( 'themes.php', 'themes.php' );
@@ -63,6 +70,13 @@ function wpe_headless_remove_admin_bar_items() {
 	 * @var WP_Admin_Bar $wp_admin_bar
 	 */
 	global $wp_admin_bar;
+
+	$disable_theme = wpe_headless_get_setting( 'disable_theme', false );
+
+	if ( ! $disable_theme ) {
+		return;
+	}
+
 	$wp_admin_bar->remove_menu( 'customize' );
 	$wp_admin_bar->remove_node( 'themes' );
 	$wp_admin_bar->remove_node( 'widgets' );
@@ -75,6 +89,12 @@ add_action( 'current_screen', 'wpe_headless_prevent_admin_page_access' );
  * @return void
  */
 function wpe_headless_prevent_admin_page_access() {
+	$disable_theme = wpe_headless_get_setting( 'disable_theme', false );
+
+	if ( ! $disable_theme ) {
+		return;
+	}
+
 	$screen = get_current_screen();
 
 	if ( is_object( $screen ) && 'themes' === $screen->id ) {

--- a/plugins/wpe-headless/includes/admin-menus/callbacks.php
+++ b/plugins/wpe-headless/includes/admin-menus/callbacks.php
@@ -25,9 +25,7 @@ function wpe_headless_remove_admin_menu_pages() {
 	 */
 	global $submenu;
 
-	$disable_theme = wpe_headless_get_setting( 'disable_theme', false );
-
-	if ( ! $disable_theme ) {
+	if ( ! wpe_headless_is_themes_disabled() ) {
 		return;
 	}
 
@@ -71,9 +69,7 @@ function wpe_headless_remove_admin_bar_items() {
 	 */
 	global $wp_admin_bar;
 
-	$disable_theme = wpe_headless_get_setting( 'disable_theme', false );
-
-	if ( ! $disable_theme ) {
+	if ( ! wpe_headless_is_themes_disabled() ) {
 		return;
 	}
 
@@ -89,9 +85,7 @@ add_action( 'current_screen', 'wpe_headless_prevent_admin_page_access' );
  * @return void
  */
 function wpe_headless_prevent_admin_page_access() {
-	$disable_theme = wpe_headless_get_setting( 'disable_theme', false );
-
-	if ( ! $disable_theme ) {
+	if ( ! wpe_headless_is_themes_disabled() ) {
 		return;
 	}
 

--- a/plugins/wpe-headless/includes/deny-public-access/callbacks.php
+++ b/plugins/wpe-headless/includes/deny-public-access/callbacks.php
@@ -18,9 +18,7 @@ add_action( 'parse_request', 'wpe_headless_deny_public_access', 99 );
  * @return void
  */
 function wpe_headless_deny_public_access( $query ) {
-	$enable_redirects = wpe_headless_get_setting( 'enable_redirects', false );
-
-	if ( ! $enable_redirects ) {
+	if ( ! wpe_headless_is_redirects_enabled() ) {
 		return;
 	}
 

--- a/plugins/wpe-headless/includes/deny-public-access/callbacks.php
+++ b/plugins/wpe-headless/includes/deny-public-access/callbacks.php
@@ -18,6 +18,12 @@ add_action( 'parse_request', 'wpe_headless_deny_public_access', 99 );
  * @return void
  */
 function wpe_headless_deny_public_access( $query ) {
+	$enable_redirects = wpe_headless_get_setting( 'enable_redirects', false );
+
+	if ( ! $enable_redirects ) {
+		return;
+	}
+
 	$redirect_base = wpe_headless_get_setting( 'frontend_uri' );
 
 	if (

--- a/plugins/wpe-headless/includes/replacement/callbacks.php
+++ b/plugins/wpe-headless/includes/replacement/callbacks.php
@@ -37,13 +37,11 @@ function wpe_headless_content_replacement( $content ) {
 
 add_filter( 'preview_post_link', 'wpe_headless_post_link', 10 );
 add_filter( 'post_link', 'wpe_headless_post_link', 10 );
-
 /**
- * Callback for WordPress 'preview_post_link' filter and 'post_link' filter. For now, we use the same callback for both.
+ * Callback for WordPress 'preview_post_link' filter and 'post_link' filter.
  *
  * Swap the post preview link and post links in admin for headless front-end.
  *
- * @todo Should this always be enabled?
  * @todo Page links
  *
  * @param string $link URL used for the post preview and/or post.
@@ -51,6 +49,10 @@ add_filter( 'post_link', 'wpe_headless_post_link', 10 );
  * @return string URL used for the post preview.
  */
 function wpe_headless_post_link( $link ) {
+	if ( ! wpe_headless_domain_replacement_enabled() ) {
+		return $link;
+	}
+
 	$frontend_uri = wpe_headless_get_setting( 'frontend_uri' );
 
 	if ( $frontend_uri ) {
@@ -69,6 +71,10 @@ add_filter( 'term_link', 'wpe_headless_term_link' );
  * @return string
  */
 function wpe_headless_term_link( $term_link ) {
+	if ( ! wpe_headless_domain_replacement_enabled() ) {
+		return $term_link;
+	}
+
 	$frontend_uri = wpe_headless_get_setting( 'frontend_uri' );
 
 	if ( empty( $frontend_uri ) ) {

--- a/plugins/wpe-headless/includes/replacement/functions.php
+++ b/plugins/wpe-headless/includes/replacement/functions.php
@@ -17,10 +17,9 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @return bool True if can proceed with replacement, false if else.
  */
 function wpe_headless_domain_replacement_enabled() {
-	$enabled         = false;
-	$enable_rewrites = wpe_headless_get_setting( 'enable_rewrites', false );
+	$enabled = false;
 
-	if ( $enable_rewrites ) {
+	if ( wpe_headless_is_rewrites_enabled() ) {
 		if ( isset( $_GET['replace-domain'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			$enabled = true;
 		}

--- a/plugins/wpe-headless/includes/replacement/functions.php
+++ b/plugins/wpe-headless/includes/replacement/functions.php
@@ -17,14 +17,17 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @return bool True if can proceed with replacement, false if else.
  */
 function wpe_headless_domain_replacement_enabled() {
-	$enabled = false;
+	$enabled         = false;
+	$enable_rewrites = wpe_headless_get_setting( 'enable_rewrites', false );
 
-	if ( isset( $_GET['replace-domain'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		$enabled = true;
-	}
+	if ( $enable_rewrites ) {
+		if ( isset( $_GET['replace-domain'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			$enabled = true;
+		}
 
-	if ( isset( $_SERVER['HTTP_X_WP_HEADLESS'] ) ) {
-		$enabled = true;
+		if ( isset( $_SERVER['HTTP_X_WP_HEADLESS'] ) ) {
+			$enabled = true;
+		}
 	}
 
 	/**

--- a/plugins/wpe-headless/includes/replacement/graphql-callbacks.php
+++ b/plugins/wpe-headless/includes/replacement/graphql-callbacks.php
@@ -20,6 +20,10 @@ add_filter( 'graphql_request_results', 'wpe_headless_url_replacement' );
  * @return object The modified response with URLs replaced.
  */
 function wpe_headless_url_replacement( $response ) {
+	if ( ! wpe_headless_domain_replacement_enabled() ) {
+		return $response;
+	}
+
 	if (
 		is_object( $response ) &&
 		property_exists( $response, 'data' ) &&

--- a/plugins/wpe-headless/includes/settings/callbacks.php
+++ b/plugins/wpe-headless/includes/settings/callbacks.php
@@ -59,14 +59,7 @@ add_action( 'admin_init', 'wpe_headless_register_settings_section' );
  */
 function wpe_headless_register_settings_section() {
 	add_settings_section(
-		'frontend_site_section',
-		null,
-		null,
-		'wpe-headless-settings'
-	);
-
-	add_settings_section(
-		'menu_locations_section',
+		'settings_section',
 		null,
 		null,
 		'wpe-headless-settings'
@@ -90,7 +83,7 @@ function wpe_headless_register_settings_fields() {
 		__( 'Front-end site URL', 'wpe-headless' ),
 		'wpe_headless_display_frontend_uri_field',
 		'wpe-headless-settings',
-		'frontend_site_section'
+		'settings_section'
 	);
 
 	add_settings_field(
@@ -98,7 +91,7 @@ function wpe_headless_register_settings_fields() {
 		__( 'Secret Key', 'wpe-headless' ),
 		'wpe_headless_display_secret_key_field',
 		'wpe-headless-settings',
-		'frontend_site_section'
+		'settings_section'
 	);
 
 	add_settings_field(
@@ -106,7 +99,7 @@ function wpe_headless_register_settings_fields() {
 		__( 'Menu Locations', 'wpe-headless' ),
 		'wpe_headless_display_menu_locations_field',
 		'wpe-headless-settings',
-		'menu_locations_section'
+		'settings_section'
 	);
 }
 

--- a/plugins/wpe-headless/includes/settings/callbacks.php
+++ b/plugins/wpe-headless/includes/settings/callbacks.php
@@ -101,6 +101,14 @@ function wpe_headless_register_settings_fields() {
 		'wpe-headless-settings',
 		'settings_section'
 	);
+
+	add_settings_field(
+		'enable_disable',
+		__( 'Features', 'wpe-headless' ),
+		'wpe_headless_display_enable_disable_fields',
+		'wpe-headless-settings',
+		'settings_section'
+	);
 }
 
 add_action( 'load-settings_page_wpe-headless-settings', 'wpe_headless_handle_regenerate_secret_key', 5 );
@@ -244,5 +252,39 @@ function wpe_headless_display_frontend_uri_field() {
 	<p class="description">
 		<?php esc_html_e( 'The URL to your headless front-end. This is used for authenticated post previews and for rewriting links to point to your front-end site.', 'wpe-headless' ); ?>
 	</p>
+	<?php
+}
+
+/**
+ * Callback for WordPress add_settings_field() method parameter.
+ *
+ * Display the enable/disable features section.
+ *
+ * @return void
+ */
+function wpe_headless_display_enable_disable_fields() {
+	$enable_theme         = wpe_headless_get_setting( 'enable_theme', false );
+	$enable_rewrites      = wpe_headless_get_setting( 'enable_rewrites', false );
+	$enable_route_locking = wpe_headless_get_setting( 'enable_route_locking', false );
+
+	?>
+	<fieldset>
+		<label for="enable_theme">
+			<input type="checkbox" id="enable_theme" name="wpe_headless[enable_theme]" value="1" <?php checked( $enable_theme ); ?> />
+			<?php esc_html_e( 'Enable Theme', 'wpe-headless' ); ?>
+		</label>
+		<br />
+
+		<label for="enable_rewrites">
+			<input type="checkbox" id="enable_rewrites" name="wpe_headless[enable_rewrites]" value="1" <?php checked( $enable_rewrites ); ?> />
+			<?php esc_html_e( 'Post/category URL rewrites', 'wpe-headless' ); ?>
+		</label>
+		<br />
+
+		<label for="enable_route_locking">
+			<input type="checkbox" id="enable_route_locking" name="wpe_headless[enable_route_locking]" value="1" <?php checked( $enable_route_locking ); ?> />
+			<?php esc_html_e( 'Lock down routes', 'wpe-headless' ); ?>
+		</label>
+	</fieldset>
 	<?php
 }

--- a/plugins/wpe-headless/includes/settings/callbacks.php
+++ b/plugins/wpe-headless/includes/settings/callbacks.php
@@ -263,9 +263,9 @@ function wpe_headless_display_frontend_uri_field() {
  * @return void
  */
 function wpe_headless_display_enable_disable_fields() {
-	$disable_theme    = wpe_headless_get_setting( 'disable_theme', false );
-	$enable_rewrites  = wpe_headless_get_setting( 'enable_rewrites', false );
-	$enable_redirects = wpe_headless_get_setting( 'enable_redirects', false );
+	$disable_theme    = wpe_headless_is_themes_disabled();
+	$enable_rewrites  = wpe_headless_is_rewrites_enabled();
+	$enable_redirects = wpe_headless_is_redirects_enabled();
 
 	?>
 	<fieldset>

--- a/plugins/wpe-headless/includes/settings/callbacks.php
+++ b/plugins/wpe-headless/includes/settings/callbacks.php
@@ -263,27 +263,27 @@ function wpe_headless_display_frontend_uri_field() {
  * @return void
  */
 function wpe_headless_display_enable_disable_fields() {
-	$enable_theme         = wpe_headless_get_setting( 'enable_theme', false );
-	$enable_rewrites      = wpe_headless_get_setting( 'enable_rewrites', false );
-	$enable_route_locking = wpe_headless_get_setting( 'enable_route_locking', false );
+	$disable_theme    = wpe_headless_get_setting( 'disable_theme', false );
+	$enable_rewrites  = wpe_headless_get_setting( 'enable_rewrites', false );
+	$enable_redirects = wpe_headless_get_setting( 'enable_redirects', false );
 
 	?>
 	<fieldset>
-		<label for="enable_theme">
-			<input type="checkbox" id="enable_theme" name="wpe_headless[enable_theme]" value="1" <?php checked( $enable_theme ); ?> />
-			<?php esc_html_e( 'Enable Theme', 'wpe-headless' ); ?>
+		<label for="disable_theme">
+			<input type="checkbox" id="disable_theme" name="wpe_headless[disable_theme]" value="1" <?php checked( $disable_theme ); ?> />
+			<?php esc_html_e( 'Disable WordPress theme functionality', 'wpe-headless' ); ?>
 		</label>
 		<br />
 
 		<label for="enable_rewrites">
 			<input type="checkbox" id="enable_rewrites" name="wpe_headless[enable_rewrites]" value="1" <?php checked( $enable_rewrites ); ?> />
-			<?php esc_html_e( 'Post/category URL rewrites', 'wpe-headless' ); ?>
+			<?php esc_html_e( 'Enable Post and Category URL rewrites', 'wpe-headless' ); ?>
 		</label>
 		<br />
 
-		<label for="enable_route_locking">
-			<input type="checkbox" id="enable_route_locking" name="wpe_headless[enable_route_locking]" value="1" <?php checked( $enable_route_locking ); ?> />
-			<?php esc_html_e( 'Lock down routes', 'wpe-headless' ); ?>
+		<label for="enable_redirects">
+			<input type="checkbox" id="enable_redirects" name="wpe_headless[enable_redirects]" value="1" <?php checked( $enable_redirects ); ?> />
+			<?php esc_html_e( 'Enable public route redirects', 'wpe-headless' ); ?>
 		</label>
 	</fieldset>
 	<?php
@@ -302,6 +302,7 @@ function wpe_headless_verify_graphql_dependency() {
 	if ( function_exists( 'graphql' ) ) {
 		return;
 	}
+
 	add_action( 'admin_notices', 'wpe_headless_display_graphql_notice' );
 	add_action( 'admin_enqueue_scripts', 'wpe_headless_add_graphql_scripts' );
 }
@@ -331,6 +332,7 @@ function wpe_headless_display_graphql_notice() {
  */
 function wpe_headless_add_graphql_scripts() {
 	wp_enqueue_script( 'wp-api-fetch' );
+
 	?>
 	<script>
 		document.addEventListener( 'DOMContentLoaded', function() {

--- a/plugins/wpe-headless/includes/settings/functions.php
+++ b/plugins/wpe-headless/includes/settings/functions.php
@@ -79,9 +79,9 @@ function wpe_headless_get_settings() {
 	$settings = get_option( 'wpe_headless', array() );
 
 	/**
-	 * Filter 'wpe_headless_get_setting'.
+	 * Filter 'wpe_headless_get_settings'.
 	 *
 	 * @param array $settings Array of plugin settings.
 	 */
-	return apply_filters( 'wpe_headless_get_setting', $settings );
+	return apply_filters( 'wpe_headless_get_settings', $settings );
 }

--- a/plugins/wpe-headless/includes/settings/functions.php
+++ b/plugins/wpe-headless/includes/settings/functions.php
@@ -10,6 +10,33 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
+ * Determine if redirects are enabled.
+ *
+ * @return bool True if redirects are enabled, false if else.
+ */
+function wpe_headless_is_redirects_enabled() {
+	return '1' === wpe_headless_get_setting( 'enable_redirects' );
+}
+
+/**
+ * Determine if rewrites are enabled.
+ *
+ * @return bool True if rewrites are enabled, false if else.
+ */
+function wpe_headless_is_rewrites_enabled() {
+	return '1' === wpe_headless_get_setting( 'enable_rewrites' );
+}
+
+/**
+ * Determine if themes are disabled.
+ *
+ * @return bool True if themes are disabled, false if else.
+ */
+function wpe_headless_is_themes_disabled() {
+	return '1' === wpe_headless_get_setting( 'disable_theme' );
+}
+
+/**
  * Determine if events are enabled.
  *
  * @return bool True if events are enabled, false if else.

--- a/plugins/wpe-headless/includes/utilities/callbacks.php
+++ b/plugins/wpe-headless/includes/utilities/callbacks.php
@@ -13,7 +13,9 @@ register_activation_hook( WPE_HEADLESS_FILE, 'wpe_headless_handle_activation' );
 /**
  * Callback for WordPress register_activation_hook() function.
  *
- * Set the secret key and flush rewrite rules.
+ * 1. Set default settings if no settings exist.
+ * 2. Set secret_key if does not exist.
+ * 3. Flush rewrite rules.
  *
  * @todo is flush_rewrite_rules() needed?
  *
@@ -23,6 +25,13 @@ register_activation_hook( WPE_HEADLESS_FILE, 'wpe_headless_handle_activation' );
  */
 function wpe_headless_handle_activation() {
 	$secret_key = wpe_headless_get_secret_key();
+	$settings   = wpe_headless_get_settings();
+
+	if ( empty( $settings ) ) {
+		wpe_headless_update_setting( 'disable_theme', '1' );
+		wpe_headless_update_setting( 'enable_rewrites', '1' );
+		wpe_headless_update_setting( 'enable_redirects', '1' );
+	}
 
 	if ( ! $secret_key ) {
 		wpe_headless_update_setting( 'secret_key', wp_generate_uuid4() );

--- a/plugins/wpe-headless/tests/integration/settings/test-functions.php
+++ b/plugins/wpe-headless/tests/integration/settings/test-functions.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Class FunctionsTest
+ *
+ * @package WPE_Headless
+ */
+
+namespace WPE_Headless\Tests\Settings;
+
+class FunctionsTest extends \WP_UnitTestCase {
+	/** @test */
+	public function wpe_headless_is_redirects_enabled_will_return_true_if_enabled() {
+		delete_option( 'wpe_headless' );
+
+		$this->assertFalse( wpe_headless_is_redirects_enabled() );
+
+		update_option( 'wpe_headless', array( 'enable_redirects' => '1' ) );
+
+		$this->assertTrue( wpe_headless_is_redirects_enabled() );
+	}
+
+	/** @test */
+	public function wpe_headless_is_rewrites_enabled_will_return_true_if_enabled() {
+		delete_option( 'wpe_headless' );
+
+		$this->assertFalse( wpe_headless_is_rewrites_enabled() );
+
+		update_option( 'wpe_headless', array( 'enable_rewrites' => '1' ) );
+
+		$this->assertTrue( wpe_headless_is_rewrites_enabled() );
+	}
+
+	/** @test */
+	public function wpe_headless_is_themes_disabled_will_return_true_if_disabled() {
+		delete_option( 'wpe_headless' );
+
+		$this->assertFalse( wpe_headless_is_themes_disabled() );
+
+		update_option( 'wpe_headless', array( 'disable_theme' => '1' ) );
+
+		$this->assertTrue( wpe_headless_is_themes_disabled() );
+	}
+}


### PR DESCRIPTION
This pull request adds three settings to allow users to enable or disable plugin features.

- Disable WordPress theme functionality
  - Removes theme related links.
- Enable Post and Category URL rewrites
  - Enable or disable content, and taxonomy url rewrites
- Enable public route redirects
  - Enable or disable front-end redirects

When the plugin is activated for the first time, the three settings will be enabled (only if the settings do not exist in the database).

The copy/naming used may be poor. Let me know if any changes are needed.

<img width="1133" alt="Screen Shot 2021-01-04 at 1 53 02 PM" src="https://user-images.githubusercontent.com/1128283/103573648-323e4480-4e94-11eb-9339-2951dbae0cfc.png">