### PR TITLE
Added optional operator when filtering gutenburg stylesheets 

### DIFF
--- a/packages/headless/src/components/WPHead.tsx
+++ b/packages/headless/src/components/WPHead.tsx
@@ -26,7 +26,7 @@ export default function WPHead(): JSX.Element {
 
   if (post?.enqueuedStylesheets?.nodes) {
     stylesheets = post.enqueuedStylesheets.nodes.filter((node) => {
-      return node.src.indexOf('wp-content/themes') < 0;
+      return node.src?.indexOf('wp-content/themes') < 0;
     });
   }
 


### PR DESCRIPTION
This pull request adds an optional operator when filtering stylesheets within the `WPHead` component.