### PR TITLE
fix: properly hydrate Apollo cache if using a static frontpage

### DIFF
--- a/examples/preview/theme/index.tsx
+++ b/examples/preview/theme/index.tsx
@@ -15,9 +15,9 @@ export default function Index() {
             <div key={post.id} id={`post-${post.id}`}>
               <div>
                 <Link href={post.uri}>
-                  <h5>
+                  <h2>
                     <a href={post.uri}>{post.title}</a>
-                  </h5>
+                  </h2>
                 </Link>
                 <div dangerouslySetInnerHTML={{ __html: post.excerpt ?? '' }} />
               </div>

--- a/examples/preview/theme/page.tsx
+++ b/examples/preview/theme/page.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { usePost, WPHead } from '@wpengine/headless';
+
+export default function Page() {
+  const post = usePost();
+
+  return (
+    <>
+      <WPHead />
+
+      <div>
+        {post && (
+          <div>
+            <div>
+              <h5>{post.title}</h5>
+              <div dangerouslySetInnerHTML={{ __html: post.content ?? '' }} />
+            </div>
+          </div>
+        )}
+      </div>
+    </>
+  );
+}

--- a/examples/preview/theme/page.tsx
+++ b/examples/preview/theme/page.tsx
@@ -12,7 +12,7 @@ export default function Page() {
         {post && (
           <div>
             <div>
-              <h5>{post.title}</h5>
+              <h1>{post.title}</h1>
               <div dangerouslySetInnerHTML={{ __html: post.content ?? '' }} />
             </div>
           </div>

--- a/examples/preview/theme/single.tsx
+++ b/examples/preview/theme/single.tsx
@@ -15,7 +15,7 @@ export default function Single() {
         {post && (
           <div>
             <div>
-              <h5>{post.title}</h5>
+              <h1>{post.title}</h1>
               <div dangerouslySetInnerHTML={{ __html: post.content ?? '' }} />
             </div>
           </div>

--- a/packages/headless/src/api/initializeNextServerSideProps.ts
+++ b/packages/headless/src/api/initializeNextServerSideProps.ts
@@ -1,20 +1,11 @@
 import { GetServerSidePropsContext, GetServerSidePropsResult } from 'next';
-import {
-  getUriInfo,
-  getPosts,
-  getContentNode,
-  getGeneralSettings,
-} from './services';
 import { initializeApollo, addApolloState } from '../provider';
 import { headlessConfig } from '../config';
-import { UriInfo } from '../types';
 import { resolvePrefixedUrlPath, isPreview, isPreviewPath } from '../utils';
 import getCurrentPath from '../utils/getCurrentPath';
 import { ensureAuthorization } from '../auth';
 import isHTTPS from '../utils/isHTTPS';
-
-import type { Template } from '../components/TemplateLoader';
-import { resolveTemplate } from '../utils/resolveTemplate';
+import nextFetchFromWP from './nextFetchFromWP';
 
 /**
  * Must be called from getServerSideProps within a Next app in order to support SSR. It will
@@ -59,36 +50,7 @@ export async function initializeNextServerSideProps(
     };
   }
 
-  /**
-   * Cannot happen at the same time as the rest of the requests because we need to know which templates to load for
-   * middleware.
-   */
-  const pageInfo = await getUriInfo(
-    apolloClient,
-    currentUrlPath,
-    isPreview(context),
-  );
-
-  const template: Template | null = resolveTemplate(pageInfo as UriInfo);
-
-  const promises = [
-    getGeneralSettings(apolloClient),
-    getPosts(apolloClient),
-    currentUrlPath !== '/'
-      ? getContentNode(apolloClient, currentUrlPath, 'URI', isPreview(context))
-      : undefined,
-  ];
-
-  await Promise.all(
-    template?.getPropsMiddleware
-      ? template?.getPropsMiddleware(
-          promises,
-          apolloClient,
-          currentUrlPath,
-          context,
-        )
-      : promises,
-  );
+  await nextFetchFromWP({ apolloClient, currentUrlPath, context });
 
   return addApolloState(apolloClient, {
     props: { preview: context.preview ?? false },

--- a/packages/headless/src/api/initializeNextStaticProps.ts
+++ b/packages/headless/src/api/initializeNextStaticProps.ts
@@ -1,20 +1,11 @@
 import { GetServerSidePropsResult, GetStaticPropsContext } from 'next';
-import {
-  getUriInfo,
-  getPosts,
-  getContentNode,
-  getGeneralSettings,
-} from './services';
 import { initializeApollo, addApolloState } from '../provider';
 import { headlessConfig } from '../config';
-import { UriInfo } from '../types';
 import { resolvePrefixedUrlPath, isPreview, isPreviewPath } from '../utils';
 import getCurrentPath from '../utils/getCurrentPath';
 import { ensureAuthorization } from '../auth';
 import isHTTPS from '../utils/isHTTPS';
-
-import type { Template } from '../components/TemplateLoader';
-import { resolveTemplate } from '../utils/resolveTemplate';
+import nextFetchFromWP from './nextFetchFromWP';
 
 /**
  * Must be called from getServerSideProps within a Next app in order to support SSR. It will
@@ -61,36 +52,7 @@ export async function initializeNextStaticProps(
     };
   }
 
-  /**
-   * Cannot happen at the same time as the rest of the requests because we need to know which templates to load for
-   * middleware.
-   */
-  const pageInfo = await getUriInfo(
-    apolloClient,
-    currentUrlPath,
-    isPreview(context),
-  );
-
-  const template: Template | null = resolveTemplate(pageInfo as UriInfo);
-
-  const promises = [
-    getGeneralSettings(apolloClient),
-    getPosts(apolloClient),
-    currentUrlPath !== '/'
-      ? getContentNode(apolloClient, currentUrlPath, 'URI', isPreview(context))
-      : undefined,
-  ];
-
-  await Promise.all(
-    template?.getPropsMiddleware
-      ? template?.getPropsMiddleware(
-          promises,
-          apolloClient,
-          currentUrlPath,
-          context,
-        )
-      : promises,
-  );
+  await nextFetchFromWP({ apolloClient, currentUrlPath, context });
 
   return addApolloState(apolloClient, {
     props: { preview: context.preview ?? false },

--- a/packages/headless/src/api/nextFetchFromWP.ts
+++ b/packages/headless/src/api/nextFetchFromWP.ts
@@ -1,0 +1,68 @@
+import { ApolloClient, NormalizedCacheObject } from '@apollo/client';
+import { GetServerSidePropsContext, GetStaticPropsContext } from 'next';
+import {
+  getContentNode,
+  getGeneralSettings,
+  getPosts,
+  getUriInfo,
+} from './services';
+import { isPreview } from '../utils';
+// eslint-disable-next-line import/no-cycle
+import { Template } from '../components/TemplateLoader';
+import { resolveTemplate } from '../utils/resolveTemplate';
+import { UriInfo } from '../types';
+
+/**
+ * Runs default queries from Node.js to WordPress backend to prime Apollo Cache.
+ */
+export default async function nextFetchFromWP({
+  apolloClient,
+  currentUrlPath,
+  context,
+}: {
+  apolloClient: ApolloClient<NormalizedCacheObject>;
+  currentUrlPath: string;
+  context: GetStaticPropsContext | GetServerSidePropsContext;
+}): Promise<void> {
+  /**
+   * Cannot happen at the same time as the rest of the requests because we need to know which templates to load for
+   * middleware.
+   */
+  const pageInfo = await getUriInfo(
+    apolloClient,
+    currentUrlPath,
+    isPreview(context),
+  );
+
+  const template: Template | null = resolveTemplate(pageInfo as UriInfo);
+
+  const promises = [
+    getGeneralSettings(apolloClient),
+    getPosts(apolloClient),
+    /**
+     * Running getContentNode blindly on the site root will result in a 500 error from WP GraphQL if the frontpage
+     * is not set.
+     *
+     * If a frontpage/blog is not set in Settings » Reading, both isFrontPage and isPostsPage will be true.
+     */
+    !(
+      currentUrlPath === '/' &&
+      pageInfo &&
+      pageInfo?.isFrontPage &&
+      pageInfo?.isPostsPage
+    )
+      ? getContentNode(apolloClient, currentUrlPath, 'URI', isPreview(context))
+      : undefined,
+  ];
+
+  await Promise.all(
+    template?.getPropsMiddleware
+      ? template?.getPropsMiddleware(
+          promises,
+          apolloClient,
+          currentUrlPath,
+          context,
+        )
+      : promises,
+  );
+}

--- a/packages/headless/src/components/TemplateLoader.tsx
+++ b/packages/headless/src/components/TemplateLoader.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import type { GetServerSidePropsContext, GetStaticPropsContext } from 'next';
 import type { ApolloClient, NormalizedCacheObject } from '@apollo/client';
-import { useNextUriInfo } from '../api';
+import { useNextUriInfo } from '../api/hooks';
 import { resolveTemplate } from '../utils/resolveTemplate';
 
 export interface Template {


### PR DESCRIPTION
Run `getContentNode()` if a static front page is enabled. Note, it needs to be conditionally run as the query will result in a 500 error if a static front page is not in use.

Additionally, this DRYs things up by extracting out the querying in the Data Fetchers into a new method named `nextFetchFromWP`