### PR TITLE
docs: Improve secret key field description

### DIFF
--- a/plugins/wpe-headless/includes/settings/callbacks.php
+++ b/plugins/wpe-headless/includes/settings/callbacks.php
@@ -229,8 +229,8 @@ function wpe_headless_display_secret_key_field() {
 	<p class="description">
 		<?php
 		printf(
-			/* translators: %s: link to documentation */
-			wp_kses_post( 'This key is used to enable post previewing with Next.js. Read about post previewing <a href="%s" target="_blank" rel="noopener noreferrer">here</a>.', 'wpe-headless' ),
+			/* translators: %s: Documentation URL. */
+			wp_kses_post( __( 'This key is used to enable <a href="%s" target="_blank" rel="noopener noreferrer">headless post previews</a>.', 'wpe-headless' ) ),
 			'https://github.com/wpengine/headless-framework/blob/main/docs/previews/README.md'
 		);
 		?>


### PR DESCRIPTION
- Makes link text more accessible (screenreaders now say “headless post previews” instead of “here”).
- Adds missing `__()` translation function call.

### Before
<img width="850" alt="Screenshot 2021-01-20 at 11 23 52" src="https://user-images.githubusercontent.com/647669/105161799-12548500-5b12-11eb-880d-cb4ebbddd604.png">

### After
<img width="734" alt="Screenshot 2021-01-20 at 11 23 05" src="https://user-images.githubusercontent.com/647669/105161804-1385b200-5b12-11eb-9e06-5d01d2906c7b.png">

