### PR TITLE
fix: ensure WP stylesheets start with WP URL

### DIFF
--- a/packages/headless/src/api/queries/GENERAL_SETTINGS.ts
+++ b/packages/headless/src/api/queries/GENERAL_SETTINGS.ts
@@ -5,6 +5,7 @@ const GENERAL_SETTINGS = gql`
     generalSettings {
       title
       description
+      url
     }
   }
 `;

--- a/packages/headless/src/components/WPHead.tsx
+++ b/packages/headless/src/components/WPHead.tsx
@@ -1,11 +1,6 @@
 import React from 'react';
 import Head from 'next/head';
 import { usePost, useGeneralSettings } from '../api';
-import { trimTrailingSlash } from '../utils';
-
-const WP_URL = trimTrailingSlash(
-  process.env.NEXT_PUBLIC_WORDPRESS_URL || process.env.WORDPRESS_URL,
-);
 
 export default function WPHead(): JSX.Element {
   const settings = useGeneralSettings();
@@ -35,9 +30,11 @@ export default function WPHead(): JSX.Element {
   const stylesheetUrl = (
     stylesheet: Required<Pick<WPGraphQL.EnqueuedStylesheet, 'src'>>,
   ): string => {
+    const WP_URL = settings?.url || '';
+
     return stylesheet.src.indexOf('http') === 0
       ? stylesheet.src
-      : `${WP_URL as string}${stylesheet.src}`;
+      : `${WP_URL}${stylesheet.src}`;
   };
 
   return (

--- a/packages/headless/src/types/wpgraphql.d.ts
+++ b/packages/headless/src/types/wpgraphql.d.ts
@@ -7958,7 +7958,7 @@ export type UsersConnectionOrderbyInput = {
 export type GeneralSettingsQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type GeneralSettingsQuery = { generalSettings: Maybe<{ title: Maybe<string>, description: Maybe<string> }> };
+export type GeneralSettingsQuery = { generalSettings: Maybe<{ title: Maybe<string>, description: Maybe<string>, url: Maybe<string> }> };
 
 export type GetContentNodeQueryVariables = Exact<{
   id: Scalars['ID'];


### PR DESCRIPTION
While documenting the `WPHead` component I noticed that stylesheets hotlinked to the WP instance are being rendered with an 'undefined' URL like this:

```
<link href="undefined/wp-includes/css/dist/block-library/style.css" rel="stylesheet">
```

Which causes a console error in Chrome due to the bad URL:

```
head-manager.ts?0645:83 Resource interpreted as Stylesheet but transferred with MIME type text/html:
"http://localhost:3000/undefined/wp-includes/css/dist/block-library/style.css".
```

This PR fixes things by passing the WP URL to Next.js via WPGraphQL instead of depending on `process.env`, which is `undefined` when the `WPHead` component uses it. I'm open to alternative solutions.

```
<link href="http://dev.test/wp-includes/css/dist/block-library/style.css" rel="stylesheet">
```

## To test
1. Create a WP page with a slug of `about`.
2. `npm run dev` and visit http://localhost:3000/about

View source or inspect the `head`. You should see a `block-library/style.css` `link` element prepended with your WordPress URL.
