### PR TITLE
feat: add getMenus service and useMenus hook

### DIFF
--- a/docs/reference/components/menu/index.md
+++ b/docs/reference/components/menu/index.md
@@ -53,7 +53,7 @@ function MyApp2() {
   const nextLink = (item: MenuItem): React.ReactNode => (
     <Link href={item.href}>
       <a>{item.title}</a>
-      </Link>
+    </Link>
   );
 
   return (

--- a/docs/reference/components/menu/index.md
+++ b/docs/reference/components/menu/index.md
@@ -67,7 +67,7 @@ function MyApp2() {
     </>
   );
 }
-export default MyApp2
+export default MyApp2;
 ```
 
 ## Fetch menu items from WordPress

--- a/docs/reference/components/menu/index.md
+++ b/docs/reference/components/menu/index.md
@@ -1,0 +1,135 @@
+# Menu
+
+The `<Menu />` component displays a nav element and list items from the supplied `items` prop.
+
+## Basic Usage
+
+```ts
+import { Menu } from '@wpengine/headless'
+
+function MyApp() {
+  const items = [
+    { title: 'Home', href: '/' },
+    {
+      title: 'About',
+      href: '/about',
+      children: [{ title: 'Careers', href: '/careers' }],
+    },
+  ];
+
+  return (
+    <>
+      <Menu items={items} />
+    </>
+  );
+}
+export default MyApp;
+```
+
+## Custom link markup
+
+`<Menu />` uses basic anchor elements by default:
+
+```ts
+const defaultAnchor = (item: MenuItem) => <a href={item.href}>{item.title}</a>;
+```
+
+Use the `anchor` prop to render anchors with other markup or components, such as the [Next.js Link element](https://nextjs.org/docs/api-reference/next/link):
+
+```ts
+import { Menu, MenuItem } from '@wpengine/headless'
+import Link from 'next/link';
+
+function MyApp2() {
+  const items = [
+    { title: 'Home', href: '/' },
+    {
+      title: 'About',
+      href: '/about',
+      children: [{ title: 'Careers', href: '/careers' }],
+    },
+  ];
+
+  const nextLink = (item: MenuItem): React.ReactNode => (
+    <Link href={item.href}>
+      <a>{item.title}</a>
+      </Link>
+  );
+
+  return (
+    <>
+      <Menu
+        items={items}
+        anchor={nextLink}
+        className="menu header" /* HTML attributes are also supported. */
+        aria-label="Main"
+      />
+    </>
+  );
+}
+export default MyApp2
+```
+
+## Fetch menu items from WordPress
+
+Fetch menu items from a named WordPress menu location via GraphQL with the `useMenus` hook and `menuLocation` helper.
+
+`useMenus` requires that you use the `HeadlessProvider` component, which handles data fetching.
+
+```ts
+import { Menu, useMenus, menuLocation, WPGraphQL } from '@wpengine/headless'
+
+function MyApp3() {
+  // All menu items as a flat array, as provided by WPGraphQL.
+  const menus = useMenus();
+
+  // Menu items in WordPress's 'primary' menu location only, organized as a parent-child tree.
+  const primaryMenu = menuLocation(menus, WPGraphQL.MenuLocationEnum.Primary);
+
+  return (
+    <>
+      <Menu items={primaryMenu} />
+    </>
+  );
+}
+export default MyApp3;
+```
+
+`menuLocation` takes a `WPGraphQL.MenuLocationEnum` as the second argument to filter by a single preset WPGraphQL menu location:
+
+- WPGraphQL.MenuLocationEnum.Expanded
+- WPGraphQL.MenuLocationEnum.Footer
+- WPGraphQL.MenuLocationEnum.Mobile
+- WPGraphQL.MenuLocationEnum.Primary
+- WPGraphQL.MenuLocationEnum.Social
+- WPGraphQL.MenuLocationEnum.Test
+
+The WPE Headless WordPress plugin registers the Primary and Footer menu locations by default. Register others if needed at Settings → Headless using the “Menu Locations” field.
+
+[Add menus and menu items in WordPress](https://codex.wordpress.org/WordPress_Menu_User_Guide) and assign them to a menu location at Appearance → Menus.
+
+
+## Styling
+
+`<Menu />` is not styled by default. This CSS offers a starting point, assuming `menu` is passed to `className`:
+
+```css
+.menu li {
+    display: inline-block;
+    position: relative;
+    padding-right: 24px;
+}
+
+.menu .submenu {
+    display: none;
+    position: absolute;
+}
+
+.menu li:hover ul.submenu {
+    display: block;
+}
+
+.menu ul.submenu li {
+    width: 280px;
+}
+```

--- a/examples/preview/theme/index.tsx
+++ b/examples/preview/theme/index.tsx
@@ -1,14 +1,35 @@
 import React from 'react';
 import Link from 'next/link';
-import { usePosts, WPHead } from '@wpengine/headless';
+import {
+  usePosts,
+  useMenus,
+  menuLocation,
+  WPGraphQL,
+  WPHead,
+  Menu,
+  MenuItem,
+} from '@wpengine/headless';
 
 export default function Index() {
   const posts = usePosts();
 
+  const menus = useMenus();
+  const primaryMenu = menuLocation(menus, WPGraphQL.MenuLocationEnum.Primary);
+  const nextLink = (item: MenuItem): React.ReactNode => (
+    <Link href={item.href}>
+      <a>{item.title}</a>
+    </Link>
+  );
+
   return (
     <>
       <WPHead />
-
+      <Menu
+        items={primaryMenu}
+        className="header"
+        aria-label="Main"
+        anchor={nextLink}
+      />
       <div>
         {posts &&
           posts.map((post) => (

--- a/packages/headless/src/api/hooks.ts
+++ b/packages/headless/src/api/hooks.ts
@@ -11,6 +11,7 @@ import {
   getGeneralSettings,
   getContentNode,
   getUriInfo,
+  getMenus,
 } from './services';
 import { headlessConfig } from '../config';
 import {
@@ -445,6 +446,44 @@ export function usePost(
       subscribed = false;
     };
   }, [client, pageInfo, id, idType]);
+
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+  return result;
+}
+
+/**
+ * React Hook for retrieving menus from your WordPress site
+ */
+export function useMenus():
+  | WPGraphQL.GetMenusQuery['menuItems']['nodes']
+  | undefined {
+  const [result, setResult] = useState<
+    WPGraphQL.GetMenusQuery['menuItems']['nodes'] | undefined
+  >();
+  const client = useApolloClient();
+
+  useEffect(() => {
+    let subscribed = true;
+    if (client) {
+      void (async () => {
+        try {
+          const menu = await getMenus(
+            client as ApolloClient<NormalizedCacheObject>,
+          );
+
+          if (subscribed) {
+            setResult(menu);
+          }
+        } catch (e) {
+          console.error('Error getting menu', e);
+        }
+      })();
+    }
+
+    return () => {
+      subscribed = false;
+    };
+  }, [result, client]);
 
   // eslint-disable-next-line @typescript-eslint/no-unsafe-return
   return result;

--- a/packages/headless/src/api/initializeNextStaticProps.ts
+++ b/packages/headless/src/api/initializeNextStaticProps.ts
@@ -2,6 +2,7 @@ import { GetServerSidePropsResult, GetStaticPropsContext } from 'next';
 import {
   getUriInfo,
   getPosts,
+  getMenus,
   getContentNode,
   getGeneralSettings,
 } from './services';
@@ -80,6 +81,7 @@ export async function initializeNextStaticProps(
   const promises = [
     getGeneralSettings(apolloClient),
     getPosts(apolloClient),
+    getMenus(apolloClient),
     currentUrlPath !== '/'
       ? getContentNode(
           apolloClient,

--- a/packages/headless/src/api/services.ts
+++ b/packages/headless/src/api/services.ts
@@ -302,40 +302,32 @@ export async function getUriInfo(
 /* eslint-enable consistent-return */
 
 /**
- * Gets menu items from the named location from WordPress.
- *
- * Valid locations are exposed by WPGraphQL in MenuLocationEnum.
+ * Gets menu items from WordPress.
  *
  * @async
  * @export
  * @param {ApolloClient<NormalizedCacheObject>} client
- * @param {MenuLocationEnum} location
  * @returns
  */
-export async function getMenu(
+export async function getMenus(
   client: ApolloClient<NormalizedCacheObject>,
-  location: WPGraphQL.MenuLocationEnum,
 ): Promise<WPGraphQL.GetMenusQuery['menuItems']['nodes']> {
-  const result = await client.query<
-    WPGraphQL.GetMenusQuery,
-    WPGraphQL.GetMenusQueryVariables
-  >({
+  const result = await client.query<WPGraphQL.GetMenusQuery>({
     query: gql`
-      query GetMenus($location: MenuLocationEnum) {
-        menuItems(where: { location: $location }) {
+      query GetMenus {
+        menuItems {
           nodes {
             id
             parentId
-            label
-            url
+            title: label
+            href: url
+            locations
           }
         }
       }
     `,
-    variables: {
-      location,
-    },
   });
 
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-return
   return result?.data?.menuItems?.nodes;
 }

--- a/packages/headless/src/api/services.ts
+++ b/packages/headless/src/api/services.ts
@@ -300,3 +300,42 @@ export async function getUriInfo(
   };
 }
 /* eslint-enable consistent-return */
+
+/**
+ * Gets menu items from the named location from WordPress.
+ *
+ * Valid locations are exposed by WPGraphQL in MenuLocationEnum.
+ *
+ * @async
+ * @export
+ * @param {ApolloClient<NormalizedCacheObject>} client
+ * @param {MenuLocationEnum} location
+ * @returns
+ */
+export async function getMenu(
+  client: ApolloClient<NormalizedCacheObject>,
+  location: WPGraphQL.MenuLocationEnum,
+): Promise<WPGraphQL.GetMenusQuery['menuItems']['nodes']> {
+  const result = await client.query<
+    WPGraphQL.GetMenusQuery,
+    WPGraphQL.GetMenusQueryVariables
+  >({
+    query: gql`
+      query GetMenus($location: MenuLocationEnum) {
+        menuItems(where: { location: $location }) {
+          nodes {
+            id
+            parentId
+            label
+            url
+          }
+        }
+      }
+    `,
+    variables: {
+      location,
+    },
+  });
+
+  return result?.data?.menuItems?.nodes;
+}

--- a/packages/headless/src/components/menu/Menu.tsx
+++ b/packages/headless/src/components/menu/Menu.tsx
@@ -41,7 +41,7 @@ interface Props
  *     return (
  *         <>
  *             <Menu items={items} />
- *             <Menu items={items} className="menu" ariaLabel="main" />
+ *             <Menu items={items} className="menu" aria-label="main" />
  *             <Menu items={items} anchor={nextLink} />
  *             <Menu items={items} anchor={reactRouterLink} />
  *         </>
@@ -56,7 +56,7 @@ export default function Menu({
   anchor,
   ...attributes
 }: Props): JSX.Element | null {
-  if (items.length === 0) {
+  if (items?.length === 0) {
     return null;
   }
 

--- a/packages/headless/src/index.ts
+++ b/packages/headless/src/index.ts
@@ -8,3 +8,4 @@ export * from './components';
 export * from './provider';
 // eslint-disable-next-line import/export
 export * from './types';
+export * from './utils';

--- a/packages/headless/src/types/wpgraphql.ts
+++ b/packages/headless/src/types/wpgraphql.ts
@@ -8002,3 +8002,10 @@ export type GetUriInfoQueryVariables = Exact<{
 
 
 export type GetUriInfoQuery = { nodeByUri: Maybe<{ id: string, templates: Maybe<Array<Maybe<string>>> } | { isFrontPage: boolean, isPostsPage: boolean, id: string, templates: Maybe<Array<Maybe<string>>> } | { id: string, templates: Maybe<Array<Maybe<string>>> } | { id: string, templates: Maybe<Array<Maybe<string>>> } | { id: string, templates: Maybe<Array<Maybe<string>>> } | { id: string, templates: Maybe<Array<Maybe<string>>> } | { id: string, templates: Maybe<Array<Maybe<string>>> } | { id: string, templates: Maybe<Array<Maybe<string>>> }> };
+
+export type GetMenusQueryVariables = Exact<{
+  location: Maybe<MenuLocationEnum>;
+}>;
+
+
+export type GetMenusQuery = { menuItems: Maybe<{ nodes: Maybe<Array<Maybe<{ id: string, parentId: Maybe<string>, label: Maybe<string>, url: Maybe<string> }>>> }> };

--- a/packages/headless/src/types/wpgraphql.ts
+++ b/packages/headless/src/types/wpgraphql.ts
@@ -8006,4 +8006,4 @@ export type GetUriInfoQuery = { nodeByUri: Maybe<{ id: string, templates: Maybe<
 export type GetMenusQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type GetMenusQuery = { menuItems: Maybe<{ nodes: Maybe<Array<Maybe<{ id: string, parentId: Maybe<string>, label: Maybe<string>, url: Maybe<string>, locations: Maybe<Array<Maybe<MenuLocationEnum>>> }>>> }> };
+export type GetMenusQuery = { menuItems: Maybe<{ nodes: Maybe<Array<Maybe<{ id: string, parentId: Maybe<string>, locations: Maybe<Array<Maybe<MenuLocationEnum>>>, title: Maybe<string>, href: Maybe<string> }>>> }> };

--- a/packages/headless/src/types/wpgraphql.ts
+++ b/packages/headless/src/types/wpgraphql.ts
@@ -8003,9 +8003,7 @@ export type GetUriInfoQueryVariables = Exact<{
 
 export type GetUriInfoQuery = { nodeByUri: Maybe<{ id: string, templates: Maybe<Array<Maybe<string>>> } | { isFrontPage: boolean, isPostsPage: boolean, id: string, templates: Maybe<Array<Maybe<string>>> } | { id: string, templates: Maybe<Array<Maybe<string>>> } | { id: string, templates: Maybe<Array<Maybe<string>>> } | { id: string, templates: Maybe<Array<Maybe<string>>> } | { id: string, templates: Maybe<Array<Maybe<string>>> } | { id: string, templates: Maybe<Array<Maybe<string>>> } | { id: string, templates: Maybe<Array<Maybe<string>>> }> };
 
-export type GetMenusQueryVariables = Exact<{
-  location: Maybe<MenuLocationEnum>;
-}>;
+export type GetMenusQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type GetMenusQuery = { menuItems: Maybe<{ nodes: Maybe<Array<Maybe<{ id: string, parentId: Maybe<string>, label: Maybe<string>, url: Maybe<string> }>>> }> };
+export type GetMenusQuery = { menuItems: Maybe<{ nodes: Maybe<Array<Maybe<{ id: string, parentId: Maybe<string>, label: Maybe<string>, url: Maybe<string>, locations: Maybe<Array<Maybe<MenuLocationEnum>>> }>>> }> };

--- a/packages/headless/src/utils/index.ts
+++ b/packages/headless/src/utils/index.ts
@@ -1,5 +1,6 @@
 export * from './assert';
 export * from './convert';
+export * from './menu';
 export { default as getCurrentPath } from './getCurrentPath';
 export * from './preview';
 export * from './resolveTemplate';

--- a/packages/headless/src/utils/menu.test.ts
+++ b/packages/headless/src/utils/menu.test.ts
@@ -1,0 +1,92 @@
+import { menuLocation } from './menu';
+import { WPGraphQL } from '../types';
+import MenuItem from '../components/menu/MenuItemInterface';
+
+describe('menuLocation', () => {
+  test('filters by location', () => {
+    const input: WPGraphQL.GetMenusQuery['menuItems']['nodes'] = [
+      {
+        id: 'primary-location',
+        parentId: '',
+        title: 'Home',
+        href: '/',
+        locations: [WPGraphQL.MenuLocationEnum.Primary],
+      },
+      {
+        id: 'no-location',
+        parentId: '',
+        title: 'Landing',
+        href: '/',
+        locations: [],
+      },
+      {
+        id: 'footer-location',
+        parentId: '',
+        title: 'Careers',
+        href: '/',
+        locations: [WPGraphQL.MenuLocationEnum.Footer],
+      },
+    ];
+
+    const expected: MenuItem[] = [
+      { id: 'primary-location', title: 'Home', href: '/', children: [] },
+    ];
+
+    const result = menuLocation(input, WPGraphQL.MenuLocationEnum.Primary);
+
+    expect(result).toStrictEqual(expected);
+  });
+
+  test('moves children into parents', () => {
+    const input: WPGraphQL.GetMenusQuery['menuItems']['nodes'] = [
+      {
+        id: 'root-menu-item',
+        parentId: '',
+        title: 'Root',
+        href: '/',
+        locations: [WPGraphQL.MenuLocationEnum.Primary],
+      },
+      {
+        id: 'child-menu-item',
+        parentId: 'root-menu-item',
+        title: 'Child',
+        href: '/child',
+        locations: [WPGraphQL.MenuLocationEnum.Primary],
+      },
+      {
+        id: 'grandchild-menu-item',
+        parentId: 'child-menu-item',
+        title: 'Grandchild',
+        href: '/grandchild',
+        locations: [WPGraphQL.MenuLocationEnum.Primary],
+      },
+    ];
+
+    const expected: MenuItem[] = [
+      {
+        id: 'root-menu-item',
+        title: 'Root',
+        href: '/',
+        children: [
+          {
+            id: 'child-menu-item',
+            title: 'Child',
+            href: '/child',
+            children: [
+              {
+                id: 'grandchild-menu-item',
+                title: 'Grandchild',
+                href: '/grandchild',
+                children: [],
+              },
+            ],
+          },
+        ],
+      },
+    ];
+
+    const result = menuLocation(input, WPGraphQL.MenuLocationEnum.Primary);
+
+    expect(result).toStrictEqual(expected);
+  });
+});

--- a/packages/headless/src/utils/menu.ts
+++ b/packages/headless/src/utils/menu.ts
@@ -1,0 +1,52 @@
+import { WPGraphQL } from '../types';
+import MenuItem from '../components/menu/MenuItemInterface';
+
+type WPGraphQLMenuItems =
+  | WPGraphQL.GetMenusQuery['menuItems']['nodes']
+  | undefined;
+
+/**
+ * Takes a flat list of menu items with `id` and `parentID` properties.
+ * Moves items with a parentID to the parent's `children` array.
+ *
+ * @see https://www.wpgraphql.com/docs/menus/#hierarchical-data.
+ */
+const flatToTree = (
+  data = [],
+  { idKey = 'id', parentKey = 'parentId', childrenKey = 'children' } = {},
+) => {
+  const tree = [];
+  const childrenOf = {};
+  data.forEach((item) => {
+    const newItem = { ...item };
+    const { [idKey]: id, [parentKey]: parentId = 0 } = newItem;
+    childrenOf[id] = childrenOf[id] || [];
+    newItem[childrenKey] = childrenOf[id];
+    if (parentId) {
+      (childrenOf[parentId] = childrenOf[parentId] || []).push(newItem);
+    } else {
+      tree.push(newItem);
+    }
+  });
+  return tree;
+};
+
+/**
+ * Filters `menus` to leave only menu items from the WordPress menu `location`.
+ *
+ * Restores parent-child relationships from the flat WPGraphQL menu item list.
+ *
+ * @param menus
+ * @param location
+ */
+export function menuLocation(
+  menus: WPGraphQLMenuItems,
+  location: WPGraphQL.MenuLocationEnum,
+): MenuItem[] | undefined {
+  if (menus) {
+    const locationItems = menus.filter((m) => m.locations.includes(location));
+    return flatToTree(locationItems);
+  }
+
+  return menus;
+}


### PR DESCRIPTION
For [BH-830](https://wpengine.atlassian.net/browse/BH-830) to document and improve UX of the Menu component.

Adds:
- Docs for the `Menu` component.
- A `getMenus` service to fetch menu items from WPGraphQL.
- A `useMenus` hook to provide menu items to the Menu component.
- A `menuLocation` helper to filter and build a tree of parent-child items from the flat WPGraphQL menu items.
- An example of the menu in use in the `preview` project (to be renamed in a future PR).

### To test manually
1. In WordPress at Appearance → Menus, create a menu, assign it to the Primary location, and add menu items to it.
2. Follow the install steps here to spin up the demo: https://github.com/wpengine/headless-framework/blob/canary/docs/DEVELOPMENT.md#npm-packages
3. Visit http://localhost:3000/. You should see your menu on the index page (unstyled).

<img width="294" alt="Screenshot 2021-01-26 at 21 58 32" src="https://user-images.githubusercontent.com/647669/105904628-a9916f00-6021-11eb-9a94-05e987bf7444.png">

### Jest tests
`cd packages/headless && npm run test src/utils/menu.test.ts`

### Notes
- URL rewrites for the menu URLs are currently broken. Will investigate and file a separate PR.
- Our preview project does not display pages at present. Will add a `page.tsx` to `/theme` in a separate PR.
