### PR TITLE
Added check for WP_CLI before redirecting user on plugin activation

### DIFF
--- a/plugins/wpe-headless/wpe-headless.php
+++ b/plugins/wpe-headless/wpe-headless.php
@@ -44,17 +44,18 @@ if ( wpe_headless_is_events_enabled() ) {
 	require WPE_HEADLESS_DIR . '/includes/events/callbacks.php';
 }
 
+add_action( 'activated_plugin', 'wpe_headless_activated_plugin', 10, 2 );
 /**
- * Runs plugin activation tasks.
+ * Callback for WordPress 'activated_plugin' action.
+ *
+ * Redirect the user to WPE Headless settings page on activation.
+ *
+ * @param string $plugin       The plugin name.
+ * @param bool   $network_wide True if a network plugin, false if else.
  */
-add_action(
-	'activated_plugin',
-	static function( $plugin, $network_wide ) {
-		if ( ! $network_wide && plugin_basename( __FILE__ ) === $plugin ) {
-			wp_safe_redirect( esc_url( admin_url( 'options-general.php?page=wpe-headless-settings' ) ) );
-			exit;
-		}
-	},
-	10,
-	2
-);
+function wpe_headless_activated_plugin( $plugin, $network_wide ) {
+	if ( ! defined( 'WP_CLI' ) && ! $network_wide && WPE_HEADLESS_PATH === $plugin ) {
+		wp_safe_redirect( esc_url( admin_url( 'options-general.php?page=wpe-headless-settings' ) ) );
+		exit;
+	}
+}


### PR DESCRIPTION
This pull request checks if the `WP_CLI` constant is defined before redirection a user on the `wpe-headless` plugin activation.