### PR TITLE
fix: remove hash when querying GetUriInfo in useUriInfo()

### DIFF
--- a/packages/headless/src/api/hooks.ts
+++ b/packages/headless/src/api/hooks.ts
@@ -114,7 +114,9 @@ export function useUriInfo(
     );
   }
 
-  localUri = trimOriginFromUrl(localUri);
+  localUri = getUrlPath(localUri);
+  // eslint-disable-next-line no-param-reassign
+  resolvedUri = getUrlPath(resolvedUri);
 
   const result = useQuery<
     WPGraphQL.GetUriInfoQuery,


### PR DESCRIPTION
Remove hash when querying for URI info via `nodeByUri` in `useUriInfo()` to prevent URLs such as `/page#testing` from returning with no content.

Note, we already use `getUrlPath()` in `getUriInfo()`.