### PR TITLE
fix: Use 302 redirects for public URLs

### DIFF
--- a/plugins/wpe-headless/includes/deny-public-access/callbacks.php
+++ b/plugins/wpe-headless/includes/deny-public-access/callbacks.php
@@ -36,10 +36,7 @@ function wpe_headless_deny_public_access( $query ) {
 	) {
 		return;
 	}
-
-	// TODO: abort redirect if $query->request matches a list of whitelist strings/regexes specified by the user.
-
-	$response_code = 301;
+	$response_code = 302;
 	$redirect_url  = trailingslashit( $redirect_base ) . $query->request;
 
 	header( 'X-Redirect-By: WP Engine Headless plugin' ); // For support teams. See https://developer.yoast.com/blog/x-redirect-by-header/.


### PR DESCRIPTION
Turning off “Enable public route redirects” will no longer continue to cause redirects due to aggressive browser caching of 301 redirects.

For [BH-845](https://wpengine.atlassian.net/browse/BH-845). 

## To test
1. At Settings → Headless, add your front-end site URL and tick “Enable public route redirects”.
2. In your shell, `curl -I http://your-wp-instance.test`

You should see a `HTTP/1.1 302 Found` response instead of `HTTP/1.1 301 Moved Permanently`.