### PR TITLE
docs: Adjust “disable theme” label

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ Eager to try out the Headless Framework? Here's how you can get started:
 - **Smart content redirects**
   - Automatically redirects content from the WP site to the front-end site to minimize site visitors’ confusion and avoid SEO penalties for duplicate content
   - Redirects hyperlinks inserted into posts’ content to the front-end site
-- **Removal of WP themes**
-  - Prevents confusion around the active theme
+- **Disable WP theme admin pages**
+  - Prevents access to admin pages that have no effect on the headless front-end appearance, such as Appearance → Themes.
 - **Ability to define custom menus in a GUI**
 - **Additional data exposed through WPGraphQL**
   - Block stylesheets

--- a/plugins/wpe-headless/includes/settings/callbacks.php
+++ b/plugins/wpe-headless/includes/settings/callbacks.php
@@ -272,7 +272,7 @@ function wpe_headless_display_enable_disable_fields() {
 	<fieldset>
 		<label for="disable_theme">
 			<input type="checkbox" id="disable_theme" name="wpe_headless[disable_theme]" value="1" <?php checked( $disable_theme ); ?> />
-			<?php esc_html_e( 'Disable WordPress theme functionality', 'wpe-headless' ); ?>
+			<?php esc_html_e( 'Disable WordPress theme admin pages', 'wpe-headless' ); ?>
 		</label>
 		<br />
 


### PR DESCRIPTION
To make it more clear that the “disable theme” plugin option at Settings → Headless currently disables theme admin pages, not full theme functionality.

As discussed in Slack with @trevanhetzel and @mindctrl.

## Before
<img width="525" alt="Screenshot 2021-01-22 at 11 25 01" src="https://user-images.githubusercontent.com/647669/105479255-8aeb4b00-5ca4-11eb-8307-6ba00dd89700.png">

## After
<img width="517" alt="Screenshot 2021-01-22 at 11 24 44" src="https://user-images.githubusercontent.com/647669/105479257-8c1c7800-5ca4-11eb-8460-e1ab6b136203.png">
