### PR TITLE
fix: resolve issues with hooks preventing rendering of HTML when client-side JS is disabled

### DIFF
--- a/examples/preview/package-lock.json
+++ b/examples/preview/package-lock.json
@@ -5,63 +5,39 @@
   "requires": true,
   "dependencies": {
     "@ampproject/toolbox-core": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/@ampproject/toolbox-core/-/toolbox-core-2.7.1.tgz",
-      "integrity": "sha512-MWGmCLyBOouXTy1Vc30Jw7NkshJ5XkPlcXhhRc9Gw3dDAZJ8rUS69SIQ6cFMt2owCQnw7irMNlvZQTqdyx61rA==",
+      "version": "2.7.4",
+      "resolved": "https://registry.npmjs.org/@ampproject/toolbox-core/-/toolbox-core-2.7.4.tgz",
+      "integrity": "sha512-qpBhcS4urB7IKc+jx2kksN7BuvvwCo7Y3IstapWo+EW+COY5EYAUwb2pil37v3TsaqHKgX//NloFP1SKzGZAnw==",
       "requires": {
         "cross-fetch": "3.0.6",
         "lru-cache": "6.0.0"
-      },
-      "dependencies": {
-        "cross-fetch": {
-          "version": "3.0.6",
-          "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.0.6.tgz",
-          "integrity": "sha512-KBPUbqgFjzWlVcURG+Svp9TlhA5uliYtiNx/0r8nv0pdypeQCRJ9IaSIc3q/x3q8t3F75cHuwxVql1HFGHCNJQ==",
-          "requires": {
-            "node-fetch": "2.6.1"
-          }
-        }
       }
     },
     "@ampproject/toolbox-optimizer": {
-      "version": "2.7.0-alpha.1",
-      "resolved": "https://registry.npmjs.org/@ampproject/toolbox-optimizer/-/toolbox-optimizer-2.7.0-alpha.1.tgz",
-      "integrity": "sha512-2wTvOyM6GP6FrYQzxSQCg43STo1jMRGeDKa6YUkYXYH9fm9Wbt2wTRx+ajjb48JQ6WwUnGwga1MhQhVFzRQ+wQ==",
+      "version": "2.7.1-alpha.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/toolbox-optimizer/-/toolbox-optimizer-2.7.1-alpha.0.tgz",
+      "integrity": "sha512-WGPZKVQvHgNYJk1XVJCCmY+NVGTGJtvn0OALDyiegN4FJWOcilQUhCIcjMkZN59u1flz/u+sEKccM5qsROqVyg==",
       "requires": {
-        "@ampproject/toolbox-core": "^2.6.0",
-        "@ampproject/toolbox-runtime-version": "^2.7.0-alpha.1",
+        "@ampproject/toolbox-core": "^2.7.1-alpha.0",
+        "@ampproject/toolbox-runtime-version": "^2.7.1-alpha.0",
         "@ampproject/toolbox-script-csp": "^2.5.4",
-        "@ampproject/toolbox-validator-rules": "^2.5.4",
+        "@ampproject/toolbox-validator-rules": "^2.7.1-alpha.0",
         "abort-controller": "3.0.0",
-        "cross-fetch": "3.0.5",
-        "cssnano-simple": "1.2.0",
-        "dom-serializer": "1.0.1",
-        "domhandler": "3.0.0",
-        "domutils": "2.1.0",
-        "htmlparser2": "4.1.0",
+        "cross-fetch": "3.0.6",
+        "cssnano-simple": "1.2.1",
+        "dom-serializer": "1.1.0",
+        "domhandler": "3.3.0",
+        "domutils": "2.4.2",
+        "htmlparser2": "5.0.1",
         "https-proxy-agent": "5.0.0",
         "lru-cache": "6.0.0",
-        "node-fetch": "2.6.0",
+        "node-fetch": "2.6.1",
         "normalize-html-whitespace": "1.0.0",
         "postcss": "7.0.32",
         "postcss-safe-parser": "4.0.2",
-        "terser": "5.1.0"
+        "terser": "5.5.1"
       },
       "dependencies": {
-        "cssnano-simple": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/cssnano-simple/-/cssnano-simple-1.2.0.tgz",
-          "integrity": "sha512-pton9cZ70/wOCWMAbEGHO1ACsW1KggTB6Ikj7k71uOEsz6SfByH++86+WAmXjRSc9q/g9gxkpFP9bDX9vRotdA==",
-          "requires": {
-            "cssnano-preset-simple": "1.2.0",
-            "postcss": "^7.0.32"
-          }
-        },
-        "node-fetch": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
-          "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
-        },
         "postcss": {
           "version": "7.0.32",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.32.tgz",
@@ -75,11 +51,11 @@
       }
     },
     "@ampproject/toolbox-runtime-version": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/@ampproject/toolbox-runtime-version/-/toolbox-runtime-version-2.7.1.tgz",
-      "integrity": "sha512-3LsjaOz/Aw4YpWG6ZxpVhA2N8GF0gRfvCrNm0ZspUviz/NR+MLrJ50BPoOOAmKCzoNVA2Q8xF3Y8dfamGuoblA==",
+      "version": "2.7.4",
+      "resolved": "https://registry.npmjs.org/@ampproject/toolbox-runtime-version/-/toolbox-runtime-version-2.7.4.tgz",
+      "integrity": "sha512-SAdOUOERp42thVNWaBJlnFvFVvnacMVnz5z9LyUZHSnoL1EqrAW5Sz5jv+Ly+gkA8NYsEaUxAdSCBAzE9Uzb4Q==",
       "requires": {
-        "@ampproject/toolbox-core": "^2.7.1"
+        "@ampproject/toolbox-core": "2.7.4"
       }
     },
     "@ampproject/toolbox-script-csp": {
@@ -88,21 +64,11 @@
       "integrity": "sha512-+knTYetI5nWllRZ9wFcj7mYxelkiiFVRAAW/hl0ad8EnKHMH82tRlk40CapEnUHhp6Er5sCYkumQ8dngs3Q4zQ=="
     },
     "@ampproject/toolbox-validator-rules": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/@ampproject/toolbox-validator-rules/-/toolbox-validator-rules-2.7.1.tgz",
-      "integrity": "sha512-LYkGKqFBOC39lvRX38wGjbLf4r8VXJyiCZSLRepiHjO4xbstZLyHPwxHlobQrBhD7UbHZn5TVD+qw+VMJNMSxw==",
+      "version": "2.7.4",
+      "resolved": "https://registry.npmjs.org/@ampproject/toolbox-validator-rules/-/toolbox-validator-rules-2.7.4.tgz",
+      "integrity": "sha512-z3JRcpIZLLdVC9XVe7YTZuB3a/eR9s2SjElYB9AWRdyJyL5Jt7+pGNv4Uwh1uHVoBXsWEVQzNOWSNtrO3mSwZA==",
       "requires": {
-        "cross-fetch": "^3.0.6"
-      },
-      "dependencies": {
-        "cross-fetch": {
-          "version": "3.0.6",
-          "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.0.6.tgz",
-          "integrity": "sha512-KBPUbqgFjzWlVcURG+Svp9TlhA5uliYtiNx/0r8nv0pdypeQCRJ9IaSIc3q/x3q8t3F75cHuwxVql1HFGHCNJQ==",
-          "requires": {
-            "node-fetch": "2.6.1"
-          }
-        }
+        "cross-fetch": "3.0.6"
       }
     },
     "@apollo/client": {
@@ -129,6 +95,7 @@
       "version": "7.10.4",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
       "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
+      "dev": true,
       "requires": {
         "@babel/highlight": "^7.10.4"
       }
@@ -1657,9 +1624,9 @@
       }
     },
     "@hapi/boom": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-9.1.0.tgz",
-      "integrity": "sha512-4nZmpp4tXbm162LaZT45P7F7sgiem8dwAh2vHWT6XX24dozNjGMg6BvKCRvtCUcmcXqeMIUqWN8Rc5X8yKuROQ==",
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-9.1.1.tgz",
+      "integrity": "sha512-VNR8eDbBrOxBgbkddRYIe7+8DZ+vSbV6qlmaN2x7eWjsUjy2VmQgChkOKcVZIeupEZYj+I0dqNg430OhwzagjA==",
       "requires": {
         "@hapi/hoek": "9.x.x"
       }
@@ -1679,32 +1646,41 @@
       }
     },
     "@next/env": {
-      "version": "10.0.3",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-10.0.3.tgz",
-      "integrity": "sha512-xjJt2VXoSxAydskmt77nJuEtRL782E4ltaj5JtMzJ8YkNUMMu3d5ktpCR+Q3INKHF/RY6zHJ9QzyE3/s1ikbNg=="
+      "version": "10.0.5",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-10.0.5.tgz",
+      "integrity": "sha512-dw6Q7PALIo7nTFfaB4OnRDte3EikrApGtjX/4cRmYXLh+uudDI50aS39MaGeKKZ2mxPKoNiFcY6Slv1f6KIPOw=="
     },
     "@next/polyfill-module": {
-      "version": "10.0.3",
-      "resolved": "https://registry.npmjs.org/@next/polyfill-module/-/polyfill-module-10.0.3.tgz",
-      "integrity": "sha512-JaiycQZZbqViaMZgRGYcPIdCPDz+qRnqEGxbhQlrxyPaBaOtsrAEkGf1SS2wJZKa/ncxqWHMfSvizDcGcz/ygQ=="
+      "version": "10.0.5",
+      "resolved": "https://registry.npmjs.org/@next/polyfill-module/-/polyfill-module-10.0.5.tgz",
+      "integrity": "sha512-R6ySTTIl6yqyO3Xft7h+QR9Z4e6epEw+AGO125CrwPmCDQ8ASLGltsHYvSHBP7Eae7xaorkXHW0jeI8NewLpew=="
     },
     "@next/react-dev-overlay": {
-      "version": "10.0.3",
-      "resolved": "https://registry.npmjs.org/@next/react-dev-overlay/-/react-dev-overlay-10.0.3.tgz",
-      "integrity": "sha512-ykiKeUhTsMRoyyYnx4jM8xeOPfKGqQ7xgx2dNXOu4tbPpdivzjJp2+K6+xnqhTmZ7uxfFBV+b1OE1ZzA8qyX5Q==",
+      "version": "10.0.5",
+      "resolved": "https://registry.npmjs.org/@next/react-dev-overlay/-/react-dev-overlay-10.0.5.tgz",
+      "integrity": "sha512-olqIaaRvFezzi02V/AYwvmrGbShUNrJDvyZTGNahxXEkiYsuu67llY5IKFM5Oya93/eRqaCCKMn89vpvYtvDcw==",
       "requires": {
-        "@babel/code-frame": "7.10.4",
-        "ally.js": "1.4.1",
+        "@babel/code-frame": "7.12.11",
         "anser": "1.4.9",
         "chalk": "4.0.0",
         "classnames": "2.2.6",
-        "data-uri-to-buffer": "3.0.0",
+        "css.escape": "1.5.1",
+        "data-uri-to-buffer": "3.0.1",
+        "platform": "1.3.6",
         "shell-quote": "1.7.2",
         "source-map": "0.8.0-beta.0",
         "stacktrace-parser": "0.1.10",
         "strip-ansi": "6.0.0"
       },
       "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.12.11",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
+          "integrity": "sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==",
+          "requires": {
+            "@babel/highlight": "^7.10.4"
+          }
+        },
         "ansi-styles": {
           "version": "4.3.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -1759,9 +1735,9 @@
       }
     },
     "@next/react-refresh-utils": {
-      "version": "10.0.3",
-      "resolved": "https://registry.npmjs.org/@next/react-refresh-utils/-/react-refresh-utils-10.0.3.tgz",
-      "integrity": "sha512-XtzzPX2R4+MIyu1waEQUo2tiNwWVEkmObA6pboRCDTPOs4Ri8ckaIE08lN5A5opyF6GVN+IEq/J8KQrgsePsZQ=="
+      "version": "10.0.5",
+      "resolved": "https://registry.npmjs.org/@next/react-refresh-utils/-/react-refresh-utils-10.0.5.tgz",
+      "integrity": "sha512-Eo+nvW1ZhdkuxBWSsKHGDLNspUaJJQClld9R+H+EtiIuAQtTa8f2rhcQeyUOtvUNQoPyq7Em2PwUqOQD6LOOMA=="
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.3",
@@ -1788,6 +1764,19 @@
         "@nodelib/fs.scandir": "2.1.3",
         "fastq": "^1.6.0"
       }
+    },
+    "@opentelemetry/api": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-0.14.0.tgz",
+      "integrity": "sha512-L7RMuZr5LzMmZiQSQDy9O1jo0q+DaLy6XpYJfIGfYSfoJA5qzYwUP3sP1uMIQ549DvxAgM3ng85EaPTM/hUHwQ==",
+      "requires": {
+        "@opentelemetry/context-base": "^0.14.0"
+      }
+    },
+    "@opentelemetry/context-base": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/context-base/-/context-base-0.14.0.tgz",
+      "integrity": "sha512-sDOAZcYwynHFTbLo6n8kIbLiVF3a3BLkrmehJUyEbT9F+Smbi47kLGS2gG2g0fjBLR/Lr1InPD7kXL7FaTqEkw=="
     },
     "@sideway/address": {
       "version": "4.1.0",
@@ -2381,15 +2370,6 @@
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
       "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ=="
     },
-    "ally.js": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/ally.js/-/ally.js-1.4.1.tgz",
-      "integrity": "sha1-n7fmuljvrE7pExyymqnuO1QLzx4=",
-      "requires": {
-        "css.escape": "^1.5.0",
-        "platform": "1.3.3"
-      }
-    },
     "anser": {
       "version": "1.4.9",
       "resolved": "https://registry.npmjs.org/anser/-/anser-1.4.9.tgz",
@@ -2508,6 +2488,12 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
       "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ="
+    },
+    "array-flatten": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-3.0.0.tgz",
+      "integrity": "sha512-zPMVc3ZYlGLNk4mpK1NzP2wg0ml9t7fUgDsayR5Y5rSzxQilzR9FGu/EH2jQOcKSAeAfWeylyW8juy3OkWRvNA==",
+      "optional": true
     },
     "array-includes": {
       "version": "3.1.2",
@@ -2757,9 +2743,9 @@
       "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ=="
     },
     "binary-extensions": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.1.0.tgz",
-      "integrity": "sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ=="
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
+      "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA=="
     },
     "bindings": {
       "version": "1.5.0",
@@ -3445,18 +3431,11 @@
       }
     },
     "cross-fetch": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.0.5.tgz",
-      "integrity": "sha512-FFLcLtraisj5eteosnX1gf01qYDCOc4fDy0+euOt8Kn9YBY2NtXL/pCoYPavw24NIQkQqm5ZOLsGD5Zzj0gyew==",
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.0.6.tgz",
+      "integrity": "sha512-KBPUbqgFjzWlVcURG+Svp9TlhA5uliYtiNx/0r8nv0pdypeQCRJ9IaSIc3q/x3q8t3F75cHuwxVql1HFGHCNJQ==",
       "requires": {
-        "node-fetch": "2.6.0"
-      },
-      "dependencies": {
-        "node-fetch": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
-          "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
-        }
+        "node-fetch": "2.6.1"
       }
     },
     "cross-spawn": {
@@ -3619,9 +3598,9 @@
       "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg=="
     },
     "cssnano-preset-simple": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/cssnano-preset-simple/-/cssnano-preset-simple-1.2.0.tgz",
-      "integrity": "sha512-zojGlY+KasFeQT/SnD/WqYXHcKddz2XHRDtIwxrWpGqGHp5IyLWsWFS3UW7pOf3AWvfkpYSRdxOSlYuJPz8j8g==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/cssnano-preset-simple/-/cssnano-preset-simple-1.2.1.tgz",
+      "integrity": "sha512-B2KahOIFTV6dw5Ioy9jHshTh/vAYNnUB2enyWRgnAEg3oJBjI/035ExpePaMqS2SwpbH7gCgvQqwpMBH6hTJSw==",
       "requires": {
         "caniuse-lite": "^1.0.30001093",
         "postcss": "^7.0.32"
@@ -3648,15 +3627,6 @@
         "postcss": "^7.0.32"
       },
       "dependencies": {
-        "cssnano-preset-simple": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/cssnano-preset-simple/-/cssnano-preset-simple-1.2.1.tgz",
-          "integrity": "sha512-B2KahOIFTV6dw5Ioy9jHshTh/vAYNnUB2enyWRgnAEg3oJBjI/035ExpePaMqS2SwpbH7gCgvQqwpMBH6hTJSw==",
-          "requires": {
-            "caniuse-lite": "^1.0.30001093",
-            "postcss": "^7.0.32"
-          }
-        },
         "postcss": {
           "version": "7.0.35",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.35.tgz",
@@ -3723,12 +3693,9 @@
       "dev": true
     },
     "data-uri-to-buffer": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-3.0.0.tgz",
-      "integrity": "sha512-MJ6mFTZ+nPQO+39ua/ltwNePXrfdF3Ww0wP1Od7EePySXN1cP9XNqRQOG3FxTfipp8jx898LUCgBCEP11Qw/ZQ==",
-      "requires": {
-        "buffer-from": "^1.1.1"
-      }
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-3.0.1.tgz",
+      "integrity": "sha512-WboRycPNsVw3B3TL559F7kuBUM4d8CgMEvk6xEJlOp7OBPjt6G7z8WMWlD2rOFZLk6OYfFIUGsCOWzcQH9K2og=="
     },
     "debug": {
       "version": "4.3.1",
@@ -3913,9 +3880,9 @@
       }
     },
     "dom-serializer": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.0.1.tgz",
-      "integrity": "sha512-1Aj1Qy3YLbdslkI75QEOfdp9TkQ3o8LRISAzxOibjBs/xWwr1WxZFOQphFkZuepHFGo+kB8e5FVJSS0faAJ4Rw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.1.0.tgz",
+      "integrity": "sha512-ox7bvGXt2n+uLWtCRLybYx60IrOlWL/aCebWJk1T0d4m3y2tzf4U3ij9wBMUb6YJZpz06HCCYuyCDveE2xXmzQ==",
       "requires": {
         "domelementtype": "^2.0.1",
         "domhandler": "^3.0.0",
@@ -3933,32 +3900,21 @@
       "integrity": "sha512-LsTgx/L5VpD+Q8lmsXSHW2WpA+eBlZ9HPf3erD1IoPF00/3JKHZ3BknUVA2QGDNu69ZNmyFmCWBSO45XjYKC5w=="
     },
     "domhandler": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-3.0.0.tgz",
-      "integrity": "sha512-eKLdI5v9m67kbXQbJSNn1zjh0SDzvzWVWtX+qEI3eMjZw8daH9k8rlj1FZY9memPwjiskQFbe7vHVVJIAqoEhw==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-3.3.0.tgz",
+      "integrity": "sha512-J1C5rIANUbuYK+FuFL98650rihynUOEzRLxW+90bKZRWB6A1X1Tf82GxR1qAWLyfNPRvjqfip3Q5tdYlmAa9lA==",
       "requires": {
         "domelementtype": "^2.0.1"
       }
     },
     "domutils": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.1.0.tgz",
-      "integrity": "sha512-CD9M0Dm1iaHfQ1R/TI+z3/JWp/pgub0j4jIQKH89ARR4ATAV2nbaOQS5XxU9maJP5jHaPdDDQSEHuE2UmpUTKg==",
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.4.2.tgz",
+      "integrity": "sha512-NKbgaM8ZJOecTZsIzW5gSuplsX2IWW2mIK7xVr8hTQF2v1CJWTmLZ1HOCh5sH+IzVPAGE5IucooOkvwBRAdowA==",
       "requires": {
-        "dom-serializer": "^0.2.1",
+        "dom-serializer": "^1.0.1",
         "domelementtype": "^2.0.1",
-        "domhandler": "^3.0.0"
-      },
-      "dependencies": {
-        "dom-serializer": {
-          "version": "0.2.2",
-          "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.2.2.tgz",
-          "integrity": "sha512-2/xPb3ORsQ42nHYiSunXkDjPLBaEj/xTwUO4B7XCZQTRk7EBtTOPaygh10YAAh2OI1Qrp6NWfpAhzswj0ydt9g==",
-          "requires": {
-            "domelementtype": "^2.0.1",
-            "entities": "^2.0.0"
-          }
-        }
+        "domhandler": "^3.3.0"
       }
     },
     "duplexify": {
@@ -4047,51 +4003,12 @@
       }
     },
     "enhanced-resolve": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-4.3.0.tgz",
-      "integrity": "sha512-3e87LvavsdxyoCfGusJnrZ5G8SLPOFeHSNpZI/ATL9a5leXo2k0w6MKnbqhdBad9qTobSfB20Ld7UmgoNbAZkQ==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.7.0.tgz",
+      "integrity": "sha512-6njwt/NsZFUKhM6j9U8hzVyD4E4r0x7NQzhTCbcWOJ0IQjNSAoalWmb0AE51Wn+fwan5qVESWi7t2ToBxs9vrw==",
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "memory-fs": "^0.5.0",
-        "tapable": "^1.0.0"
-      },
-      "dependencies": {
-        "memory-fs": {
-          "version": "0.5.0",
-          "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.5.0.tgz",
-          "integrity": "sha512-jA0rdU5KoQMC0e6ppoNRtpp6vjFq6+NY7r8hywnC7V+1Xj/MtHwGIbB1QaK/dunyjWteJzmkpd7ooeWg10T7GA==",
-          "requires": {
-            "errno": "^0.1.3",
-            "readable-stream": "^2.0.1"
-          }
-        },
-        "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        }
+        "graceful-fs": "^4.2.4",
+        "tapable": "^2.2.0"
       }
     },
     "enquirer": {
@@ -4109,9 +4026,9 @@
       "integrity": "sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w=="
     },
     "errno": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",
-      "integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.8.tgz",
+      "integrity": "sha512-dJ6oBr5SQ1VSd9qkk7ByRgb/1SH4JZjCHSW/mr63/QcXO9zLVxvJ6Oy13nio03rxpSnVDDjFor75SjVeZWPW/A==",
       "requires": {
         "prr": "~1.0.1"
       }
@@ -5553,13 +5470,13 @@
       "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg=="
     },
     "htmlparser2": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-4.1.0.tgz",
-      "integrity": "sha512-4zDq1a1zhE4gQso/c5LP1OtrhYTncXNSpvJYtWJBtXAETPlMfi3IFNjGuQbYLuVY4ZR0QMqRVvo4Pdy9KLyP8Q==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-5.0.1.tgz",
+      "integrity": "sha512-vKZZra6CSe9qsJzh0BjBGXo8dvzNsq/oGvsjfRdOrrryfeD9UOBEEQdeoqCRmKZchF5h2zOBMQ6YuQ0uRUmdbQ==",
       "requires": {
         "domelementtype": "^2.0.1",
-        "domhandler": "^3.0.0",
-        "domutils": "^2.0.0",
+        "domhandler": "^3.3.0",
+        "domutils": "^2.4.2",
         "entities": "^2.0.0"
       }
     },
@@ -5748,9 +5665,9 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "ini": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.6.tgz",
-      "integrity": "sha512-IZUoxEjNjubzrmvzZU4lKP7OnYmX72XRl3sqkfJhBKweKi5rnGi5+IUdlj/H1M+Ip5JQ1WzaDMOBRY90Ajc5jg==",
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "optional": true
     },
     "internal-slot": {
@@ -6679,17 +6596,18 @@
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="
     },
     "next": {
-      "version": "10.0.3",
-      "resolved": "https://registry.npmjs.org/next/-/next-10.0.3.tgz",
-      "integrity": "sha512-QYCfjZgowjaLUFvyV8959SmkUZU/edFgHeiXNtWDv7kffo/oTm891p0KZAkk5cMIHcsDX3g3UuQdw/zmui783g==",
+      "version": "10.0.5",
+      "resolved": "https://registry.npmjs.org/next/-/next-10.0.5.tgz",
+      "integrity": "sha512-yr7ap2TLugf0aMHz+3JoKFP9CCkFE+k6jCfdUymORhptjLYZbD3YGlTcUC1CRl+b5Phlbl7m/WUIPde0VcguiA==",
       "requires": {
-        "@ampproject/toolbox-optimizer": "2.7.0-alpha.1",
+        "@ampproject/toolbox-optimizer": "2.7.1-alpha.0",
         "@babel/runtime": "7.12.5",
         "@hapi/accept": "5.0.1",
-        "@next/env": "10.0.3",
-        "@next/polyfill-module": "10.0.3",
-        "@next/react-dev-overlay": "10.0.3",
-        "@next/react-refresh-utils": "10.0.3",
+        "@next/env": "10.0.5",
+        "@next/polyfill-module": "10.0.5",
+        "@next/react-dev-overlay": "10.0.5",
+        "@next/react-refresh-utils": "10.0.5",
+        "@opentelemetry/api": "0.14.0",
         "ast-types": "0.13.2",
         "babel-plugin-transform-define": "2.0.0",
         "babel-plugin-transform-react-remove-prop-types": "0.4.24",
@@ -6708,6 +6626,7 @@
         "native-url": "0.3.4",
         "node-fetch": "2.6.1",
         "node-html-parser": "1.4.9",
+        "p-limit": "3.1.0",
         "path-browserify": "1.0.1",
         "pnp-webpack-plugin": "1.6.4",
         "postcss": "8.1.7",
@@ -6719,7 +6638,7 @@
         "resolve-url-loader": "3.1.2",
         "sass-loader": "10.0.5",
         "schema-utils": "2.7.1",
-        "sharp": "0.26.2",
+        "sharp": "0.26.3",
         "stream-browserify": "3.0.0",
         "style-loader": "1.2.1",
         "styled-jsx": "3.3.2",
@@ -6728,6 +6647,16 @@
         "watchpack": "2.0.0-beta.13",
         "webpack": "4.44.1",
         "webpack-sources": "1.4.3"
+      },
+      "dependencies": {
+        "p-limit": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+          "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+          "requires": {
+            "yocto-queue": "^0.1.0"
+          }
+        }
       }
     },
     "next-tick": {
@@ -6736,69 +6665,12 @@
       "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw="
     },
     "next-transpile-modules": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/next-transpile-modules/-/next-transpile-modules-6.0.0.tgz",
-      "integrity": "sha512-+Xdn4Upb8FeOXorzqVFyqww3kR9ML6S7y6Q3gFnoLdsqC5Jim3fwGNGTHENLOwedoKxcM6bCyRBuMYzyxru/wA==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/next-transpile-modules/-/next-transpile-modules-6.1.0.tgz",
+      "integrity": "sha512-IVjXHXnvr/n7liIe7SZcDbq3Gab4zltmKk7sC8zqn/L3TJt1V49W0OnUdtD/LRUdET3i34EfH/4p45SjgyQbNw==",
       "requires": {
         "enhanced-resolve": "^5.3.2",
-        "pkg-dir": "^5.0.0"
-      },
-      "dependencies": {
-        "enhanced-resolve": {
-          "version": "5.7.0",
-          "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.7.0.tgz",
-          "integrity": "sha512-6njwt/NsZFUKhM6j9U8hzVyD4E4r0x7NQzhTCbcWOJ0IQjNSAoalWmb0AE51Wn+fwan5qVESWi7t2ToBxs9vrw==",
-          "requires": {
-            "graceful-fs": "^4.2.4",
-            "tapable": "^2.2.0"
-          }
-        },
-        "find-up": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
-          "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
-          "requires": {
-            "locate-path": "^6.0.0",
-            "path-exists": "^4.0.0"
-          }
-        },
-        "locate-path": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
-          "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
-          "requires": {
-            "p-locate": "^5.0.0"
-          }
-        },
-        "p-limit": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
-          "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
-          "requires": {
-            "yocto-queue": "^0.1.0"
-          }
-        },
-        "p-locate": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
-          "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
-          "requires": {
-            "p-limit": "^3.0.2"
-          }
-        },
-        "pkg-dir": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-5.0.0.tgz",
-          "integrity": "sha512-NPE8TDbzl/3YQYY7CSS228s3g2ollTFnc+Qi3tqmqJp9Vg2ovUpixcJEo2HJScN2Ez+kEaal6y70c0ehqJBJeA==",
-          "requires": {
-            "find-up": "^5.0.0"
-          }
-        },
-        "tapable": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.0.tgz",
-          "integrity": "sha512-FBk4IesMV1rBxX2tfiK8RAmogtWn53puLOQlvO8XuwlgxcYbP4mVPS9Ph4aeamSyyVjOl24aYWAuc8U5kCVwMw=="
-        }
+        "escalade": "^3.1.1"
       }
     },
     "nice-try": {
@@ -6824,9 +6696,9 @@
       }
     },
     "node-addon-api": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.0.2.tgz",
-      "integrity": "sha512-+D4s2HCnxPd5PjjI0STKwncjXTUKKqm74MDMz9OPXavjsGmjkvwgLtA5yoxJUdmpj52+2u+RrXgPipahKczMKg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.1.0.tgz",
+      "integrity": "sha512-flmrDNB06LIl5lywUz7YlNGZH/5p0M7W28k8hzd9Lshtdh1wshD2Y+U4h9LD6KObOy1f+fEVdgprPrEymjM5uw==",
       "optional": true
     },
     "node-fetch": {
@@ -7408,9 +7280,9 @@
       }
     },
     "platform": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.3.tgz",
-      "integrity": "sha1-ZGx3ARiZhwtqCQPnXpl+jlHadGE="
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.6.tgz",
+      "integrity": "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg=="
     },
     "please-upgrade-node": {
       "version": "3.2.0",
@@ -7567,9 +7439,9 @@
       "integrity": "sha512-97DXOFbQJhk71ne5/Mt6cOu6yxsSfM0QGQyl0L25Gca4yGWEGJaig7l7gbCX623VqTBNGLRLaVUCnNkcedlRSQ=="
     },
     "prebuild-install": {
-      "version": "5.3.6",
-      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-5.3.6.tgz",
-      "integrity": "sha512-s8Aai8++QQGi4sSbs/M1Qku62PFK49Jm1CbgXklGz4nmHveDq0wzJkg7Na5QbnO1uNH8K7iqx2EQ/mV0MZEmOg==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-6.0.0.tgz",
+      "integrity": "sha512-h2ZJ1PXHKWZpp1caLw0oX9sagVpL2YTk+ZwInQbQ3QqNd4J03O6MpFNmMTJlkfgPENWqe5kP0WjQLqz5OjLfsw==",
       "optional": true,
       "requires": {
         "detect-libc": "^1.0.3",
@@ -8381,19 +8253,20 @@
       }
     },
     "sharp": {
-      "version": "0.26.2",
-      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.26.2.tgz",
-      "integrity": "sha512-bGBPCxRAvdK9bX5HokqEYma4j/Q5+w8Nrmb2/sfgQCLEUx/HblcpmOfp59obL3+knIKnOhyKmDb4tEOhvFlp6Q==",
+      "version": "0.26.3",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.26.3.tgz",
+      "integrity": "sha512-NdEJ9S6AMr8Px0zgtFo1TJjMK/ROMU92MkDtYn2BBrDjIx3YfH9TUyGdzPC+I/L619GeYQc690Vbaxc5FPCCWg==",
       "optional": true,
       "requires": {
-        "color": "^3.1.2",
+        "array-flatten": "^3.0.0",
+        "color": "^3.1.3",
         "detect-libc": "^1.0.3",
         "node-addon-api": "^3.0.2",
         "npmlog": "^4.1.2",
-        "prebuild-install": "^5.3.5",
+        "prebuild-install": "^6.0.0",
         "semver": "^7.3.2",
         "simple-get": "^4.0.0",
-        "tar-fs": "^2.1.0",
+        "tar-fs": "^2.1.1",
         "tunnel-agent": "^0.6.0"
       }
     },
@@ -9081,9 +8954,9 @@
       }
     },
     "tapable": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/tapable/-/tapable-1.1.3.tgz",
-      "integrity": "sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA=="
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.0.tgz",
+      "integrity": "sha512-FBk4IesMV1rBxX2tfiK8RAmogtWn53puLOQlvO8XuwlgxcYbP4mVPS9Ph4aeamSyyVjOl24aYWAuc8U5kCVwMw=="
     },
     "tar-fs": {
       "version": "2.1.1",
@@ -9098,9 +8971,9 @@
       }
     },
     "tar-stream": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.1.4.tgz",
-      "integrity": "sha512-o3pS2zlG4gxr67GmFYBLlq+dM8gyRGUOvsrHclSkvtVtQbjV0s/+ZE8OpICbaj8clrX3tjeHngYGP7rweaBnuw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
       "optional": true,
       "requires": {
         "bl": "^4.0.3",
@@ -9130,13 +9003,20 @@
       }
     },
     "terser": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.1.0.tgz",
-      "integrity": "sha512-pwC1Jbzahz1ZPU87NQ8B3g5pKbhyJSiHih4gLH6WZiPU8mmS1IlGbB0A2Nuvkj/LCNsgIKctg6GkYwWCeTvXZQ==",
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.5.1.tgz",
+      "integrity": "sha512-6VGWZNVP2KTUcltUQJ25TtNjx/XgdDsBDKGt8nN0MpydU36LmbPPcMBd2kmtZNNGVVDLg44k7GKeHHj+4zPIBQ==",
       "requires": {
         "commander": "^2.20.0",
-        "source-map": "~0.6.1",
-        "source-map-support": "~0.5.12"
+        "source-map": "~0.7.2",
+        "source-map-support": "~0.5.19"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.7.3",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
+          "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ=="
+        }
       }
     },
     "terser-webpack-plugin": {
@@ -9994,6 +9874,27 @@
         "webpack-sources": "^1.4.1"
       },
       "dependencies": {
+        "enhanced-resolve": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-4.5.0.tgz",
+          "integrity": "sha512-Nv9m36S/vxpsI+Hc4/ZGRs0n9mXqSWGGq49zxb/cJfPAQMbUtttJAlNPS4AQzaBdw/pKskw5bMbekT/Y7W/Wlg==",
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "memory-fs": "^0.5.0",
+            "tapable": "^1.0.0"
+          },
+          "dependencies": {
+            "memory-fs": {
+              "version": "0.5.0",
+              "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.5.0.tgz",
+              "integrity": "sha512-jA0rdU5KoQMC0e6ppoNRtpp6vjFq6+NY7r8hywnC7V+1Xj/MtHwGIbB1QaK/dunyjWteJzmkpd7ooeWg10T7GA==",
+              "requires": {
+                "errno": "^0.1.3",
+                "readable-stream": "^2.0.1"
+              }
+            }
+          }
+        },
         "json5": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
@@ -10012,6 +9913,25 @@
             "json5": "^1.0.1"
           }
         },
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+        },
         "schema-utils": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
@@ -10021,6 +9941,19 @@
             "ajv-errors": "^1.0.0",
             "ajv-keywords": "^3.1.0"
           }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        },
+        "tapable": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/tapable/-/tapable-1.1.3.tgz",
+          "integrity": "sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA=="
         },
         "watchpack": {
           "version": "1.7.5",

--- a/examples/preview/package.json
+++ b/examples/preview/package.json
@@ -30,7 +30,7 @@
     "@apollo/client": "^3.3.4",
     "@wpengine/headless": "0.3.5-alpha.1",
     "graphql": "^15.4.0",
-    "next": "^10.0.3",
+    "next": "^10.0.5",
     "npm-run-all": "^4.1.5",
     "react": "^17.0.1",
     "react-dom": "^17.0.1"

--- a/examples/preview/theme/index.tsx
+++ b/examples/preview/theme/index.tsx
@@ -19,7 +19,7 @@ export default function Index() {
                     <a href={post.uri}>{post.title}</a>
                   </h5>
                 </Link>
-                <p dangerouslySetInnerHTML={{ __html: post.excerpt ?? '' }} />
+                <div dangerouslySetInnerHTML={{ __html: post.excerpt ?? '' }} />
               </div>
             </div>
           ))}

--- a/examples/preview/theme/single.tsx
+++ b/examples/preview/theme/single.tsx
@@ -16,7 +16,7 @@ export default function Single() {
           <div>
             <div>
               <h5>{post.title}</h5>
-              <p dangerouslySetInnerHTML={{ __html: post.content ?? '' }} />
+              <div dangerouslySetInnerHTML={{ __html: post.content ?? '' }} />
             </div>
           </div>
         )}

--- a/packages/headless/src/api/queries/GENERAL_SETTINGS.ts
+++ b/packages/headless/src/api/queries/GENERAL_SETTINGS.ts
@@ -1,0 +1,12 @@
+import { gql } from '@apollo/client';
+
+const GENERAL_SETTINGS = gql`
+  query GeneralSettings {
+    generalSettings {
+      title
+      description
+    }
+  }
+`;
+
+export { GENERAL_SETTINGS };

--- a/packages/headless/src/api/queries/GET_CONTENT_NODE.ts
+++ b/packages/headless/src/api/queries/GET_CONTENT_NODE.ts
@@ -1,0 +1,106 @@
+import { gql } from '@apollo/client';
+
+const GET_CONTENT_NODE = gql`
+  query GetContentNode(
+    $id: ID!
+    $idType: ContentNodeIdTypeEnum
+    $asPreview: Boolean
+  ) {
+    contentNode(id: $id, idType: $idType, asPreview: $asPreview) {
+      ... on Post {
+        id
+        slug
+        title
+        content
+        isRevision
+        isPreview
+        isSticky
+        excerpt
+        uri
+        status
+        featuredImage {
+          node {
+            id
+            altText
+            sourceUrl
+          }
+        }
+        preview {
+          node {
+            id
+            slug
+            title
+            content
+            isRevision
+            isPreview
+            isSticky
+            excerpt
+            uri
+            status
+            featuredImage {
+              node {
+                id
+                altText
+                sourceUrl
+              }
+            }
+          }
+        }
+        enqueuedStylesheets {
+          nodes {
+            src
+            handle
+          }
+        }
+      }
+      ... on Page {
+        id
+        slug
+        title
+        content
+        isPreview
+        isRevision
+        isFrontPage
+        isPostsPage
+        uri
+        status
+        featuredImage {
+          node {
+            id
+            altText
+            sourceUrl
+          }
+        }
+        preview {
+          node {
+            id
+            slug
+            title
+            content
+            isPreview
+            isRevision
+            isFrontPage
+            isPostsPage
+            uri
+            status
+            featuredImage {
+              node {
+                id
+                altText
+                sourceUrl
+              }
+            }
+          }
+        }
+        enqueuedStylesheets {
+          nodes {
+            src
+            handle
+          }
+        }
+      }
+    }
+  }
+`;
+
+export { GET_CONTENT_NODE };

--- a/packages/headless/src/api/queries/GET_POSTS.ts
+++ b/packages/headless/src/api/queries/GET_POSTS.ts
@@ -1,0 +1,29 @@
+import { gql } from '@apollo/client';
+
+const GET_POSTS = gql`
+  query GetPosts {
+    posts {
+      nodes {
+        id
+        slug
+        title
+        content
+        isRevision
+        isPreview
+        isSticky
+        excerpt
+        uri
+        status
+        featuredImage {
+          node {
+            id
+            altText
+            sourceUrl
+          }
+        }
+      }
+    }
+  }
+`;
+
+export { GET_POSTS };

--- a/packages/headless/src/api/queries/GET_URI_INFO.ts
+++ b/packages/headless/src/api/queries/GET_URI_INFO.ts
@@ -1,0 +1,16 @@
+import { gql } from '@apollo/client';
+
+const GET_URI_INFO = gql`
+  query GetUriInfo($uri: String!) {
+    nodeByUri(uri: $uri) {
+      id
+      templates
+      ... on ContentType {
+        isFrontPage
+        isPostsPage
+      }
+    }
+  }
+`;
+
+export { GET_URI_INFO };

--- a/packages/headless/src/api/queries/index.ts
+++ b/packages/headless/src/api/queries/index.ts
@@ -1,0 +1,4 @@
+export * from './GET_POSTS';
+export * from './GET_CONTENT_NODE';
+export * from './GENERAL_SETTINGS';
+export * from './GET_URI_INFO';

--- a/packages/headless/src/api/services.ts
+++ b/packages/headless/src/api/services.ts
@@ -1,8 +1,14 @@
-import { gql, ApolloClient, NormalizedCacheObject } from '@apollo/client';
+import { ApolloClient, NormalizedCacheObject } from '@apollo/client';
 import { WPGraphQL, UriInfo } from '../types';
 import * as utils from '../utils';
 import { ensureAuthorization } from '../auth';
 import { isServerSide } from '../utils';
+import {
+  GET_POSTS,
+  GET_CONTENT_NODE,
+  GENERAL_SETTINGS,
+  GET_URI_INFO,
+} from './queries';
 
 /**
  * Gets all posts from WordPress
@@ -16,31 +22,7 @@ export async function getPosts(
   client: ApolloClient<NormalizedCacheObject>,
 ): Promise<WPGraphQL.GetPostsQuery['posts']['nodes']> {
   const result = await client.query<WPGraphQL.GetPostsQuery>({
-    query: gql`
-      query GetPosts {
-        posts {
-          nodes {
-            id
-            slug
-            title
-            content
-            isRevision
-            isPreview
-            isSticky
-            excerpt
-            uri
-            status
-            featuredImage {
-              node {
-                id
-                altText
-                sourceUrl
-              }
-            }
-          }
-        }
-      }
-    `,
+    query: GET_POSTS,
   });
 
   return result.data.posts.nodes;
@@ -68,108 +50,7 @@ export async function getContentNode(
   | undefined
 > {
   const result = await client.query<WPGraphQL.GetContentNodeQuery>({
-    query: gql`
-      query GetContentNode(
-        $id: ID!
-        $idType: ContentNodeIdTypeEnum
-        $asPreview: Boolean
-      ) {
-        contentNode(id: $id, idType: $idType, asPreview: $asPreview) {
-          ... on Post {
-            id
-            slug
-            title
-            content
-            isRevision
-            isPreview
-            isSticky
-            excerpt
-            uri
-            status
-            featuredImage {
-              node {
-                id
-                altText
-                sourceUrl
-              }
-            }
-            preview {
-              node {
-                id
-                slug
-                title
-                content
-                isRevision
-                isPreview
-                isSticky
-                excerpt
-                uri
-                status
-                featuredImage {
-                  node {
-                    id
-                    altText
-                    sourceUrl
-                  }
-                }
-              }
-            }
-            enqueuedStylesheets {
-              nodes {
-                src
-                handle
-              }
-            }
-          }
-          ... on Page {
-            id
-            slug
-            title
-            content
-            isPreview
-            isRevision
-            isFrontPage
-            isPostsPage
-            uri
-            status
-            featuredImage {
-              node {
-                id
-                altText
-                sourceUrl
-              }
-            }
-            preview {
-              node {
-                id
-                slug
-                title
-                content
-                isPreview
-                isRevision
-                isFrontPage
-                isPostsPage
-                uri
-                status
-                featuredImage {
-                  node {
-                    id
-                    altText
-                    sourceUrl
-                  }
-                }
-              }
-            }
-            enqueuedStylesheets {
-              nodes {
-                src
-                handle
-              }
-            }
-          }
-        }
-      }
-    `,
+    query: GET_CONTENT_NODE,
     variables: {
       id,
       idType,
@@ -207,14 +88,7 @@ export async function getGeneralSettings(
   client: ApolloClient<NormalizedCacheObject>,
 ): Promise<WPGraphQL.GeneralSettingsQuery['generalSettings']> {
   const result = await client.query<WPGraphQL.GeneralSettingsQuery>({
-    query: gql`
-      query GeneralSettings {
-        generalSettings {
-          title
-          description
-        }
-      }
-    `,
+    query: GENERAL_SETTINGS,
   });
 
   return result?.data?.generalSettings;
@@ -251,18 +125,7 @@ export async function getUriInfo(
     WPGraphQL.GetUriInfoQuery,
     WPGraphQL.GetUriInfoQueryVariables
   >({
-    query: gql`
-      query GetUriInfo($uri: String!) {
-        nodeByUri(uri: $uri) {
-          id
-          templates
-          ... on ContentType {
-            isFrontPage
-            isPostsPage
-          }
-        }
-      }
-    `,
+    query: GET_URI_INFO,
     variables: {
       uri: urlPath,
     },

--- a/packages/headless/src/utils/trimOriginFromUrl.ts
+++ b/packages/headless/src/utils/trimOriginFromUrl.ts
@@ -1,0 +1,12 @@
+/**
+ * Trims the origin (protocol, host, port) from URL so only the path and query params remain
+ */
+export default function trimOriginFromUrl(url: string): string {
+  try {
+    const parsedUrl = new URL(url);
+
+    return url.replace(parsedUrl.origin, '');
+  } catch (e) {
+    return url;
+  }
+}


### PR DESCRIPTION
This PR updates our current hooks to use Apollo's `useQuery()` which plays better with SSR/SSG and ensures that the HTML is properly rendered.

Without this, pages may not render when JavaScript is disabled on the client-side.