### PR TITLE
Change Next to start on port 8080

### DIFF
--- a/examples/preview/package.json
+++ b/examples/preview/package.json
@@ -11,7 +11,7 @@
     "open": "run-s open:local",
     "open:local": "open-cli http://localhost:3000/",
     "lint": "tsc --noEmit -p . && eslint **/*.{ts,tsx} --parser-options=project:tsconfig.json --quiet --fix",
-    "start": "next start",
+    "start": "next start -p 8080",
     "test": "echo \"Error: no test specified\" && exit 1",
     "wpe-build": "next build"
   },


### PR DESCRIPTION
Since the WP Atlas hosting/deployment service expects the service to run on port 8080, we should update the example so it's ready to work with the deployment service.