### PR TITLE
Docs: Add getting started docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,3 +1,0 @@
-# Headless Framework Documentation
-
-- [Previews](./previews/README.md)

--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -1,0 +1,74 @@
+# Getting started
+
+This guide will get you up and running with our Headless Framework and help you understand what it offers.
+
+## Set up the WordPress plugin
+
+Install our [Headless WordPress plugin](https://github.com/wpengine/headless-framework#wordpress-plugin) to get the full benefits of the framework. We recommend [Local](https://localwp.com/) to quickly spin up a local WordPress site. Once you have a WordPress site up and running, [download the plugin](https://wp-product-info.wpesvc.net/v1/plugins/wpe-headless?download) and upload and activate it [through the WordPress Admin](https://wordpress.org/support/article/managing-plugins/#manual-upload-via-wordpress-admin).
+
+After activation, you will be redirected to the Headless settings page. The plugin has a dependency on WPGraphQL, so you’ll see a button on the right under the “Get Started with Headless” box to install and activate the WPGraphQL plugin if it’s not already active.
+
+At this point, if you know what the URL to your front-end site is (or is going to be), you can enter that now in the Front-end Site URL field. That’s all you need to do for now on the WordPress side!
+
+### What is the WordPress plugin doing?
+
+The plugin ensures that your WordPress site runs smoothly as a headless CMS. From smart content redirects to enabling post previewing to ensuring the right data is available in WPGraphQL, installing the plugin gives you the things you need to run WordPress as a headless CMS. Find a [full list of plugin features here](https://github.com/wpengine/headless-framework#plugin-features).
+
+## Create a Next.js app
+
+Our headless framework is built on top of [Next.js](https://nextjs.org/). You get all the amazing features that Next.js provides, plus an easy way to use it with WordPress!
+
+For this guide, we’ll start with an [example project](https://github.com/wpengine/headless-framework/tree/canary/examples/preview) to quickly see the power of our framework. To pull it down, we recommend using npx and create-react-app with the URL to our example project:
+
+```npx create-next-app -e https://github.com/wpengine/headless-framework/tree/canary --example-path examples/preview --use-npm```
+
+create-next-app will prompt you to provide a name for your project. Once you do that and the dependencies are installed, cd into the new project and make a copy of .env.local.sample.
+
+```cp .env.local.sample .env.local```
+
+This config file is where you’ll set the WordPress URL and secret key that ties it all together.
+
+```
+# Base URL for WordPress
+WORDPRESS_URL=http://yourwpsite.com
+
+# Plugin secret found in WordPress Settings->Headless
+WPE_HEADLESS_SECRET=YOUR_PLUGIN_SECRET
+```
+
+Now you’re ready to run the app!
+
+```npm run dev```
+
+Open up http://localhost:3000 and you should see a list of posts from your WordPress site and be able to view a single post.
+
+## Breaking down the example project
+
+The example project is set up with most of the features our [@wpengine/headless](https://npmjs.org/package/@wpengine/headless) npm package provides, along with a way to structure your app.
+
+### ```pages/_app.tsx```
+
+We’re using a Next.js [Custom App](https://nextjs.org/docs/advanced-features/custom-app) to override the default `App` in order to inject our `<HeadlessProvider />` wrapper component. `HeadlessProvider` sets up an Apollo client that connects to WordPress via the `WORDPRESS_URL` environment variable. Our Apollo client is all set up to support both server side and client side rendering out of the box.
+
+### ```pages/[[..page]].tsx```
+
+In Next.js, pages are used for both rendering and routing purposes. For instance, an `about.tsx` file would automatically be rendered at `/about`. In our example, we’re using an [optional catch-all route](https://nextjs.org/docs/routing/dynamic-routes#optional-catch-all-routes) - `[[..page]].tsx`, which Next.js will hit any time a request is made. This component simply returns a `<TemplateLoader />` component. `TemplateLoader` is imported from the [@wpengine/headless](https://npmjs.org/package/@wpengine/headless) npm package and is responsible for determining what template to render based on the requested URL’s content type in WordPress. This allows you to mimic the [WordPress template hierarchy](https://developer.wordpress.org/themes/basics/template-hierarchy/) inside your Next.js app.
+
+### ```/theme/```
+
+The `theme/` folder contains templates that are responsible for the final rendering of a page. They are rendered from the `<TemplateLoader />` in the catch-all route page mentioned above, in the same way that WordPress PHP theme files are loaded according to the template hierarchy. This is accomplished by the `TemplateLoader` picking up what type of WordPress content is sent over from GraphQL. The naming convention of files in the `theme/` directory follows 1:1 with the WordPress template hierarchy. For example, `single.tsx` is the template rendered for single posts, `page.tsx` is the template for pages, `category.tsx` is for categories, and so on.
+
+An `index.tsx` and `single.tsx` template is included in our example project. To handle other content types like pages or custom types, you can create a new `.tsx` file with the name of the desired template.
+
+[More information about how the `TemplateLoader` works can be found here](/docs/templating/).
+
+### Hooks
+
+The [@wpengine/headless](https://npmjs.org/package/@wpengine/headless) npm package contains several custom React hooks for interacting with WPGraphQL. In the example project’s `index.tsx` template, for example, the `usePosts` hook is used to get a list of all posts. Similarly, `usePost` is used in `single.tsx` to get the data for a single post. The hooks permit certain parameters, which allow you to refine the data returned (passing in an `id` to `usePost`, for example, to get a certain post).
+
+## Learn more
+
+- [Enabling WordPress post previews](/docs/preview/)
+- [Using the WordPress template hierarchy in Next.js](/docs/templating/)
+
+


### PR DESCRIPTION
Adding a new doc on getting started with the framework. Also removed the top level README from `/docs`.