### PR TITLE
docs: Add deployment steps for wpe-headless plugin

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -80,3 +80,18 @@ or
 ```
 composer test
 ```
+
+## Deployment
+
+Developers with full GitHub repository access can create public releases:
+
+### Release the wpe-headless plugin
+
+1. Update the `Version` in the file header at `plugins/wpe-headless/wpe-headless.php`.
+2. Update the changelog in `plugins/wpe-headless/readme.txt`.
+3. Commit and push your changes for review.
+4. Tag the approved commit with `plugin/wpe-headless/[version]`, for example: `plugin/wpe-headless/0.3.5-alpha.1` and push the tag. Or use GitHub to [create a new release](https://github.com/wpengine/headless-framework/releases/new) with that tag.
+
+CircleCI will build and deploy the plugin zip. The latest version will be available here:
+
+`https://wp-product-info.wpesvc.net/v1/plugins/wpe-headless?download`


### PR DESCRIPTION
Documented plugin deployment steps at the request of @trevanhetzel.

@claygriffiths / @markkelnar / @mindctrl Do you have time to check that these are correct, please?