### PR TITLE
build: add ESLint workflow

### DIFF
--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -1,0 +1,26 @@
+name: ESLint
+on: pull_request
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install Node Dependencies
+        run: yarn install
+        working-directory: packages/headless
+        env:
+          CI: TRUE
+      - name: Test Code Linting
+        run:  yarn run eslint --output-file eslint_report.json --format json . --ext .js,.jsx,.ts,.tsx
+        working-directory: packages/headless
+        continue-on-error: true
+      - name: Annotate Code Linting Results
+        uses: ataylorme/eslint-annotate-action@1.1.2
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          report-json: "packages/headless/eslint_report.json"
+      - name: Upload ESLint report
+        uses: actions/upload-artifact@v1
+        with:
+          name: eslint_report_headless_package.json
+          path: packages/headless/eslint_report.json

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -19,8 +19,3 @@ jobs:
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           report-json: "packages/headless/eslint_report.json"
-      - name: Upload ESLint report
-        uses: actions/upload-artifact@v1
-        with:
-          name: eslint_report_headless_package.json
-          path: packages/headless/eslint_report.json

--- a/packages/headless/.eslintignore
+++ b/packages/headless/.eslintignore
@@ -1,0 +1,2 @@
+dist
+node_modules

--- a/packages/headless/.eslintignore
+++ b/packages/headless/.eslintignore
@@ -1,2 +1,5 @@
 dist
 node_modules
+/*.js
+/*.ts
+/*.d.ts


### PR DESCRIPTION
Add ESLint GitHub Actions workflow to lint `packages/headless`. `examples/preview` is out of scope as I could not get the annotator to run twice.

### Screenshots

![image](https://user-images.githubusercontent.com/375381/104062780-a8a6b380-51c0-11eb-8c28-399deef4a9b4.png)