### PR TITLE
fix: publish generated WP GraphQL types and bump to 0.4.3

### DIFF
--- a/examples/preview/package-lock.json
+++ b/examples/preview/package-lock.json
@@ -2277,9 +2277,9 @@
       }
     },
     "@wpengine/headless": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@wpengine/headless/-/headless-0.4.1.tgz",
-      "integrity": "sha512-oGYqdyw2bAFl0D0nvo+zDQdPZldND1V8c0g6E0QAUJ7WKCj785Wcw8nhIIkW7q9Cmp/mkmKqUvJh9eP39Jbk5g==",
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@wpengine/headless/-/headless-0.4.3.tgz",
+      "integrity": "sha512-7zp+6IcHdyuulgQD6bi/vfxS1jmvC1BrZKcgA+zoqoJgUKjMd+MILpeTjLFZtw9dDJ2ZtLyuDH++03om7QMEOw==",
       "requires": {
         "deepmerge": "^4.2.2",
         "isomorphic-fetch": "^3.0.0",
@@ -6665,11 +6665,11 @@
       "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw="
     },
     "next-transpile-modules": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/next-transpile-modules/-/next-transpile-modules-6.1.0.tgz",
-      "integrity": "sha512-IVjXHXnvr/n7liIe7SZcDbq3Gab4zltmKk7sC8zqn/L3TJt1V49W0OnUdtD/LRUdET3i34EfH/4p45SjgyQbNw==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/next-transpile-modules/-/next-transpile-modules-6.2.0.tgz",
+      "integrity": "sha512-THMOWVuLqA16LsdU84pY+pKFfTHVykV1sJz2w6ANMZ7/yjfISHVHDxUnnGRP2XRK9Q/Wl9KBb5AK+spWv6j7yw==",
       "requires": {
-        "enhanced-resolve": "^5.3.2",
+        "enhanced-resolve": "^5.7.0",
         "escalade": "^3.1.1"
       }
     },

--- a/examples/preview/package.json
+++ b/examples/preview/package.json
@@ -27,7 +27,7 @@
   "homepage": "https://github.com/wpengine/headless-framework/tree/main/examples/preview#readme",
   "dependencies": {
     "@apollo/client": "^3.3.4",
-    "@wpengine/headless": "^0.4.1",
+    "@wpengine/headless": "^0.4.3",
     "graphql": "^15.4.0",
     "next": "^10.0.5",
     "normalize.css": "^8.0.1",

--- a/packages/headless/.npmignore
+++ b/packages/headless/.npmignore
@@ -1,4 +1,5 @@
-src/
+src/**/*
+!src/types/wpgraphql.d.ts
 .eslintrc.js
 .prettierrc.js
 .gitignore

--- a/packages/headless/package-lock.json
+++ b/packages/headless/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpengine/headless",
-  "version": "0.4.1",
+  "version": "0.4.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/headless/package.json
+++ b/packages/headless/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpengine/headless",
-  "version": "0.4.1",
+  "version": "0.4.3",
   "description": "This module helps you use WordPress as a Headless CMS",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Now that the WP GraphQL types are in a `.d.ts` file, the TypeScript compiler doesn't automatically copy the file into the `dist` directory.

To get around this issue, a [triple-slash reference](https://github.com/wpengine/headless-framework/pull/103/files#diff-74d79f0f5fedfe81ebcb9151fe91d5c88030f530cea34a34c2a3cd70267f124cR2) is used to link `src/types/wpgraphql.d.ts`. However, the file wasn't being included in the published NPM package.

See https://github.com/wpengine/headless-framework/pull/103 for more context.