### PR TITLE
feat: Add getting started sidebar box to plugin settings page

### DIFF
--- a/plugins/wpe-headless/includes/settings/assets/js/wpgraphql-install.js
+++ b/plugins/wpe-headless/includes/settings/assets/js/wpgraphql-install.js
@@ -3,13 +3,22 @@
  */
 wpeHeadless.installWPGraphQL = (() => {
 	const $button = document.getElementById('wpe-headless-button-install-graphql');
-	const $spinner = document.querySelector('.sidebar .spinner');
+	const $spinner = document.querySelector('.get-started .spinner');
+	const $status = document.querySelector('.get-started .error-message');
 
 	// Attaches event listeners.
 	function init() {
 		$button.onclick = (event) => {
 			event.preventDefault();
-			installWPGraphQL().then(() => update('complete'));
+			installWPGraphQL().then((result) => {
+				if (result.status === 'active') {
+					update('complete');
+				} else {
+					update('failed', wpeHeadless.strings.failed);
+				}
+			}).catch(result => {
+				update('failed', result.message || wpeHeadless.strings.failed);
+			});
 		}
 	}
 
@@ -30,27 +39,35 @@ wpeHeadless.installWPGraphQL = (() => {
 			request.data = {status: 'active'};
 		}
 
-		await wp.apiFetch(request);
+		return await wp.apiFetch(request);
 	}
 
 	// Updates the button and spinner.
-	function update(state = 'installing') {
+	function update(state = 'installing', error = "") {
 		switch (state) {
 			case 'installing':
 				wp.a11y.speak(wpeHeadless.strings.installing, 'polite');
 				$button.innerHTML = wpeHeadless.strings.installing;
 				$button.disabled = true;
 				$spinner.style.visibility = 'visible';
+				$status.innerHTML = '';
 				break;
 			case 'complete':
 				wp.a11y.speak(wpeHeadless.strings.active, 'polite');
 				$button.innerHTML = `☑️ ${wpeHeadless.strings.active}`;
 				$spinner.style.visibility = 'hidden';
 				break;
+			case 'failed':
+				wp.a11y.speak(error || wpeHeadless.strings.failed, 'polite');
+				$button.innerHTML = wpeHeadless.strings.default;
+				$button.disabled = false;
+				$spinner.style.visibility = 'hidden';
+				$status.innerHTML = error;
+				break;
 		}
 	}
 
-	return { init: init }
+	return {init: init}
 })();
 
 wpeHeadless.installWPGraphQL.init();

--- a/plugins/wpe-headless/includes/settings/assets/js/wpgraphql-install.js
+++ b/plugins/wpe-headless/includes/settings/assets/js/wpgraphql-install.js
@@ -22,7 +22,7 @@ wpeHeadless.installWPGraphQL = (() => {
 		}
 	}
 
-	// Installs and activates the WP GraphQL plugin.
+	// Installs and activates the WPGraphQL plugin.
 	async function installWPGraphQL() {
 		update('installing');
 
@@ -43,7 +43,7 @@ wpeHeadless.installWPGraphQL = (() => {
 	}
 
 	// Updates the button and spinner.
-	function update(state = 'installing', error = "") {
+	function update(state = 'installing', error = '') {
 		switch (state) {
 			case 'installing':
 				wp.a11y.speak(wpeHeadless.strings.installing, 'polite');

--- a/plugins/wpe-headless/includes/settings/assets/js/wpgraphql-install.js
+++ b/plugins/wpe-headless/includes/settings/assets/js/wpgraphql-install.js
@@ -45,7 +45,6 @@ wpeHeadless.installWPGraphQL = (() => {
 			case 'complete':
 				wp.a11y.speak(wpeHeadless.strings.active, 'polite');
 				$button.innerHTML = `☑️ ${wpeHeadless.strings.active}`;
-				$button.classList.add('active');
 				$spinner.style.visibility = 'hidden';
 				break;
 		}

--- a/plugins/wpe-headless/includes/settings/assets/js/wpgraphql-install.js
+++ b/plugins/wpe-headless/includes/settings/assets/js/wpgraphql-install.js
@@ -1,0 +1,57 @@
+/**
+ * Handles WPGraphQL plugin installation at Settings → Headless.
+ */
+wpeHeadless.installWPGraphQL = (() => {
+	const $button = document.getElementById('wpe-headless-button-install-graphql');
+	const $spinner = document.querySelector('.sidebar .spinner');
+
+	// Attaches event listeners.
+	function init() {
+		$button.onclick = (event) => {
+			event.preventDefault();
+			installWPGraphQL().then(() => update('complete'));
+		}
+	}
+
+	// Installs and activates the WP GraphQL plugin.
+	async function installWPGraphQL() {
+		update('installing');
+
+		// Default to install and activate.
+		const request = {
+			path: '/wp/v2/plugins',
+			method: 'POST',
+			data: {slug: 'wp-graphql', status: 'active'}
+		}
+
+		// Just activate the plugin if it is already installed.
+		if (wpeHeadless.wpgraphqlIsInstalled) {
+			request.path = '/wp/v2/plugins/wp-graphql/wp-graphql';
+			request.data = {status: 'active'};
+		}
+
+		await wp.apiFetch(request);
+	}
+
+	// Updates the button and spinner.
+	function update(state = 'installing') {
+		switch (state) {
+			case 'installing':
+				wp.a11y.speak(wpeHeadless.strings.installing, 'polite');
+				$button.innerHTML = wpeHeadless.strings.installing;
+				$button.disabled = true;
+				$spinner.style.visibility = 'visible';
+				break;
+			case 'complete':
+				wp.a11y.speak(wpeHeadless.strings.active, 'polite');
+				$button.innerHTML = `☑️ ${wpeHeadless.strings.active}`;
+				$button.classList.add('active');
+				$spinner.style.visibility = 'hidden';
+				break;
+		}
+	}
+
+	return { init: init }
+})();
+
+wpeHeadless.installWPGraphQL.init();

--- a/plugins/wpe-headless/includes/settings/assets/style.css
+++ b/plugins/wpe-headless/includes/settings/assets/style.css
@@ -68,6 +68,10 @@ svg.wpengine {
 	margin-left: 26px;
 }
 
+.form-table .align-middle th {
+	padding-top: 30px;
+}
+
 /* Sidebar. Based on https://every-layout.dev/layouts/sidebar/#the-generator.
 ---------------------------------------------------------------------------- */
 

--- a/plugins/wpe-headless/includes/settings/assets/style.css
+++ b/plugins/wpe-headless/includes/settings/assets/style.css
@@ -155,6 +155,7 @@ svg.wpengine {
 
 .sidebar .box.get-started #wpe-headless-button-install-graphql {
 	float: left;
+	margin-bottom: 5px;
 }
 
 .sidebar .box.get-started .spinner {
@@ -162,6 +163,10 @@ svg.wpengine {
 	margin-top: 7px;
 }
 
+.sidebar .error-message {
+	color: #cf0000;
+	clear: both;
+}
 
 /* WP Admin Layout Overrides
 ---------------------------------------------------------------------------- */

--- a/plugins/wpe-headless/includes/settings/assets/style.css
+++ b/plugins/wpe-headless/includes/settings/assets/style.css
@@ -95,16 +95,47 @@ svg.wpengine {
 	flex-grow: 999;
 }
 
-.sidebar .box h3 {
-	margin-bottom: 32px;
-}
-
 .sidebar .box {
 	background: #fff;
 	border-radius: 4px;
 	border: 1px solid #ddd;
-	margin: 20px 0 10px;
+	margin: 20px 0 30px;
+}
+
+.sidebar .box p,
+.sidebar .box li {
+	font-size: 1.1em;
+}
+
+.sidebar .box section {
+	overflow: hidden;
+	padding: 0 30px 10px;
+}
+
+.sidebar .box section:last-of-type {
+	padding: 0 30px 20px;
+}
+
+.sidebar .box h3 {
+	border-bottom: 1px solid #ddd;
+	font-size: 1.4em;
+	margin-bottom: 1.6em;
+	margin-top: 0;
 	padding: 20px 30px;
+}
+
+.sidebar .box h4 {
+	font-size: 1.3em;
+	margin: 1em 0;
+}
+
+.sidebar .box section:first-of-type h4 {
+	margin-top: 0;
+}
+
+.sidebar .box.primary h3 {
+	background: var(--brand-color);
+	color: #fff;
 }
 
 .sidebar .box.docs li {
@@ -121,6 +152,16 @@ svg.wpengine {
 	position: absolute;
 	width: 0.5em;
 }
+
+.sidebar .box.get-started #wpe-headless-button-install-graphql {
+	float: left;
+}
+
+.sidebar .box.get-started .spinner {
+	float: left;
+	margin-top: 7px;
+}
+
 
 /* WP Admin Layout Overrides
 ---------------------------------------------------------------------------- */
@@ -206,5 +247,10 @@ textarea:focus {
 	.form-table td textarea,
 	.form-table span.description {
 		width: 98%;
+	}
+
+	.field-action {
+		display: block;
+		margin: 12px 0;
 	}
 }

--- a/plugins/wpe-headless/includes/settings/callbacks.php
+++ b/plugins/wpe-headless/includes/settings/callbacks.php
@@ -318,8 +318,10 @@ function wpe_headless_add_settings_assets() {
 		$wpe_headless = array(
 			'wpgraphqlIsInstalled' => array_key_exists( 'wp-graphql/wp-graphql.php', get_plugins() ),
 			'strings'              => array(
+				'default'    => esc_html__( 'Install and Activate', 'wpe-headless' ),
 				'installing' => esc_html__( 'Installing…', 'wpe-headless' ),
 				'active'     => esc_html__( 'WPGraphQL is active', 'wpe-headless' ),
+				'failed'     => esc_html__( 'Installation failed', 'wpe-headless' ),
 			),
 		);
 

--- a/plugins/wpe-headless/includes/settings/callbacks.php
+++ b/plugins/wpe-headless/includes/settings/callbacks.php
@@ -316,7 +316,7 @@ function wpe_headless_add_settings_assets() {
 		);
 
 		$wpe_headless = array(
-			'wpgraphqlIsInstalled' => array_key_exists('wp-graphql/wp-graphql.php', get_plugins()),
+			'wpgraphqlIsInstalled' => array_key_exists( 'wp-graphql/wp-graphql.php', get_plugins() ),
 			'strings'              => array(
 				'installing' => esc_html__( 'Installing…', 'wpe-headless' ),
 				'active'     => esc_html__( 'WPGraphQL is active', 'wpe-headless' ),

--- a/plugins/wpe-headless/includes/settings/callbacks.php
+++ b/plugins/wpe-headless/includes/settings/callbacks.php
@@ -83,7 +83,11 @@ function wpe_headless_register_settings_fields() {
 		__( 'Front-end site URL', 'wpe-headless' ),
 		'wpe_headless_display_frontend_uri_field',
 		'wpe-headless-settings',
-		'settings_section'
+		'settings_section',
+		array(
+			'class'     => 'align-middle',
+			'label_for' => 'frontend_uri',
+		)
 	);
 
 	add_settings_field(
@@ -91,7 +95,11 @@ function wpe_headless_register_settings_fields() {
 		__( 'Secret Key', 'wpe-headless' ),
 		'wpe_headless_display_secret_key_field',
 		'wpe-headless-settings',
-		'settings_section'
+		'settings_section',
+		array(
+			'class'     => 'align-middle',
+			'label_for' => 'secret_key',
+		)
 	);
 
 	add_settings_field(
@@ -99,7 +107,11 @@ function wpe_headless_register_settings_fields() {
 		__( 'Menu Locations', 'wpe-headless' ),
 		'wpe_headless_display_menu_locations_field',
 		'wpe-headless-settings',
-		'settings_section'
+		'settings_section',
+		array(
+			'class'     => 'align-middle',
+			'label_for' => 'menu_locations',
+		)
 	);
 
 	add_settings_field(

--- a/plugins/wpe-headless/includes/settings/callbacks.php
+++ b/plugins/wpe-headless/includes/settings/callbacks.php
@@ -288,22 +288,15 @@ add_action( 'load-settings_page_wpe-headless-settings', 'wpe_headless_verify_gra
  * @return void
  */
 function wpe_headless_verify_graphql_dependency() {
-	add_action( 'admin_enqueue_scripts', 'wpe_headless_add_settings_styles' );
-
-	if ( function_exists( 'graphql' ) ) {
-		return;
-	}
-
-	add_action( 'admin_notices', 'wpe_headless_display_graphql_notice' );
-	add_action( 'admin_enqueue_scripts', 'wpe_headless_add_graphql_scripts' );
+	add_action( 'admin_enqueue_scripts', 'wpe_headless_add_settings_assets' );
 }
 
 /**
- * Enqueues the settings stylesheet on the Settings → Headless admin page.
+ * Enqueues the settings stylesheet and scripts at Settings → Headless.
  *
  * Callback for admin_enqueue_scripts.
  */
-function wpe_headless_add_settings_styles() {
+function wpe_headless_add_settings_assets() {
 	$plugin = get_plugin_data( WPE_HEADLESS_FILE );
 
 	wp_enqueue_style(
@@ -312,125 +305,28 @@ function wpe_headless_add_settings_styles() {
 		array(),
 		$plugin['Version']
 	);
-}
 
-/**
- * Displays the WP GraphQL dependency notice.
- */
-function wpe_headless_display_graphql_notice() {
-	?>
-	<div id="wpe-headless-notice-graphql" class="notice notice-info wpe-headless-notice wpe-headless-notice-graphql">
-		<p>
-			<?php
-			printf(
-			/* translators: %s: Link to plugin install page. */
-				wp_kses_post( __( 'WP Engine Headless requires the WP GraphQL plugin. <a id="wpe-headless-link-install-graphql" href="%s">Install and activate it now</a>.', 'wpe-headless' ) ),
-				esc_url( admin_url( 'plugin-install.php?s=wp+graphql&tab=search&type=term' ) )
-			);
-			?>
-		</p>
-	</div>
-	<?php
-}
+	if ( ! function_exists( 'graphql' ) ) {
+		wp_enqueue_script(
+			'wpe-headless-wpgraphql-install',
+			WPE_HEADLESS_URL . 'includes/settings/assets/js/wpgraphql-install.js',
+			array( 'wp-a11y', 'wp-api-fetch' ),
+			$plugin['Version'],
+			true
+		);
 
-/**
- * Adds the scripts required to install the
- * WP GraphQL plugin dependency.
- */
-function wpe_headless_add_graphql_scripts() {
-	wp_enqueue_script( 'wp-api-fetch' );
+		$wpe_headless = array(
+			'wpgraphqlIsInstalled' => array_key_exists('wp-graphql/wp-graphql.php', get_plugins()),
+			'strings'              => array(
+				'installing' => esc_html__( 'Installing…', 'wpe-headless' ),
+				'active'     => esc_html__( 'WPGraphQL is active', 'wpe-headless' ),
+			),
+		);
 
-	?>
-	<script>
-		document.addEventListener( 'DOMContentLoaded', function() {
-			document.getElementById( 'wpe-headless-link-install-graphql' ).onclick = ( event ) => {
-				event.preventDefault();
-				doGraphQLInstall();
-			}
-		} );
-
-		// Installs and activates the WP GraphQL plugin.
-		async function doGraphQLInstall() {
-			updateGraphQLNotice( 'installing' );
-
-			let installed = false;
-
-			/**
-			 * Check if the plugin is installed first.
-			 * Otherwise the REST endpoint downloads
-			 * and tries to install the plugin before
-			 * returning an error that the folder
-			 * already exists.
-			 */
-			await isGraphQLPluginInstalled().then( ( result ) => {
-				installed = result;
-			} ).catch( ( result ) => {
-				console.log( result );
-				installed = false;
-			} );
-
-			if ( installed ) {
-				await activateGraphQL();
-			} else {
-				await installActivateGraphQLPlugin();
-			}
-			updateGraphQLNotice( 'complete' );
-		}
-
-		// Updates the admin notice text.
-		function updateGraphQLNotice( type = 'installing' ) {
-			const notices = document.getElementsByClassName( 'wpe-headless-notice-graphql' );
-			const notice = notices[0];
-			switch ( type ) {
-				case 'installing':
-					notice.innerHTML = '<p>Installing and activating the WP GraphQL plugin...</p>';
-					break;
-
-				case 'complete':
-					notice.innerHTML = '<p>GraphQL installed and activated!</p>';
-					break;
-			}
-		}
-
-		// Returns whether or not the WP GraphQL plugin is installed.
-		async function isGraphQLPluginInstalled() {
-			let installed = false;
-			await wp.apiFetch( {
-				path: '/wp/v2/plugins/wp-graphql/wp-graphql',
-				method: 'GET'
-			} ).then( ( result ) => {
-				if ( result.hasOwnProperty( 'code' ) && result.code === 'rest_plugin_not_found' ) {
-					installed = false;
-				}
-
-				if ( result.hasOwnProperty( 'plugin' ) && result.plugin === 'wp-graphql/wp-graphql' ) {
-					installed = true;
-				}
-			} );
-			return installed;
-		}
-
-		// Activates the plugin if it already exists.
-		async function activateGraphQL() {
-			await wp.apiFetch( {
-				path: '/wp/v2/plugins/wp-graphql/wp-graphql',
-				method: 'POST',
-				data: { status: 'active' },
-			} ).then( ( result ) => {
-				console.log( result );
-			} )
-		}
-
-		// Installs and activates the plugin.
-		async function installActivateGraphQLPlugin() {
-			await wp.apiFetch( {
-				path: '/wp/v2/plugins',
-				method: 'POST',
-				data: { slug: 'wp-graphql', status: 'active' }
-			} ).then( ( result ) => {
-				console.log(result);
-			} );
-		}
-	</script>
-	<?php
+		wp_localize_script(
+			'wpe-headless-wpgraphql-install',
+			'wpeHeadless',
+			$wpe_headless
+		);
+	}
 }

--- a/plugins/wpe-headless/includes/settings/views/headless-settings.php
+++ b/plugins/wpe-headless/includes/settings/views/headless-settings.php
@@ -38,6 +38,7 @@
 						<?php else : ?>
 							<button class="button-primary" id="wpe-headless-button-install-graphql" aria-label="<?php esc_html_e( 'Install and Activate the WPGraphQL plugin', 'wpe-headless' ); ?>"><?php esc_html_e( 'Install and Activate', 'wpe-headless' ); ?></button>
 							<span class="spinner"></span>
+							<p class="error-message"></p>
 						<?php endif; ?>
 					</section>
 					<section>

--- a/plugins/wpe-headless/includes/settings/views/headless-settings.php
+++ b/plugins/wpe-headless/includes/settings/views/headless-settings.php
@@ -35,7 +35,7 @@
 						<p><a href="https://www.wpgraphql.com/docs/quick-start/" target="_blank" rel="noopener noreferrer"><?php esc_html_e( 'Learn about the plugin', 'wpe-headless' ); ?></a>.</p>
 						<?php if ( function_exists( 'graphql' ) ) : ?>
 							<button class="button-primary" disabled><?php esc_html_e( '☑️ WPGraphQL is active', 'wpe-headless' ); ?></button>
-						<?php else: ?>
+						<?php else : ?>
 							<button class="button-primary" id="wpe-headless-button-install-graphql" aria-label="<?php esc_html_e( 'Install and Activate the WPGraphQL plugin', 'wpe-headless' ); ?>"><?php esc_html_e( 'Install and Activate', 'wpe-headless' ); ?></button>
 							<span class="spinner"></span>
 						<?php endif; ?>

--- a/plugins/wpe-headless/includes/settings/views/headless-settings.php
+++ b/plugins/wpe-headless/includes/settings/views/headless-settings.php
@@ -28,16 +28,35 @@
 				</form>
 			</div>
 			<div class="sidebar">
+				<div class="box get-started primary">
+					<h3><?php esc_html_e( 'Get Started With Headless', 'wpe-headless' ); ?></h3>
+					<section>
+						<h4><?php esc_html_e( 'Install WPGraphQL', 'wpe-headless' ); ?></h4>
+						<p><a href="https://www.wpgraphql.com/docs/quick-start/" target="_blank" rel="noopener noreferrer"><?php esc_html_e( 'Learn about the plugin', 'wpe-headless' ); ?></a>.</p>
+						<?php if ( function_exists( 'graphql' ) ) : ?>
+							<button class="button-primary" disabled><?php esc_html_e( '☑️ WPGraphQL is active', 'wpe-headless' ); ?></button>
+						<?php else: ?>
+							<button class="button-primary" id="wpe-headless-button-install-graphql" aria-label="<?php esc_html_e( 'Install and Activate the WPGraphQL plugin', 'wpe-headless' ); ?>"><?php esc_html_e( 'Install and Activate', 'wpe-headless' ); ?></button>
+							<span class="spinner"></span>
+						<?php endif; ?>
+					</section>
+					<section>
+						<h4><?php esc_html_e( 'Create Your Headless App', 'wpe-headless' ); ?></h4>
+						<p><a href="https://github.com/wpengine/headless-framework/#readme" target="_blank" rel="noopener noreferrer">Follow our setup guide</a>.</p>
+					</section>
+				</div>
 				<div class="box docs">
 					<h3>Headless Documentation</h3>
-					<ul>
-						<li><a href="https://github.com/wpengine/headless-framework/#wordpress-headless-framework-previewalpha" target="_blank" rel="noopener noreferrer">Getting started</a></li>
-						<li><a href="https://github.com/wpengine/headless-framework/blob/main/packages/headless/src/provider/HeadlessProvider.tsx" target="_blank" rel="noopener noreferrer">HeadlessProvider component</a></li>
-						<li><a href="https://github.com/wpengine/headless-framework/blob/main/packages/headless/src/components/TemplateLoader.tsx" target="_blank" rel="noopener noreferrer">TemplateLoader component</a></li>
-						<li><a href="https://github.com/wpengine/headless-framework/blob/main/packages/headless/src/components/menu/Menu.tsx" target="_blank" rel="noopener noreferrer">Menu component</a></li>
-						<li><a href="https://github.com/wpengine/headless-framework/blob/main/docs/previews/README.md" target="_blank" rel="noopener noreferrer">Post previews</a></li>
-					</ul>
-					<p><a class="button-primary" href="https://github.com/wpengine/headless-framework/" target="_blank" rel="noopener noreferrer">Headless on GitHub</a></p>
+					<section>
+						<ul>
+							<li><a href="https://github.com/wpengine/headless-framework/#wordpress-headless-framework-previewalpha" target="_blank" rel="noopener noreferrer">Getting started</a></li>
+							<li><a href="https://github.com/wpengine/headless-framework/blob/main/packages/headless/src/provider/HeadlessProvider.tsx" target="_blank" rel="noopener noreferrer">HeadlessProvider component</a></li>
+							<li><a href="https://github.com/wpengine/headless-framework/blob/main/packages/headless/src/components/TemplateLoader.tsx" target="_blank" rel="noopener noreferrer">TemplateLoader component</a></li>
+							<li><a href="https://github.com/wpengine/headless-framework/blob/main/packages/headless/src/components/menu/Menu.tsx" target="_blank" rel="noopener noreferrer">Menu component</a></li>
+							<li><a href="https://github.com/wpengine/headless-framework/blob/main/docs/previews/README.md" target="_blank" rel="noopener noreferrer">Post previews</a></li>
+						</ul>
+						<p><a class="button-primary" href="https://github.com/wpengine/headless-framework/" target="_blank" rel="noopener noreferrer">Headless on GitHub</a></p>
+					</section>
 				</div>
 			</div>
 		</div>


### PR DESCRIPTION
- Adds a Get Started with Headless box to the Settings → Headless page.
- Removes the full-width notification to install WPGraphQL (the button in the sidebar replaces this).
- Adds an “Install and Activate” button to prompt the user to install WPGraphQL.

<img width="1526" alt="Screenshot 2021-01-19 at 13 41 08" src="https://user-images.githubusercontent.com/647669/105035965-19b95700-5a5c-11eb-936f-083300cbe8d5.png">

https://user-images.githubusercontent.com/647669/105033824-e9bc8480-5a58-11eb-987f-b1ff3274e157.mp4

https://user-images.githubusercontent.com/647669/105036476-d01d3c00-5a5c-11eb-8d47-1fd176abfde9.mp4

## To test
Test “Install WPGraphQL” button in three states:
- WPGraphQL is not installed or active. (Should install and activate.)
- WPGraphQL is installed but not active. (Should activate.)
- WPGraphQL is installed and active. (Should show as already installed.)

## Notes
Mikolaj suggested:
- Leaving the getting started box in place instead of dismissing it once WPGraphQL is active.
- Dropping the third step we had in previous mockups (to enter your site URL), which is already the first form field on the page.
- Removing the numbered steps (since there are only two left).