### PR TITLE
feat: change fallback mode to 'blocking' allow passing overrides in initializeNextStaticPaths()

### DIFF
--- a/packages/headless/src/api/initializeNextStaticPaths.ts
+++ b/packages/headless/src/api/initializeNextStaticPaths.ts
@@ -4,9 +4,24 @@
  * This function currently returns only the root path to be built during build-time. Any other pages will be built using
  * incremental static regeneration (ISR) thanks to the fallback props.
  */
-export function initializeNextStaticPaths() {
+import { GetStaticPathsResult } from 'next';
+
+export function initializeNextStaticPaths(override?: GetStaticPathsResult) {
   return {
+    /**
+     * Only render the root path by default as we're also leveraging the fallback below which will render missing pages
+     * during runtime and cache them.
+     */
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
     paths: ['/'],
-    fallback: true,
+    /**
+     * Default to 'blocking' as the fallback method to remove the need to create a loading page for a limited subset
+     * of visitors (those getting an uncached page).
+     */
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    fallback: 'blocking',
+    ...override,
   };
 }


### PR DESCRIPTION
* Switch from `true` to `'blocking'` as the default fallback mode. This will block the initial render until the page is rendered which negates the need to design/dev a loading page for a limited subset of visitors getting uncached content.
* Add param to override `fallback` and/or `paths` in initializeNextStaticPaths if desired