### PR TITLE
feat(BH-812): add initializeNextStaticPaths

### DIFF
--- a/examples/preview/pages/[[...page]].tsx
+++ b/examples/preview/pages/[[...page]].tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { TemplateLoader, initializeNextStaticProps } from '@wpengine/headless';
+import { useNextUriInfo, initializeNextStaticProps, initializeNextStaticPaths } from '@wpengine/headless';
 
 /**
  * @todo make conditionalTags available
@@ -17,8 +17,5 @@ export function getStaticProps(context: any) {
 }
 
 export function getStaticPaths() {
-  return {
-    paths: ['/'],
-    fallback: true,
-  };
+  return initializeNextStaticPaths();
 }

--- a/packages/headless/src/api/index.ts
+++ b/packages/headless/src/api/index.ts
@@ -2,3 +2,4 @@ export * from './hooks';
 export * from './services';
 export * from './initializeNextServerSideProps';
 export * from './initializeNextStaticProps';
+export * from './initializeNextStaticPaths';

--- a/packages/headless/src/api/initializeNextStaticPaths.ts
+++ b/packages/headless/src/api/initializeNextStaticPaths.ts
@@ -1,0 +1,12 @@
+/**
+ * Must be called from getStaticPaths within a Next app in order to support SSG.
+ *
+ * This function currently returns only the root path to be built during build-time. Any other pages will be built using
+ * incremental static regeneration (ISR) thanks to the fallback props.
+ */
+export function initializeNextStaticPaths() {
+  return {
+    paths: ['/'],
+    fallback: true,
+  };
+}


### PR DESCRIPTION
Add `initializeNextStaticPaths()` to be used in `getStaticPaths()`.

Currently, it provides a default array signaling Next.js to build only the root path. All other paths will be built using [Incremental Static Regeneration](https://nextjs.org/docs/basic-features/data-fetching#incremental-static-regeneration) (ISR).