### PR TITLE
chore: remove 404 page template

### DIFF
--- a/examples/preview/pages/404.tsx
+++ b/examples/preview/pages/404.tsx
@@ -1,6 +1,0 @@
-/* eslint-disable react/jsx-props-no-spreading */
-import React from 'react';
-
-export default function Page404() {
-  return <h1>404</h1>;
-}


### PR DESCRIPTION
Removes `pages/404.tsx` from the preview project, because 404s now load `theme/404.tsx` instead.

As a result:
- Devs don't have two conflicting 404 templates to choose from.
- All page templates live in the same place (the theme folder).
- Visiting the `/404` path (`example.com/404`) loads the theme 404 template instead of the `page/404.tsx` template.

### To test
- `npm run bootstrap` from the project root
- `npm run dev`
- Visit `example.com/404` and `example.com/some-other-invalid-path`.

Both should result in the same “Oops! That page can’t be found.”