### PR TITLE
Updated rewrite url logic for wp-admin links

### DIFF
--- a/plugins/wpe-headless/includes/replacement/callbacks.php
+++ b/plugins/wpe-headless/includes/replacement/callbacks.php
@@ -102,7 +102,7 @@ add_filter( 'post_link', 'wpe_headless_post_link', 10 );
  * @return string URL used for the post.
  */
 function wpe_headless_post_link( $link ) {
-	if ( ! wpe_headless_domain_replacement_enabled() ) {
+	if ( ! wpe_headless_is_rewrites_enabled() ) {
 		return $link;
 	}
 
@@ -124,7 +124,7 @@ add_filter( 'term_link', 'wpe_headless_term_link' );
  * @return string
  */
 function wpe_headless_term_link( $term_link ) {
-	if ( ! wpe_headless_domain_replacement_enabled() ) {
+	if ( ! wpe_headless_is_rewrites_enabled() ) {
 		return $term_link;
 	}
 


### PR DESCRIPTION
This pull request fixes the logic used to determine if post/taxonomy url replacement should be used.

Swapped out `wpe_headless_domain_replacement_enabled()` with `wpe_headless_is_rewrites_enabled()` to correct issue where post and taxonomy links within WordPress wp-admin were not being rewritten.

<img width="1247" alt="Screen Shot 2021-01-19 at 11 00 13 AM" src="https://user-images.githubusercontent.com/1128283/105084349-d0690780-5a5b-11eb-888c-94cb24851409.png">