### PR TITLE
refactor: use WPGraphQL types in Posts component

### DIFF
--- a/examples/getting-started/components/Posts.tsx
+++ b/examples/getting-started/components/Posts.tsx
@@ -3,24 +3,8 @@ import Link from 'next/link';
 import styles from 'scss/components/Posts.module.scss';
 import Heading, { HeadingProps } from './Heading';
 
-interface Post {
-  id: string;
-  slug?: string;
-  title?: string;
-  content?: string;
-  isRevision?: boolean;
-  isPreview?: boolean;
-  isSticky: boolean;
-  excerpt?: string;
-  uri: string;
-  status?: string;
-  featuredImage?: {
-    node: { id: string; altText?: string; sourceUrl?: string };
-  };
-}
-
 interface Props {
-  posts: Post[] | undefined;
+  posts: WPGraphQL.GetPostsQuery['posts']['nodes'] | undefined;
   intro?: string;
   id?: string;
   count?: number;


### PR DESCRIPTION
Now that [WPGraphQL types are exposed](https://github.com/wpengine/headless-framework/pull/120), we can refer to those instead of inlining/duping the Post type in the getting-started example.

### To test
1. `rm -rf examples/getting-started/.next &&  rm -rf examples/getting-started/node_modules && rm -rf packages/headless/node_modules && rm -rf node_modules` (maybe we need an `npm run clean` script!?)
2. `npm run bootstrap`
3. `npm run dev`

You should see no build errors. Posts should continue to display near the bottom of the homepage.