### PR TITLE
fix: Updated logic to enable content rewrites

### DIFF
--- a/plugins/wpe-headless/includes/replacement/callbacks.php
+++ b/plugins/wpe-headless/includes/replacement/callbacks.php
@@ -23,7 +23,7 @@ function wpe_headless_content_replacement( $content ) {
 		return $content;
 	}
 
-	$replacement = wpe_headless_get_setting( 'frontend_uri' );
+	$replacement = untrailingslashit( wpe_headless_get_setting( 'frontend_uri' ) );
 	$site_url    = site_url();
 
 	if ( ! $replacement ) {

--- a/plugins/wpe-headless/includes/replacement/functions.php
+++ b/plugins/wpe-headless/includes/replacement/functions.php
@@ -20,11 +20,11 @@ function wpe_headless_domain_replacement_enabled() {
 	$enabled = false;
 
 	if ( wpe_headless_is_rewrites_enabled() ) {
-		if ( isset( $_GET['replace-domain'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		if ( isset( $_GET['replace-domain'] ) || isset( $_SERVER['HTTP_X_WP_HEADLESS'] ) ) {
 			$enabled = true;
 		}
 
-		if ( isset( $_SERVER['HTTP_X_WP_HEADLESS'] ) ) {
+		if ( ( function_exists( 'is_graphql_http_request' ) && is_graphql_http_request() ) ) {
 			$enabled = true;
 		}
 	}

--- a/plugins/wpe-headless/includes/replacement/functions.php
+++ b/plugins/wpe-headless/includes/replacement/functions.php
@@ -20,7 +20,7 @@ function wpe_headless_domain_replacement_enabled() {
 	$enabled = false;
 
 	if ( wpe_headless_is_rewrites_enabled() ) {
-		if ( isset( $_GET['replace-domain'] ) || isset( $_SERVER['HTTP_X_WP_HEADLESS'] ) ) {
+		if ( isset( $_GET['replace-domain'] ) || isset( $_SERVER['HTTP_X_WP_HEADLESS'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			$enabled = true;
 		}
 


### PR DESCRIPTION
This pull request adds an additional check to `wpe_headless_domain_replacement_enabled()` to determine if the incoming request is a GraphQL request.