### PR TITLE
feat(BH-813): add <WPHead /> component

### DIFF
--- a/examples/preview/theme/index.tsx
+++ b/examples/preview/theme/index.tsx
@@ -1,25 +1,29 @@
 import React from 'react';
 import Link from 'next/link';
-import { usePosts } from '@wpengine/headless';
+import { usePosts, WPHead } from '@wpengine/headless';
 
 export default function Index() {
   const posts = usePosts();
 
   return (
-    <div>
-      {posts &&
-        posts.map((post) => (
-          <div key={post.id} id={`post-${post.id}`}>
-            <div>
-              <Link href={post.uri}>
-                <h5>
-                  <a href={post.uri}>{post.title}</a>
-                </h5>
-              </Link>
-              <p dangerouslySetInnerHTML={{ __html: post.excerpt ?? '' }} />
+    <>
+      <WPHead />
+
+      <div>
+        {posts &&
+          posts.map((post) => (
+            <div key={post.id} id={`post-${post.id}`}>
+              <div>
+                <Link href={post.uri}>
+                  <h5>
+                    <a href={post.uri}>{post.title}</a>
+                  </h5>
+                </Link>
+                <p dangerouslySetInnerHTML={{ __html: post.excerpt ?? '' }} />
+              </div>
             </div>
-          </div>
-        ))}
-    </div>
+          ))}
+      </div>
+    </>
   );
 }

--- a/examples/preview/theme/single.tsx
+++ b/examples/preview/theme/single.tsx
@@ -1,19 +1,23 @@
 import React from 'react';
-import { usePost } from '@wpengine/headless';
+import { usePost, WPHead } from '@wpengine/headless';
 
 export default function Single() {
   const post = usePost();
 
   return (
-    <div>
-      {post && (
-        <div>
+    <>
+      <WPHead />
+
+      <div>
+        {post && (
           <div>
-            <h5>{post.title}</h5>
-            <p dangerouslySetInnerHTML={{ __html: post.content ?? '' }} />
+            <div>
+              <h5>{post.title}</h5>
+              <p dangerouslySetInnerHTML={{ __html: post.content ?? '' }} />
+            </div>
           </div>
-        </div>
-      )}
-    </div>
+        )}
+      </div>
+    </>
   );
 }

--- a/packages/headless/src/api/initializeNextServerSideProps.ts
+++ b/packages/headless/src/api/initializeNextServerSideProps.ts
@@ -1,12 +1,17 @@
 import { GetServerSidePropsContext, GetServerSidePropsResult } from 'next';
-import { getUriInfo, getPosts, getContentNode } from './services';
+import {
+  getUriInfo,
+  getPosts,
+  getContentNode,
+  getGeneralSettings,
+} from './services';
 import { initializeApollo, addApolloState } from '../provider';
 import { headlessConfig } from '../config';
 import { ContentNodeIdType, UriInfo } from '../types';
 import { resolvePrefixedUrlPath } from '../utils';
 import getCurrentPath from '../utils/getCurrentPath';
 import { ensureAuthorization } from '../auth';
-import {isPreview, isPreviewPath} from "../utils/preview";
+import { isPreview, isPreviewPath } from '../utils/preview';
 
 /**
  * Must be called from getServerSideProps within a Next app in order to support SSR. It will
@@ -26,6 +31,9 @@ export async function initializeNextServerSideProps(
     getCurrentPath(context),
     wpeConfig.uriPrefix,
   );
+
+  /* Load settings into cache */
+  await getGeneralSettings(apolloClient);
 
   const pageInfo = (await getUriInfo(
     apolloClient,

--- a/packages/headless/src/api/initializeNextStaticProps.ts
+++ b/packages/headless/src/api/initializeNextStaticProps.ts
@@ -1,5 +1,10 @@
 import { GetServerSidePropsResult, GetStaticPropsContext } from 'next';
-import { getUriInfo, getPosts, getContentNode } from './services';
+import {
+  getUriInfo,
+  getPosts,
+  getContentNode,
+  getGeneralSettings,
+} from './services';
 import { initializeApollo, addApolloState } from '../provider';
 import { headlessConfig } from '../config';
 import { ContentNodeIdType, UriInfo } from '../types';
@@ -26,6 +31,9 @@ export async function initializeNextStaticProps(
     getCurrentPath(context),
     wpeConfig.uriPrefix,
   );
+
+  /* Load settings into cache */
+  await getGeneralSettings(apolloClient);
 
   const pageInfo = (await getUriInfo(
     apolloClient,

--- a/packages/headless/src/components/WPHead.tsx
+++ b/packages/headless/src/components/WPHead.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import Head from 'next/head';
+import { usePost, useGeneralSettings } from '../api';
+
+export default function WPHead(): JSX.Element {
+  const settings = useGeneralSettings();
+  const post = usePost();
+
+  let title: string;
+
+  const siteTitle: string = settings?.title ?? '';
+  const siteTagline: string = settings?.description ?? '';
+
+  if (post) {
+    title = `${post.title} – ${siteTitle}`;
+  } else {
+    title = `${siteTitle} – ${siteTagline}`;
+  }
+
+  return (
+    <Head>
+      <title>{title}</title>
+    </Head>
+  );
+}

--- a/packages/headless/src/components/index.ts
+++ b/packages/headless/src/components/index.ts
@@ -1,5 +1,6 @@
 import Menu from './menu/Menu';
 import MenuItem from './menu/MenuItemInterface';
 import TemplateLoader from './TemplateLoader';
+import WPHead from './WPHead';
 
-export { Menu, MenuItem, TemplateLoader };
+export { Menu, MenuItem, TemplateLoader, WPHead };


### PR DESCRIPTION
Add a basic `<WPHead />` component for a natural place to start handling things such as the document's `<title>` and soon other `<meta>`.

Note, customizing the format of the title is not possible in the current implementation. This will likely be something that we rely on SEO plugins for.