### PR TITLE
fix: Change the way GraphQL auth callback checks HTTP_AUTHORIZATION

### DIFF
--- a/plugins/wpe-headless/includes/rest/callbacks.php
+++ b/plugins/wpe-headless/includes/rest/callbacks.php
@@ -23,7 +23,7 @@ add_filter( 'graphql_authentication_errors', 'wpe_headless_rest_validate_access_
  * @return bool True if the Authorization header exists and is invalid, false otherwise.
  */
 function wpe_headless_rest_validate_access_token( $authentication_errors ) {
-	if ( ! isset( $_SERVER['HTTP_AUTHORIZATION'] ) ) {
+	if ( empty( $_SERVER['HTTP_AUTHORIZATION'] ) ) {
 		return $authentication_errors;
 	}
 


### PR DESCRIPTION
This pull request changes the way our plugin callback for `graphql_authentication_errors` handles checking `HTTP_AUTHORIZATION`.

Props to @claygriffiths for discovering this and the fix suggestion.