### PR TITLE
Docs rework to use absolute URL paths

### DIFF
--- a/docs/previews/README.md
+++ b/docs/previews/README.md
@@ -214,7 +214,7 @@ We need to let the frontend know about our WordPress instance. The framework exp
 
 ```bash
 # Base URL for WordPress
-NEXT_PUBLIC_WORDPRESS_URL=http://yourwp.com
+NEXT_PUBLIC_WORDPRESS_URL=http://yourwpsite.com
 
 # Plugin secret found in WordPress Settings->Headless
 WPE_HEADLESS_SECRET=YOUR_PLUGIN_SECRET

--- a/docs/previews/README.md
+++ b/docs/previews/README.md
@@ -15,7 +15,7 @@ npm i typescript @types/react @types/react-dom @types/node -D
 ```
 
 TL;DR
-Checkout the [example project](../../examples/preview) to see how it works.
+Checkout the [example project](/examples/preview) to see how it works.
 
 ## WPE Headless Plugin
 
@@ -29,13 +29,13 @@ In addition, the plugin will rewrite URLs in WordPress so that when a user click
 
 Go to Settings->Headless to view the plugin's settings page:
 
-![Headless Plugin Menu](./headless-settings.jpg)
+![Headless Plugin Menu](/docs/previews/headless-settings.jpg)
 
 There are 2 settings that assist in previews. The first setting is the location of your frontend. You'll need to enter a `Front-end site URL`, which will be `http://localhost:3000` for this example.
 
 The second one is read-only. It gives you an API secret key that you need to use on your backend for your frontend.
 
-![Headless Plugin Auth Settings](./headless-settings-auth.jpg)
+![Headless Plugin Auth Settings](/docs/previews/headless-settings-auth.jpg)
 
 ## Headless Framework (@wpengine/headless)
 


### PR DESCRIPTION
In working to get the developers.wpengine.com site up we need to have some restrictions on how markdown files are written in this repo:

1. All local URLs need to be absolute (i.e. `/docs/previews/headless-settings.jpg` instead of `./headless-settings.jpg`)
2. If a URL directs a user to another markdown file in the `/docs` area two things need to be true
    1. The markdown file must be a README.md inside a named folder (i.e. `/docs/previews/README.md` instead of `/docs/previews.md`
    2. The markdown file must have a corresponding nav link in the [headless-docs/developers/nav/framework.md](https://github.com/wpengine/headless-docs/blob/master/developers/nav/framework.md) file so it will show up in the side nav on developers.wpengine.com