### PR TITLE
fix: do not export resolveTemplate in /utils to reduce chance of Webpack error/warning

### DIFF
--- a/packages/headless/src/api/initializeNextServerSideProps.ts
+++ b/packages/headless/src/api/initializeNextServerSideProps.ts
@@ -8,17 +8,13 @@ import {
 import { initializeApollo, addApolloState } from '../provider';
 import { headlessConfig } from '../config';
 import { UriInfo, WPGraphQL } from '../types';
-import {
-  resolvePrefixedUrlPath,
-  resolveTemplate,
-  isPreview,
-  isPreviewPath,
-} from '../utils';
+import { resolvePrefixedUrlPath, isPreview, isPreviewPath } from '../utils';
 import getCurrentPath from '../utils/getCurrentPath';
 import { ensureAuthorization } from '../auth';
 import isHTTPS from '../utils/isHTTPS';
 
 import type { Template } from '../components/TemplateLoader';
+import { resolveTemplate } from '../utils/resolveTemplate';
 
 /**
  * Must be called from getServerSideProps within a Next app in order to support SSR. It will

--- a/packages/headless/src/api/initializeNextStaticProps.ts
+++ b/packages/headless/src/api/initializeNextStaticProps.ts
@@ -8,17 +8,13 @@ import {
 import { initializeApollo, addApolloState } from '../provider';
 import { headlessConfig } from '../config';
 import { WPGraphQL, UriInfo } from '../types';
-import {
-  resolvePrefixedUrlPath,
-  isPreview,
-  isPreviewPath,
-  resolveTemplate,
-} from '../utils';
+import { resolvePrefixedUrlPath, isPreview, isPreviewPath } from '../utils';
 import getCurrentPath from '../utils/getCurrentPath';
 import { ensureAuthorization } from '../auth';
 import isHTTPS from '../utils/isHTTPS';
 
 import type { Template } from '../components/TemplateLoader';
+import { resolveTemplate } from '../utils/resolveTemplate';
 
 /**
  * Must be called from getServerSideProps within a Next app in order to support SSR. It will

--- a/packages/headless/src/utils/index.ts
+++ b/packages/headless/src/utils/index.ts
@@ -2,4 +2,5 @@ export * from './assert';
 export * from './convert';
 export { default as getCurrentPath } from './getCurrentPath';
 export * from './preview';
-export * from './resolveTemplate';
+/* resolveTemplate is intentionally excluded here to prevent Webpack errors for setups that may not
+  have a "theme" directory */


### PR DESCRIPTION
This should prevent errors if the 'theme' directory is not present in a non-Next.js project