### PR TITLE
fix: resolve regressions with previews not working without client-side requests

### DIFF
--- a/packages/headless/src/api/hooks.ts
+++ b/packages/headless/src/api/hooks.ts
@@ -143,6 +143,7 @@ export function useUriInfo(
     isFrontPage: result?.isFrontPage,
     id,
     uriPath: utils.getUrlPath(localUri),
+    isPreview: isPreviewPath(resolvedUri ?? localUri),
     templates,
   };
 
@@ -264,7 +265,7 @@ export function usePost(
   | undefined {
   const pageInfo = useNextUriInfo();
 
-  let variables: Partial<WPGraphQL.GetContentNodeQueryVariables>;
+  let variables: Partial<WPGraphQL.GetContentNodeQueryVariables> = {};
 
   if (id) {
     variables = {
@@ -273,7 +274,7 @@ export function usePost(
     };
   } else if (pageInfo) {
     variables = {
-      asPreview: isPreviewPath(pageInfo.uriPath),
+      asPreview: pageInfo.isPreview,
       id: pageInfo.uriPath,
       idType: 'URI',
     };
@@ -284,6 +285,16 @@ export function usePost(
     // @ts-ignore
     variables,
   });
+
+  const node = result?.data?.contentNode;
+
+  if (variables?.asPreview && !node?.isPreview) {
+    if (!node?.preview?.node) {
+      return node;
+    }
+
+    return node.preview.node;
+  }
 
   return result?.data?.contentNode;
 }

--- a/packages/headless/src/api/services.ts
+++ b/packages/headless/src/api/services.ts
@@ -65,7 +65,7 @@ export async function getContentNode(
     return undefined;
   }
 
-  if (asPreview && node.isPreview) {
+  if (asPreview && !node.isPreview) {
     if (!node.preview?.node) {
       return node;
     }


### PR DESCRIPTION
There were two notable regressions that caused previews to stop working with SSR/SSG. One was made when moving over to generated GraphQL types and the other was when switching to Apollo's hooks.

Note to self: write some E2E tests 😃