### PR TITLE
fix(BH-816): make redirect in initializeNextStaticProps dynamic

### DIFF
--- a/packages/headless/src/api/initializeNextServerSideProps.ts
+++ b/packages/headless/src/api/initializeNextServerSideProps.ts
@@ -8,10 +8,16 @@ import {
 import { initializeApollo, addApolloState } from '../provider';
 import { headlessConfig } from '../config';
 import { UriInfo, WPGraphQL } from '../types';
-import { resolvePrefixedUrlPath, resolveTemplate } from '../utils';
+import {
+  resolvePrefixedUrlPath,
+  resolveTemplate,
+  isPreview,
+  isPreviewPath,
+} from '../utils';
 import getCurrentPath from '../utils/getCurrentPath';
 import { ensureAuthorization } from '../auth';
-import { isPreview, isPreviewPath } from '../utils/preview';
+import isHTTPS from '../utils/isHTTPS';
+
 import type { Template } from '../components/TemplateLoader';
 
 /**
@@ -35,9 +41,9 @@ export async function initializeNextServerSideProps(
 
   if (isPreview(context)) {
     const host = context.req.headers.host as string;
-    const protocol = /localhost/.test(host) ? 'http:' : 'https:';
+    const protocol = isHTTPS(host, context) ? 'https' : 'http';
     const response = ensureAuthorization(
-      `${protocol}//${context.req.headers.host as string}${
+      `${protocol}://${context.req.headers.host as string}${
         context.resolvedUrl ?? ''
       }`,
     );

--- a/packages/headless/src/api/initializeNextStaticProps.ts
+++ b/packages/headless/src/api/initializeNextStaticProps.ts
@@ -8,11 +8,16 @@ import {
 import { initializeApollo, addApolloState } from '../provider';
 import { headlessConfig } from '../config';
 import { WPGraphQL, UriInfo } from '../types';
-import { resolvePrefixedUrlPath } from '../utils';
+import {
+  resolvePrefixedUrlPath,
+  isPreview,
+  isPreviewPath,
+  resolveTemplate,
+} from '../utils';
 import getCurrentPath from '../utils/getCurrentPath';
 import { ensureAuthorization } from '../auth';
-import { isPreview, isPreviewPath } from '../utils/preview';
-import { resolveTemplate } from '../utils/resolveTemplate';
+import isHTTPS from '../utils/isHTTPS';
+
 import type { Template } from '../components/TemplateLoader';
 
 /**
@@ -38,11 +43,11 @@ export async function initializeNextStaticProps(
       ? context.params?.page ?? []
       : [context.params?.page];
 
-    /**
-     * @todo make this host dynamic... unfortunately it's not available in static
-     */
+    const host = context.previewData.serverInfo.host as string;
+    const protocol = isHTTPS(host, context) ? 'https' : 'http';
+
     const response = ensureAuthorization(
-      `http://localhost:3000/${path.join('/') ?? ''}`,
+      `${protocol}://${host}/${path.join('/') ?? ''}`,
     );
 
     if (typeof response !== 'string' && response?.redirect) {

--- a/packages/headless/src/auth/middleware.ts
+++ b/packages/headless/src/auth/middleware.ts
@@ -51,7 +51,16 @@ export async function nextAuthorizeHandler(
      * Set cookie to enable previewing.
      */
     console.debug('Setting Next.js Preview Data');
-    res.setPreviewData({});
+
+    /**
+     * Add server host to previewData so initializeNextStaticProps() can properly redirect as getStaticProps() does not
+     * have the headers or host in the context.
+     */
+    res.setPreviewData({
+      serverInfo: {
+        host: req.headers.host,
+      },
+    });
 
     res.redirect(302, redirectUri as string);
   } catch (e) {

--- a/packages/headless/src/utils/isHTTPS.ts
+++ b/packages/headless/src/utils/isHTTPS.ts
@@ -1,0 +1,15 @@
+import { GetServerSidePropsContext, GetStaticPropsContext } from 'next';
+
+/**
+ * @todo Make this check more robust by utilizing headers or something passed in from context.
+ *
+ * @param host Current host
+ * @param context Next.js Context from Data Fetcher
+ */
+export default function isHTTPS(
+  host: string,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  context: GetStaticPropsContext | GetServerSidePropsContext,
+): boolean {
+  return !/localhost/.test(host);
+}


### PR DESCRIPTION
# Summary

`initializeNextStaticProps` has a redirect in it to handle authorization for previewing. Before this PR, it was hard-coded as there wasn't a good way of getting the current host from the static props context.

To get around the limitation mentioned above, this PR sets some info in the Next.js preview data that can be used in the static props data fetcher.