### PR TITLE
feat(BH-806): add middleware support for Next.js Data Fetcher in templates

### DIFF
--- a/examples/preview/theme/single.tsx
+++ b/examples/preview/theme/single.tsx
@@ -1,5 +1,8 @@
 import React from 'react';
 import { usePost, WPHead } from '@wpengine/headless';
+import type { GetServerSidePropsContext, GetStaticPropsContext } from 'next';
+import type { ApolloClient, NormalizedCacheObject } from '@apollo/client';
+import { gql } from '@apollo/client';
 
 export default function Single() {
   const post = usePost();
@@ -20,4 +23,51 @@ export default function Single() {
       </div>
     </>
   );
+}
+
+/**
+ * Middleware that can be used to fetch addition (or less data) when the Next.js Data Fetcher is ran. This is
+ * particularly useful if some data needed is not requested by default in the Headless framework.
+ *
+ * @param promises Array of promises fetching data that can be manipulated to include more data or less data
+ * @param currentUrlPath Current URL/path being displayed/rendered
+ * @param apolloClient Apollo Client instance
+ * @param context Next.js context
+ */
+export function getPropsMiddleware(
+  promises: Array<Promise<unknown> | undefined>,
+  apolloClient: ApolloClient<NormalizedCacheObject>,
+  currentUrlPath: string,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  context: GetStaticPropsContext | GetServerSidePropsContext,
+): Array<Promise<unknown> | undefined> {
+  /**
+   * Fetch all menus and menu items on every page using the "single" template.
+   */
+  promises.push(
+    apolloClient.query<string[]>({
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      query: gql`
+        {
+          menus {
+            edges {
+              node {
+                menuItems {
+                  edges {
+                    node {
+                      url
+                      title
+                      label
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      `,
+    }),
+  );
+
+  return promises;
 }

--- a/packages/headless/.eslintrc.js
+++ b/packages/headless/.eslintrc.js
@@ -41,7 +41,7 @@ module.exports = {
         '@typescript-eslint/no-unsafe-assignment': 0,
         '@typescript-eslint/no-unsafe-member-access': 0,
         'jsx-a11y/anchor-is-valid': 0,
-        'no-console': ["error", { allow: ["warn", "error"] }]
+        'no-console': ["error", { allow: ["warn", "error", "debug"] }]
     },
     settings: {
         react: {

--- a/packages/headless/.eslintrc.js
+++ b/packages/headless/.eslintrc.js
@@ -40,7 +40,8 @@ module.exports = {
         'react/require-default-props': 0,
         '@typescript-eslint/no-unsafe-assignment': 0,
         '@typescript-eslint/no-unsafe-member-access': 0,
-        'jsx-a11y/anchor-is-valid': 0
+        'jsx-a11y/anchor-is-valid': 0,
+        'no-console': ["error", { allow: ["warn", "error"] }]
     },
     settings: {
         react: {

--- a/packages/headless/src/api/hooks.ts
+++ b/packages/headless/src/api/hooks.ts
@@ -65,8 +65,7 @@ export function usePosts(): Post[] | undefined {
             setResult(posts);
           }
         } catch (e) {
-          console.log('Error getting posts');
-          console.log(e);
+          console.error('Error getting posts', e);
         }
       })();
     }
@@ -122,8 +121,7 @@ export function useGeneralSettings() {
             setResult(settings);
           }
         } catch (e) {
-          console.log('Error getting settings');
-          console.log(e);
+          console.error('Error getting settings', e);
         }
       })();
     }
@@ -184,8 +182,7 @@ export function useNextUriInfo() {
 
           setUriInfo(info as UriInfo);
         } catch (e) {
-          console.log('Error getting URI info');
-          console.log(e);
+          console.error('Error getting URI info', e);
         }
       })();
     }
@@ -259,8 +256,7 @@ export function useUriInfo(uri?: string) {
 
           setUriInfo(info as UriInfo);
         } catch (e) {
-          console.log('Error getting URI info');
-          console.log(e);
+          console.error('Error getting URI info', e);
         }
       })();
     }
@@ -422,8 +418,7 @@ export function usePost(
             setResult(post);
           }
         } catch (e) {
-          console.log('Error getting a post');
-          console.log(e);
+          console.error('Error getting a post', e);
         }
       })();
     }

--- a/packages/headless/src/index.ts
+++ b/packages/headless/src/index.ts
@@ -3,3 +3,4 @@ export * from './auth';
 export * from './config';
 export * from './components';
 export * from './provider';
+export * from './types';

--- a/packages/headless/src/utils/index.ts
+++ b/packages/headless/src/utils/index.ts
@@ -1,2 +1,5 @@
 export * from './assert';
 export * from './convert';
+export { default as getCurrentPath } from './getCurrentPath';
+export * from './preview';
+export * from './resolveTemplate';

--- a/packages/headless/src/utils/resolveTemplate.ts
+++ b/packages/headless/src/utils/resolveTemplate.ts
@@ -1,0 +1,39 @@
+import { UriInfo } from '../types';
+import type { Template } from '../components/TemplateLoader';
+
+export function resolveTemplate(
+  pageInfo: UriInfo | undefined,
+): null | Template {
+  /**
+   * List out files in main project using Webpack.
+   */
+  let context;
+
+  try {
+    context = require.context('theme', false, /.*/);
+  } catch (e) {
+    console.warn(
+      '"theme" directory not detected in Next.js project. Please add it to take advantage of <TemplateLoader />.',
+    );
+    return null;
+  }
+
+  if (!pageInfo || !pageInfo.templates) {
+    return context(`./index`) as Template;
+  }
+
+  // eslint-disable-next-line no-restricted-syntax
+  for (const template of pageInfo.templates) {
+    try {
+      const importedTemplate = context(`./${template}`);
+
+      if (importedTemplate) {
+        return importedTemplate as Template;
+      }
+    } catch (e) {
+      // noop - swallow any module resolution errors as we're merely _trying_ templates.
+    }
+  }
+
+  return context(`./index`) as Template;
+}


### PR DESCRIPTION
# Summary

Templates in the `theme` directory can now export a function named `getPropsMiddleware`. This method will be called during either `getStaticProps()` or `getServerSideProps()` of the page calling the template loader.

The middleware makes it possible to request additional data when the Next.js Data Fetchers are run or to modify the default data being requested.