### PR TITLE
docs (BH-829): Generate headless package docs with typedoc

### DIFF
--- a/docs/reference/api/README.md
+++ b/docs/reference/api/README.md
@@ -1,0 +1,9 @@
+@wpengine/headless / [Exports](modules.md)
+
+# WordPress Headless Framework
+
+[![Version](https://img.shields.io/npm/v/@wpengine/headless.svg)](https://npmjs.org/package/@wpengine/headless)
+
+NOTE: This project is in the early stages of development, but it does contain useful functionallity for headless WordPress sites like authentication and post previews. Be sure to install the [WordPress plugin](https://github.com/wpengine/headless-framework) that enables the functionality in this package.
+
+[Documentation](https://github.com/wpengine/headless-framework)

--- a/docs/reference/api/README.md
+++ b/docs/reference/api/README.md
@@ -4,6 +4,6 @@
 
 [![Version](https://img.shields.io/npm/v/@wpengine/headless.svg)](https://npmjs.org/package/@wpengine/headless)
 
-NOTE: This project is in the early stages of development, but it does contain useful functionallity for headless WordPress sites like authentication and post previews. Be sure to install the [WordPress plugin](https://github.com/wpengine/headless-framework) that enables the functionality in this package.
+NOTE: This project is in the early stages of development, but it does contain useful functionality for headless WordPress sites like authentication and post previews. Be sure to install the [WordPress plugin](https://github.com/wpengine/headless-framework) that enables the functionality in this package.
 
 [Documentation](https://github.com/wpengine/headless-framework)

--- a/docs/reference/api/interfaces/cookieoptions.md
+++ b/docs/reference/api/interfaces/cookieoptions.md
@@ -1,0 +1,30 @@
+[@wpengine/headless](../README.md) / [Exports](../modules.md) / CookieOptions
+
+# Interface: CookieOptions
+
+## Hierarchy
+
+* **CookieOptions**
+
+## Table of contents
+
+### Properties
+
+- [cookies](cookieoptions.md#cookies)
+- [request](cookieoptions.md#request)
+
+## Properties
+
+### cookies
+
+• `Optional` **cookies**: *undefined* \| *string*
+
+Defined in: [auth/cookie.ts:7](https://github.com/wpengine/headless-framework/blob/9e3ac37/packages/headless/src/auth/cookie.ts#L7)
+
+___
+
+### request
+
+• `Optional` **request**: *undefined* \| *IncomingMessage*
+
+Defined in: [auth/cookie.ts:6](https://github.com/wpengine/headless-framework/blob/9e3ac37/packages/headless/src/auth/cookie.ts#L6)

--- a/docs/reference/api/interfaces/headlessconfig.md
+++ b/docs/reference/api/interfaces/headlessconfig.md
@@ -1,0 +1,34 @@
+[@wpengine/headless](../README.md) / [Exports](../modules.md) / HeadlessConfig
+
+# Interface: HeadlessConfig
+
+The configuration for your headless site
+
+**`export`** 
+
+**`interface`** HeadlessConfig
+
+## Hierarchy
+
+* **HeadlessConfig**
+
+## Table of contents
+
+### Properties
+
+- [uriPrefix](headlessconfig.md#uriprefix)
+
+## Properties
+
+### uriPrefix
+
+• `Optional` **uriPrefix**: *undefined* \| *string*
+
+This is a prefix URI path that we will use as the base URL for your WordPress posts.
+By default we will assume that your site is configured with no blog-specific URI.
+
+**`example`** /blog
+
+**`memberof`** WPEHeadlessConfig
+
+Defined in: [types.ts:17](https://github.com/wpengine/headless-framework/blob/9e3ac37/packages/headless/src/types.ts#L17)

--- a/docs/reference/api/interfaces/menuitem.md
+++ b/docs/reference/api/interfaces/menuitem.md
@@ -1,0 +1,32 @@
+[@wpengine/headless](../README.md) / [Exports](../modules.md) / MenuItem
+
+# Interface: MenuItem
+
+## Hierarchy
+
+* *DetailedHTMLProps*<*React.AnchorHTMLAttributes*<HTMLAnchorElement\>, HTMLAnchorElement\>
+
+  ↳ **MenuItem**
+
+## Table of contents
+
+### Properties
+
+- [children](menuitem.md#children)
+- [title](menuitem.md#title)
+
+## Properties
+
+### children
+
+• `Optional` **children**: *undefined* \| [*MenuItem*](menuitem.md)[]
+
+Defined in: [components/menu/MenuItemInterface.ts:9](https://github.com/wpengine/headless-framework/blob/9e3ac37/packages/headless/src/components/menu/MenuItemInterface.ts#L9)
+
+___
+
+### title
+
+• **title**: *string*
+
+Defined in: [components/menu/MenuItemInterface.ts:8](https://github.com/wpengine/headless-framework/blob/9e3ac37/packages/headless/src/components/menu/MenuItemInterface.ts#L8)

--- a/docs/reference/api/interfaces/parsedurlinfo.md
+++ b/docs/reference/api/interfaces/parsedurlinfo.md
@@ -1,0 +1,81 @@
+[@wpengine/headless](../README.md) / [Exports](../modules.md) / ParsedUrlInfo
+
+# Interface: ParsedUrlInfo
+
+The result of parsing a URL into its parts
+
+**`export`** 
+
+**`interface`** ParsedUrlInfo
+
+## Hierarchy
+
+* **ParsedUrlInfo**
+
+## Table of contents
+
+### Properties
+
+- [baseUrl](parsedurlinfo.md#baseurl)
+- [hash](parsedurlinfo.md#hash)
+- [host](parsedurlinfo.md#host)
+- [href](parsedurlinfo.md#href)
+- [pathname](parsedurlinfo.md#pathname)
+- [protocol](parsedurlinfo.md#protocol)
+- [search](parsedurlinfo.md#search)
+
+## Properties
+
+### baseUrl
+
+• **baseUrl**: *string*
+
+Defined in: [types.ts:29](https://github.com/wpengine/headless-framework/blob/9e3ac37/packages/headless/src/types.ts#L29)
+
+___
+
+### hash
+
+• **hash**: *string*
+
+Defined in: [types.ts:33](https://github.com/wpengine/headless-framework/blob/9e3ac37/packages/headless/src/types.ts#L33)
+
+___
+
+### host
+
+• **host**: *string*
+
+Defined in: [types.ts:30](https://github.com/wpengine/headless-framework/blob/9e3ac37/packages/headless/src/types.ts#L30)
+
+___
+
+### href
+
+• **href**: *string*
+
+Defined in: [types.ts:27](https://github.com/wpengine/headless-framework/blob/9e3ac37/packages/headless/src/types.ts#L27)
+
+___
+
+### pathname
+
+• **pathname**: *string*
+
+Defined in: [types.ts:31](https://github.com/wpengine/headless-framework/blob/9e3ac37/packages/headless/src/types.ts#L31)
+
+___
+
+### protocol
+
+• **protocol**: *string*
+
+Defined in: [types.ts:28](https://github.com/wpengine/headless-framework/blob/9e3ac37/packages/headless/src/types.ts#L28)
+
+___
+
+### search
+
+• **search**: *string*
+
+Defined in: [types.ts:32](https://github.com/wpengine/headless-framework/blob/9e3ac37/packages/headless/src/types.ts#L32)

--- a/docs/reference/api/interfaces/uriinfo.md
+++ b/docs/reference/api/interfaces/uriinfo.md
@@ -1,0 +1,108 @@
+[@wpengine/headless](../README.md) / [Exports](../modules.md) / UriInfo
+
+# Interface: UriInfo
+
+WordPress URI information
+
+**`export`** 
+
+**`interface`** UriInfo
+
+## Hierarchy
+
+* **UriInfo**
+
+## Table of contents
+
+### Properties
+
+- [id](uriinfo.md#id)
+- [idType](uriinfo.md#idtype)
+- [is404](uriinfo.md#is404)
+- [isArchive](uriinfo.md#isarchive)
+- [isFrontPage](uriinfo.md#isfrontpage)
+- [isPostsPage](uriinfo.md#ispostspage)
+- [isPreview](uriinfo.md#ispreview)
+- [isSingular](uriinfo.md#issingular)
+- [templates](uriinfo.md#templates)
+- [uriPath](uriinfo.md#uripath)
+
+## Properties
+
+### id
+
+• `Optional` **id**: *undefined* \| *string*
+
+Defined in: [types.ts:43](https://github.com/wpengine/headless-framework/blob/9e3ac37/packages/headless/src/types.ts#L43)
+
+___
+
+### idType
+
+• `Optional` **idType**: *undefined* \| *DATABASE_ID* \| *ID* \| *URI*
+
+Defined in: [types.ts:44](https://github.com/wpengine/headless-framework/blob/9e3ac37/packages/headless/src/types.ts#L44)
+
+___
+
+### is404
+
+• `Optional` **is404**: *undefined* \| *boolean*
+
+Defined in: [types.ts:50](https://github.com/wpengine/headless-framework/blob/9e3ac37/packages/headless/src/types.ts#L50)
+
+___
+
+### isArchive
+
+• `Optional` **isArchive**: *undefined* \| *boolean*
+
+Defined in: [types.ts:48](https://github.com/wpengine/headless-framework/blob/9e3ac37/packages/headless/src/types.ts#L48)
+
+___
+
+### isFrontPage
+
+• `Optional` **isFrontPage**: *undefined* \| *boolean*
+
+Defined in: [types.ts:46](https://github.com/wpengine/headless-framework/blob/9e3ac37/packages/headless/src/types.ts#L46)
+
+___
+
+### isPostsPage
+
+• `Optional` **isPostsPage**: *undefined* \| *boolean*
+
+Defined in: [types.ts:45](https://github.com/wpengine/headless-framework/blob/9e3ac37/packages/headless/src/types.ts#L45)
+
+___
+
+### isPreview
+
+• `Optional` **isPreview**: *undefined* \| *boolean*
+
+Defined in: [types.ts:47](https://github.com/wpengine/headless-framework/blob/9e3ac37/packages/headless/src/types.ts#L47)
+
+___
+
+### isSingular
+
+• `Optional` **isSingular**: *undefined* \| *boolean*
+
+Defined in: [types.ts:49](https://github.com/wpengine/headless-framework/blob/9e3ac37/packages/headless/src/types.ts#L49)
+
+___
+
+### templates
+
+• `Optional` **templates**: *undefined* \| *string*[]
+
+Defined in: [types.ts:52](https://github.com/wpengine/headless-framework/blob/9e3ac37/packages/headless/src/types.ts#L52)
+
+___
+
+### uriPath
+
+• **uriPath**: *string*
+
+Defined in: [types.ts:51](https://github.com/wpengine/headless-framework/blob/9e3ac37/packages/headless/src/types.ts#L51)

--- a/docs/reference/api/modules.md
+++ b/docs/reference/api/modules.md
@@ -1,0 +1,824 @@
+[@wpengine/headless](README.md) / Exports
+
+# @wpengine/headless
+
+## Table of contents
+
+### Interfaces
+
+- [CookieOptions](interfaces/cookieoptions.md)
+- [HeadlessConfig](interfaces/headlessconfig.md)
+- [MenuItem](interfaces/menuitem.md)
+- [ParsedUrlInfo](interfaces/parsedurlinfo.md)
+- [UriInfo](interfaces/uriinfo.md)
+
+### Variables
+
+- [APOLLO\_STATE\_PROP\_NAME](modules.md#apollo_state_prop_name)
+- [COOKIE\_KEY](modules.md#cookie_key)
+
+### Functions
+
+- [HeadlessProvider](modules.md#headlessprovider)
+- [Menu](modules.md#menu)
+- [NextTemplateLoader](modules.md#nexttemplateloader)
+- [TemplateLoader](modules.md#templateloader)
+- [WPHead](modules.md#wphead)
+- [addApolloState](modules.md#addapollostate)
+- [authorize](modules.md#authorize)
+- [ensureAuthorization](modules.md#ensureauthorization)
+- [getAccessToken](modules.md#getaccesstoken)
+- [getAccessTokenAsCookie](modules.md#getaccesstokenascookie)
+- [getContentNode](modules.md#getcontentnode)
+- [getGeneralSettings](modules.md#getgeneralsettings)
+- [getPosts](modules.md#getposts)
+- [getUriInfo](modules.md#geturiinfo)
+- [headlessConfig](modules.md#headlessconfig)
+- [initializeApollo](modules.md#initializeapollo)
+- [initializeCookies](modules.md#initializecookies)
+- [initializeNextServerSideProps](modules.md#initializenextserversideprops)
+- [initializeNextStaticPaths](modules.md#initializenextstaticpaths)
+- [initializeNextStaticProps](modules.md#initializenextstaticprops)
+- [nextAuthorizeHandler](modules.md#nextauthorizehandler)
+- [storeAccessToken](modules.md#storeaccesstoken)
+- [useApollo](modules.md#useapollo)
+- [useGeneralSettings](modules.md#usegeneralsettings)
+- [useNextUriInfo](modules.md#usenexturiinfo)
+- [usePost](modules.md#usepost)
+- [usePosts](modules.md#useposts)
+- [useUriInfo](modules.md#useuriinfo)
+
+## Variables
+
+### APOLLO\_STATE\_PROP\_NAME
+
+• `Const` **APOLLO\_STATE\_PROP\_NAME**: *__APOLLO_STATE__*= '\_\_APOLLO\_STATE\_\_'
+
+Defined in: [provider/apolloClient.ts:27](https://github.com/wpengine/headless-framework/blob/9e3ac37/packages/headless/src/provider/apolloClient.ts#L27)
+
+___
+
+### COOKIE\_KEY
+
+• `Const` **COOKIE\_KEY**: *string*
+
+Defined in: [auth/cookie.ts:13](https://github.com/wpengine/headless-framework/blob/9e3ac37/packages/headless/src/auth/cookie.ts#L13)
+
+## Functions
+
+### HeadlessProvider
+
+▸ **HeadlessProvider**(`__namedParameters`: *React.PropsWithChildren*<PageProps\>): JSX.Element
+
+Provider component to be used in your Next.js Custom `App` component (pages/_app.js)
+
+**`see`** https://nextjs.org/docs/advanced-features/custom-app
+
+**`example`** 
+```ts
+import {WPGraphQLProvider} from '@wpengine/headless/graphql'
+
+function MyApp({Component, pageProps}) {
+    return (
+        <WPGraphQLProvider>
+            <Component {...pageProps} />
+        </WPGraphQLProvider>
+    )
+}
+
+export default MyApp
+```
+
+#### Parameters:
+
+• **__namedParameters**: *React.PropsWithChildren*<PageProps\>
+
+**Returns:** JSX.Element
+
+Defined in: [provider/HeadlessProvider.tsx:32](https://github.com/wpengine/headless-framework/blob/9e3ac37/packages/headless/src/provider/HeadlessProvider.tsx#L32)
+
+___
+
+### Menu
+
+▸ **Menu**(`__namedParameters`: Props): JSX.Element \| *null*
+
+Menu component to display menu items.
+
+**`example`** 
+```ts
+import { Menu, MenuItem } from '@wpengine/headless/components'
+
+function MyApp() {
+    const items = [
+       { title: "Home", href: "/" },
+       {
+          title: "About",
+          href: "/about",
+          children: [{ title: "Careers", href: "/careers" }],
+       },
+    ];
+
+    // Alter link output if required. Remember to import `Link` components.
+    const nextLink = (item: MenuItem): React.ReactNode => (
+        <Link href={item.href}>
+            <a>{item.title}</a>
+        </Link>
+    );
+    const reactRouterLink = (item: MenuItem): React.ReactNode => (
+        <Link to={item.href}>{item.title}</Link>
+    );
+
+    return (
+        <>
+            <Menu items={items} />
+            <Menu items={items} className="menu" ariaLabel="main" />
+            <Menu items={items} anchor={nextLink} />
+            <Menu items={items} anchor={reactRouterLink} />
+        </>
+    );
+}
+
+export default MyApp
+```
+
+#### Parameters:
+
+• **__namedParameters**: Props
+
+**Returns:** JSX.Element \| *null*
+
+Defined in: [components/menu/Menu.tsx:54](https://github.com/wpengine/headless-framework/blob/9e3ac37/packages/headless/src/components/menu/Menu.tsx#L54)
+
+___
+
+### NextTemplateLoader
+
+▸ **NextTemplateLoader**(`__namedParameters`: { `templates`: WPTemplates  }): JSX.Element \| *null*
+
+#### Parameters:
+
+• **__namedParameters**: *object*
+
+Name | Type |
+------ | ------ |
+`templates` | WPTemplates |
+
+**Returns:** JSX.Element \| *null*
+
+Defined in: [components/NextTemplateLoader.tsx:6](https://github.com/wpengine/headless-framework/blob/9e3ac37/packages/headless/src/components/NextTemplateLoader.tsx#L6)
+
+___
+
+### TemplateLoader
+
+▸ **TemplateLoader**(`__namedParameters`: { `dynamicLoader`: (`loader`: () => *Promise*<Template\>) => React.ComponentType ; `templates`: WPTemplates ; `uriInfo`: [*UriInfo*](interfaces/uriinfo.md) \| *undefined*  }): JSX.Element \| *null*
+
+#### Parameters:
+
+• **__namedParameters**: *object*
+
+Name | Type |
+------ | ------ |
+`dynamicLoader` | (`loader`: () => *Promise*<Template\>) => React.ComponentType |
+`templates` | WPTemplates |
+`uriInfo` | [*UriInfo*](interfaces/uriinfo.md) \| *undefined* |
+
+**Returns:** JSX.Element \| *null*
+
+Defined in: [components/TemplateLoader.tsx:22](https://github.com/wpengine/headless-framework/blob/9e3ac37/packages/headless/src/components/TemplateLoader.tsx#L22)
+
+___
+
+### WPHead
+
+▸ **WPHead**(): JSX.Element
+
+**Returns:** JSX.Element
+
+Defined in: [components/WPHead.tsx:5](https://github.com/wpengine/headless-framework/blob/9e3ac37/packages/headless/src/components/WPHead.tsx#L5)
+
+___
+
+### addApolloState
+
+▸ **addApolloState**(`client`: *ApolloClient*<NormalizedCacheObject\>, `pageProps`: *GetServerSidePropsResult*<*unknown*\> \| *GetStaticPropsResult*<*unknown*\>): {} \| {} \| {} \| {} \| {} \| {}
+
+Merges the Apollo state with the page props passed through the various Next.js Data Fetching
+functions such as getStaticProps, getServerSideProps, etc.
+
+**`example`** 
+```ts
+export async function getStaticProps({preview = false}) {
+    const apolloClient = initializeApollo()
+
+    await apolloClient.query({query: YOUR_QUERY})
+
+    return addApolloState(apolloClient, {
+        props: {preview},
+        revalidate: 1
+    })
+}
+```
+
+#### Parameters:
+
+Name | Type |
+------ | ------ |
+`client` | *ApolloClient*<NormalizedCacheObject\> |
+`pageProps` | *GetServerSidePropsResult*<*unknown*\> \| *GetStaticPropsResult*<*unknown*\> |
+
+**Returns:** {} \| {} \| {} \| {} \| {} \| {}
+
+Defined in: [provider/apolloClient.ts:166](https://github.com/wpengine/headless-framework/blob/9e3ac37/packages/headless/src/provider/apolloClient.ts#L166)
+
+___
+
+### authorize
+
+▸ **authorize**(`code`: *string*): *Promise*<{ `access_token?`: *string*  }\>
+
+Exchanges an Authorization Code for an Access Token that you can use to make authenticated requests to
+the WordPress API
+
+**`async`** 
+
+**`export`** 
+
+#### Parameters:
+
+Name | Type |
+------ | ------ |
+`code` | *string* |
+
+**Returns:** *Promise*<{ `access_token?`: *string*  }\>
+
+>}
+
+Defined in: [auth/authorize.ts:35](https://github.com/wpengine/headless-framework/blob/9e3ac37/packages/headless/src/auth/authorize.ts#L35)
+
+___
+
+### ensureAuthorization
+
+▸ **ensureAuthorization**(`redirectUri`: *string*, `options?`: [*CookieOptions*](interfaces/cookieoptions.md)): *string* \| { `redirect`: *string*  } \| *undefined*
+
+Checks for an existing Access Token and returns one if it exists. Otherwise returns
+an object containing a redirect URI to send the client to for authorization.
+
+**`export`** 
+
+#### Parameters:
+
+Name | Type |
+------ | ------ |
+`redirectUri` | *string* |
+`options?` | [*CookieOptions*](interfaces/cookieoptions.md) |
+
+**Returns:** *string* \| { `redirect`: *string*  } \| *undefined*
+
+)}
+
+Defined in: [auth/authorize.ts:74](https://github.com/wpengine/headless-framework/blob/9e3ac37/packages/headless/src/auth/authorize.ts#L74)
+
+___
+
+### getAccessToken
+
+▸ **getAccessToken**(`options?`: [*CookieOptions*](interfaces/cookieoptions.md)): *string* \| *undefined*
+
+Gets an Access Token from the cookie, if it exists
+
+**`export`** 
+
+#### Parameters:
+
+Name | Type |
+------ | ------ |
+`options?` | [*CookieOptions*](interfaces/cookieoptions.md) |
+
+**Returns:** *string* \| *undefined*
+
+Defined in: [auth/cookie.ts:37](https://github.com/wpengine/headless-framework/blob/9e3ac37/packages/headless/src/auth/cookie.ts#L37)
+
+___
+
+### getAccessTokenAsCookie
+
+▸ **getAccessTokenAsCookie**(`options?`: [*CookieOptions*](interfaces/cookieoptions.md)): *string* \| *undefined*
+
+Gets an Access Token from the cookie and formats it as a cookie pair
+
+**`export`** 
+
+#### Parameters:
+
+Name | Type |
+------ | ------ |
+`options?` | [*CookieOptions*](interfaces/cookieoptions.md) |
+
+**Returns:** *string* \| *undefined*
+
+Defined in: [auth/cookie.ts:56](https://github.com/wpengine/headless-framework/blob/9e3ac37/packages/headless/src/auth/cookie.ts#L56)
+
+___
+
+### getContentNode
+
+▸ **getContentNode**(`client`: *ApolloClient*<NormalizedCacheObject\>, `id`: *string*, `idType?`: WPGraphQL.ContentNodeIdTypeEnum, `asPreview?`: *boolean*): *Promise*<WPGraphQL.GetContentNodeQuery[*contentNode*] \| WPGraphQL.GetContentNodeQuery[*contentNode*][*preview*][*node*] \| *undefined*\>
+
+Gets an individual Post or Page from WordPress
+
+**`async`** 
+
+**`export`** 
+
+#### Parameters:
+
+Name | Type | Default value | Description |
+------ | ------ | ------ | ------ |
+`client` | *ApolloClient*<NormalizedCacheObject\> | - |  |
+`id` | *string* | - | The identifier for the Post or Page   |
+`idType` | WPGraphQL.ContentNodeIdTypeEnum | 'URI' | - |
+`asPreview` | *boolean* | false | - |
+
+**Returns:** *Promise*<WPGraphQL.GetContentNodeQuery[*contentNode*] \| WPGraphQL.GetContentNodeQuery[*contentNode*][*preview*][*node*] \| *undefined*\>
+
+Defined in: [api/services.ts:42](https://github.com/wpengine/headless-framework/blob/9e3ac37/packages/headless/src/api/services.ts#L42)
+
+___
+
+### getGeneralSettings
+
+▸ **getGeneralSettings**(`client`: *ApolloClient*<NormalizedCacheObject\>): *Promise*<WPGraphQL.GeneralSettingsQuery[*generalSettings*]\>
+
+Gets the General Settings from WordPress
+
+**`async`** 
+
+**`export`** 
+
+#### Parameters:
+
+Name | Type |
+------ | ------ |
+`client` | *ApolloClient*<NormalizedCacheObject\> |
+
+**Returns:** *Promise*<WPGraphQL.GeneralSettingsQuery[*generalSettings*]\>
+
+Defined in: [api/services.ts:87](https://github.com/wpengine/headless-framework/blob/9e3ac37/packages/headless/src/api/services.ts#L87)
+
+___
+
+### getPosts
+
+▸ **getPosts**(`client`: *ApolloClient*<NormalizedCacheObject\>): *Promise*<WPGraphQL.GetPostsQuery[*posts*][*nodes*]\>
+
+Gets all posts from WordPress
+
+**`async`** 
+
+**`export`** 
+
+#### Parameters:
+
+Name | Type |
+------ | ------ |
+`client` | *ApolloClient*<NormalizedCacheObject\> |
+
+**Returns:** *Promise*<WPGraphQL.GetPostsQuery[*posts*][*nodes*]\>
+
+Defined in: [api/services.ts:21](https://github.com/wpengine/headless-framework/blob/9e3ac37/packages/headless/src/api/services.ts#L21)
+
+___
+
+### getUriInfo
+
+▸ **getUriInfo**(`client`: *ApolloClient*<NormalizedCacheObject\>, `uriPath`: *string*, `isPreview?`: *boolean*): *Promise*<[*UriInfo*](interfaces/uriinfo.md) \| *void*\>
+
+Gets information about the URI from WordPress
+
+**`async`** 
+
+**`export`** 
+
+#### Parameters:
+
+Name | Type | Description |
+------ | ------ | ------ |
+`client` | *ApolloClient*<NormalizedCacheObject\> |  |
+`uriPath` | *string* | The path for the URI (e.g. '/hello-world')   |
+`isPreview?` | *boolean* | - |
+
+**Returns:** *Promise*<[*UriInfo*](interfaces/uriinfo.md) \| *void*\>
+
+Defined in: [api/services.ts:108](https://github.com/wpengine/headless-framework/blob/9e3ac37/packages/headless/src/api/services.ts#L108)
+
+___
+
+### headlessConfig
+
+▸ **headlessConfig**(`config?`: [*HeadlessConfig*](interfaces/headlessconfig.md)): [*HeadlessConfig*](interfaces/headlessconfig.md)
+
+A setter/getter for the HeadlessConfig
+
+**`export`** 
+
+#### Parameters:
+
+Name | Type |
+------ | ------ |
+`config?` | [*HeadlessConfig*](interfaces/headlessconfig.md) |
+
+**Returns:** [*HeadlessConfig*](interfaces/headlessconfig.md)
+
+Defined in: [config/config.ts:13](https://github.com/wpengine/headless-framework/blob/9e3ac37/packages/headless/src/config/config.ts#L13)
+
+___
+
+### initializeApollo
+
+▸ **initializeApollo**(`context?`: NextPageContext \| GetStaticPropsContext \| GetServerSidePropsContext, `initialState?`: *null*): *ApolloClient*<NormalizedCacheObject\>
+
+Creates the Apollo Client instance if it doesn't already exist. This works on both the client side and server side.
+
+If client side, it will hydrate the cache using initial state passed through Next.js' Data Fetching functions.
+
+**`example`** 
+```ts
+// Client-side
+// For client-side, it's recommended that you use useApollo() instead initializeApollo() directly.
+```
+
+**`example`** 
+```ts
+// Server-side
+export async function getStaticProps() {
+    const apolloClient = initializeApollo()
+
+    await apolloClient.query({
+        query: ALL_POSTS_QUERY,
+        variables: allPostsQueryVars,
+    })
+
+    return addApolloState(apolloClient, {
+        props: {},
+      revalidate: 1,
+    })
+}
+```
+
+#### Parameters:
+
+Name | Type | Default value |
+------ | ------ | ------ |
+`context?` | NextPageContext \| GetStaticPropsContext \| GetServerSidePropsContext | - |
+`initialState` | *null* | null |
+
+**Returns:** *ApolloClient*<NormalizedCacheObject\>
+
+Defined in: [provider/apolloClient.ts:105](https://github.com/wpengine/headless-framework/blob/9e3ac37/packages/headless/src/provider/apolloClient.ts#L105)
+
+___
+
+### initializeCookies
+
+▸ **initializeCookies**(`__namedParameters?`: [*CookieOptions*](interfaces/cookieoptions.md)): Cookies
+
+#### Parameters:
+
+• **__namedParameters**: [*CookieOptions*](interfaces/cookieoptions.md)
+
+**Returns:** Cookies
+
+Defined in: [auth/cookie.ts:15](https://github.com/wpengine/headless-framework/blob/9e3ac37/packages/headless/src/auth/cookie.ts#L15)
+
+___
+
+### initializeNextServerSideProps
+
+▸ **initializeNextServerSideProps**(`context`: GetServerSidePropsContext, `templates?`: WPTemplates): *Promise*<*GetServerSidePropsResult*<*unknown*\>\>
+
+Must be called from getServerSideProps within a Next app in order to support SSR. It will
+initialized cookies and prefetch/cache the page content and bundle it with the page for
+rehydration on the frontend.
+
+#### Parameters:
+
+Name | Type | Description |
+------ | ------ | ------ |
+`context` | GetServerSidePropsContext | The Next SSR context   |
+`templates?` | WPTemplates | to be made available to the template loader    |
+
+**Returns:** *Promise*<*GetServerSidePropsResult*<*unknown*\>\>
+
+Defined in: [api/initializeNextServerSideProps.ts:19](https://github.com/wpengine/headless-framework/blob/9e3ac37/packages/headless/src/api/initializeNextServerSideProps.ts#L19)
+
+___
+
+### initializeNextStaticPaths
+
+▸ **initializeNextStaticPaths**(`override?`: GetStaticPathsResult): GetStaticPathsResult
+
+#### Parameters:
+
+Name | Type |
+------ | ------ |
+`override?` | GetStaticPathsResult |
+
+**Returns:** GetStaticPathsResult
+
+Defined in: [api/initializeNextStaticPaths.ts:9](https://github.com/wpengine/headless-framework/blob/9e3ac37/packages/headless/src/api/initializeNextStaticPaths.ts#L9)
+
+___
+
+### initializeNextStaticProps
+
+▸ **initializeNextStaticProps**(`context`: GetStaticPropsContext, `templates?`: WPTemplates): *Promise*<*GetServerSidePropsResult*<*unknown*\>\>
+
+Must be called from getServerSideProps within a Next app in order to support SSR. It will
+initialized cookies and prefetch/cache the page content and bundle it with the page for
+rehydration on the frontend.
+
+#### Parameters:
+
+Name | Type | Description |
+------ | ------ | ------ |
+`context` | GetStaticPropsContext | The Next SSR context   |
+`templates?` | WPTemplates | to be made available to the template loader    |
+
+**Returns:** *Promise*<*GetServerSidePropsResult*<*unknown*\>\>
+
+Defined in: [api/initializeNextStaticProps.ts:19](https://github.com/wpengine/headless-framework/blob/9e3ac37/packages/headless/src/api/initializeNextStaticProps.ts#L19)
+
+___
+
+### nextAuthorizeHandler
+
+▸ **nextAuthorizeHandler**(`req`: NextApiRequest, `res`: NextApiResponse): *Promise*<*void*\>
+
+A Node handler for processing incomming requests to exchange an Authorization Code
+for an Access Token using the WordPress API. Once the code is exchanged, this
+handler stores the Access Token on the cookie and redirects to the frontend.
+
+#### Parameters:
+
+Name | Type |
+------ | ------ |
+`req` | NextApiRequest |
+`res` | NextApiResponse |
+
+**Returns:** *Promise*<*void*\>
+
+Defined in: [auth/middleware.ts:10](https://github.com/wpengine/headless-framework/blob/9e3ac37/packages/headless/src/auth/middleware.ts#L10)
+
+___
+
+### storeAccessToken
+
+▸ **storeAccessToken**(`token`: *string* \| *undefined*, `res`: ServerResponse, `options`: [*CookieOptions*](interfaces/cookieoptions.md)): *void*
+
+Stores an Access Token on the cookie
+
+**`export`** 
+
+#### Parameters:
+
+Name | Type | Description |
+------ | ------ | ------ |
+`token` | *string* \| *undefined* |  |
+`res` | ServerResponse |     |
+`options` | [*CookieOptions*](interfaces/cookieoptions.md) | - |
+
+**Returns:** *void*
+
+Defined in: [auth/cookie.ts:77](https://github.com/wpengine/headless-framework/blob/9e3ac37/packages/headless/src/auth/cookie.ts#L77)
+
+___
+
+### useApollo
+
+▸ **useApollo**(`ctx`: NextPageContext, `pageProps`: *Record*<*string*, *any*\>): *ApolloClient*<NormalizedCacheObject\>
+
+React Hook to use the Apollo client. This is used by <WPGraphQLProvider>
+
+**`see`** WPGraphQLProvider
+
+#### Parameters:
+
+Name | Type |
+------ | ------ |
+`ctx` | NextPageContext |
+`pageProps` | *Record*<*string*, *any*\> |
+
+**Returns:** *ApolloClient*<NormalizedCacheObject\>
+
+Defined in: [provider/apolloClient.ts:185](https://github.com/wpengine/headless-framework/blob/9e3ac37/packages/headless/src/provider/apolloClient.ts#L185)
+
+___
+
+### useGeneralSettings
+
+▸ **useGeneralSettings**(): WPGraphQL.GeneralSettings \| *undefined*
+
+React Hook for retrieving the general settings (title, description) from your WordPress site
+
+**`example`** 
+```tsx
+import { useGeneralSettings } from '@wpengine/headless';
+
+export function Header() {
+  const settings = useGeneralSettings();
+
+  if (!settings) {
+    return <></>;
+  }
+
+  return (
+    <header>
+      <h1>{settings.title}</h1>
+      <h2>{settings.description}</h2>
+    </header>
+  );
+}
+```
+
+**`export`** 
+
+**Returns:** WPGraphQL.GeneralSettings \| *undefined*
+
+Defined in: [api/hooks.ts:82](https://github.com/wpengine/headless-framework/blob/9e3ac37/packages/headless/src/api/hooks.ts#L82)
+
+___
+
+### useNextUriInfo
+
+▸ **useNextUriInfo**(): [*UriInfo*](interfaces/uriinfo.md) \| *undefined*
+
+React Hook for retrieving information about the current URI within a Next app.
+
+**`see`** useUriInfo For similar functionality outside of Next apps.
+
+**`example`** 
+```tsx
+import { useNextUriInfo } from '@wpengine/headless';
+
+export function Screen() {
+  const uriInfo = useNextUriInfo();
+
+  console.log(uriInfo);
+}
+```
+
+**`export`** 
+
+**Returns:** [*UriInfo*](interfaces/uriinfo.md) \| *undefined*
+
+Defined in: [api/hooks.ts:228](https://github.com/wpengine/headless-framework/blob/9e3ac37/packages/headless/src/api/hooks.ts#L228)
+
+___
+
+### usePost
+
+▸ **usePost**(): WPGraphQL.GetContentNodeQuery[*contentNode*] \| *undefined*
+
+React Hook for retrieving the post based on the current URI. Uses window.location if necessary
+
+**`example`** 
+```tsx
+import { usePost } from '@wpengine/headless';
+
+export default function Post() {
+  const post = usePost();
+
+  return (
+    <div>
+      {post && (
+        <div>
+          <div>
+            <h5>{post.title}</h5>
+            <p dangerouslySetInnerHTML={{ __html: post.content ?? '' }} />
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+```
+
+**`export`** 
+
+**Returns:** WPGraphQL.GetContentNodeQuery[*contentNode*] \| *undefined*
+
+Defined in: [api/hooks.ts:267](https://github.com/wpengine/headless-framework/blob/9e3ac37/packages/headless/src/api/hooks.ts#L267)
+
+▸ **usePost**(`id`: *string*, `idType`: WPGraphQL.ContentNodeIdTypeEnum): WPGraphQL.GetContentNodeQuery[*contentNode*]
+
+React Hook for retrieving the post based on the passed-in id and idType.
+
+**`see`** ContentNodeIdType For the different types of identifiers you can pass in
+
+**`example`** 
+```tsx
+import { usePost, ContentNodeIdType } from '@wpengine/headless';
+
+export default function Post({ slug }: { slug: string; }) {
+  const post = usePost(slug, ContentNodeIdType.SLUG);
+
+  return (
+    <div>
+      {post && (
+        <div>
+          <div>
+            <h5>{post.title}</h5>
+            <p dangerouslySetInnerHTML={{ __html: post.content ?? '' }} />
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+```
+
+**`export`** 
+
+#### Parameters:
+
+Name | Type | Description |
+------ | ------ | ------ |
+`id` | *string* | The identifier for the post based on ContentNodeIdType   |
+`idType` | WPGraphQL.ContentNodeIdTypeEnum | The description of the type of id passed in   |
+
+**Returns:** WPGraphQL.GetContentNodeQuery[*contentNode*]
+
+Defined in: [api/hooks.ts:301](https://github.com/wpengine/headless-framework/blob/9e3ac37/packages/headless/src/api/hooks.ts#L301)
+
+___
+
+### usePosts
+
+▸ **usePosts**(): WPGraphQL.GetPostsQuery[*posts*][*nodes*] \| *undefined*
+
+React Hook for retrieving a list of posts from your WordPress site
+
+**`example`** 
+```tsx
+import { usePosts } from '@wpengine/headless';
+
+export function ListPosts() {
+  const posts = usePosts();
+
+  if (!posts) {
+    return <></>;
+  }
+
+  return (
+    <>
+      {posts.map((post) => (
+        <div key={post.id} dangerouslySetInnerHTML={ { __html: post.content ?? '' } } />
+      ))}
+    </>
+  );
+}
+```
+
+**`export`** 
+
+**Returns:** WPGraphQL.GetPostsQuery[*posts*][*nodes*] \| *undefined*
+
+Defined in: [api/hooks.ts:49](https://github.com/wpengine/headless-framework/blob/9e3ac37/packages/headless/src/api/hooks.ts#L49)
+
+___
+
+### useUriInfo
+
+▸ **useUriInfo**(`uri?`: *string*, `resolvedUri?`: *string*): [*UriInfo*](interfaces/uriinfo.md) \| *undefined*
+
+React Hook for retrieving information about the current URI. Expects you to
+either pass in a URI, otherwise it will use window.location
+
+**`see`** useNextUriInfo For similar functionality inside Next apps.
+
+**`example`** 
+```tsx
+import { useUriInfo } from '@wpengine/headless';
+
+export function Screen() {
+  const uriInfo = useUriInfo();
+
+  console.log(uriInfo);
+}
+```
+
+**`export`** 
+
+#### Parameters:
+
+Name | Type |
+------ | ------ |
+`uri?` | *string* |
+`resolvedUri?` | *string* |
+
+**Returns:** [*UriInfo*](interfaces/uriinfo.md) \| *undefined*
+
+Defined in: [api/hooks.ts:107](https://github.com/wpengine/headless-framework/blob/9e3ac37/packages/headless/src/api/hooks.ts#L107)

--- a/packages/headless/README.md
+++ b/packages/headless/README.md
@@ -2,6 +2,6 @@
 
 [![Version](https://img.shields.io/npm/v/@wpengine/headless.svg)](https://npmjs.org/package/@wpengine/headless)
 
-NOTE: This project is in the early stages of development, but it does contain useful functionallity for headless WordPress sites like authentication and post previews. Be sure to install the [WordPress plugin](https://github.com/wpengine/headless-framework) that enables the functionality in this package.
+NOTE: This project is in the early stages of development, but it does contain useful functionality for headless WordPress sites like authentication and post previews. Be sure to install the [WordPress plugin](https://github.com/wpengine/headless-framework) that enables the functionality in this package.
 
 [Documentation](https://github.com/wpengine/headless-framework)

--- a/packages/headless/package-lock.json
+++ b/packages/headless/package-lock.json
@@ -4257,6 +4257,12 @@
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
       "dev": true
     },
+    "at-least-node": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
+      "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
+      "dev": true
+    },
     "atob": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
@@ -5299,6 +5305,12 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.1.tgz",
       "integrity": "sha512-puCDz0CzydiSYOrnXpz/PKd69zRrribezjtE9yd4zvytoRc8+RY/KJPvtPFKZS3E3wP6neGyMe0vOTlHO5L3Pw==",
+      "dev": true
+    },
+    "colors": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
+      "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
       "dev": true
     },
     "combined-stream": {
@@ -7951,6 +7963,18 @@
       "dev": true,
       "optional": true
     },
+    "fs-extra": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+      "dev": true,
+      "requires": {
+        "at-least-node": "^1.0.0",
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      }
+    },
     "fs-write-stream-atomic": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz",
@@ -8409,6 +8433,19 @@
       "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
       "dev": true,
       "optional": true
+    },
+    "handlebars": {
+      "version": "4.7.6",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.6.tgz",
+      "integrity": "sha512-1f2BACcBfiwAfStCKZNrUCgqNZkGsAT7UM3kkYtXuLo0KnaVfjKOyf7PRzB6++aK9STyT1Pd2ZCPe3EGOXleXA==",
+      "dev": true,
+      "requires": {
+        "minimist": "^1.2.5",
+        "neo-async": "^2.6.0",
+        "source-map": "^0.6.1",
+        "uglify-js": "^3.1.4",
+        "wordwrap": "^1.0.0"
+      }
     },
     "har-schema": {
       "version": "2.0.0",
@@ -10546,6 +10583,16 @@
         "minimist": "^1.2.0"
       }
     },
+    "jsonfile": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.6",
+        "universalify": "^2.0.0"
+      }
+    },
     "jsonify": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
@@ -11175,6 +11222,12 @@
         "yallist": "^4.0.0"
       }
     },
+    "lunr": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
+      "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
+      "dev": true
+    },
     "lz-string": {
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.4.4.tgz",
@@ -11237,6 +11290,12 @@
       "requires": {
         "object-visit": "^1.0.0"
       }
+    },
+    "marked": {
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-1.2.9.tgz",
+      "integrity": "sha512-H8lIX2SvyitGX+TRdtS06m1jHMijKN/XjfH6Ooii9fvxMlh8QdqBfBDkGUpMWH2kQNrtixjzYUa3SH8ROTgRRw==",
+      "dev": true
     },
     "md5.js": {
       "version": "1.3.5",
@@ -12647,6 +12706,32 @@
       "dev": true,
       "requires": {
         "mimic-fn": "^2.1.0"
+      }
+    },
+    "onigasm": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/onigasm/-/onigasm-2.2.5.tgz",
+      "integrity": "sha512-F+th54mPc0l1lp1ZcFMyL/jTs2Tlq4SqIHKIXGZOR/VkHkF9A7Fr5rRr5+ZG/lWeRsyrClLYRq7s/yFQ/XhWCA==",
+      "dev": true,
+      "requires": {
+        "lru-cache": "^5.1.1"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+          "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+          "dev": true,
+          "requires": {
+            "yallist": "^3.0.2"
+          }
+        },
+        "yallist": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+          "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+          "dev": true
+        }
       }
     },
     "optimism": {
@@ -14791,12 +14876,50 @@
       "integrity": "sha512-mRz/m/JVscCrkMyPqHc/bczi3OQHkLTqXHEFu0zDhK/qfv3UcOA4SVmRCLmos4bhjr9ekVQubj/R7waKapmiQg==",
       "dev": true
     },
+    "shelljs": {
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.4.tgz",
+      "integrity": "sha512-7gk3UZ9kOfPLIAbslLzyWeGiEqx9e3rxwZM0KE6EL8GlGwjym9Mrlx5/p33bWTu9YG6vcS4MBxYZDHYr5lr8BQ==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.0.0",
+        "interpret": "^1.0.0",
+        "rechoir": "^0.6.2"
+      },
+      "dependencies": {
+        "interpret": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
+          "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
+          "dev": true
+        },
+        "rechoir": {
+          "version": "0.6.2",
+          "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+          "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+          "dev": true,
+          "requires": {
+            "resolve": "^1.1.6"
+          }
+        }
+      }
+    },
     "shellwords": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
       "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
       "dev": true,
       "optional": true
+    },
+    "shiki": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.9.2.tgz",
+      "integrity": "sha512-BjUCxVbxMnvjs8jC4b+BQ808vwjJ9Q8NtLqPwXShZ307HdXiDFYP968ORSVfaTNNSWYDBYdMnVKJ0fYNsoZUBA==",
+      "dev": true,
+      "requires": {
+        "onigasm": "^2.2.5",
+        "vscode-textmate": "^5.2.0"
+      }
     },
     "side-channel": {
       "version": "1.0.3",
@@ -16184,6 +16307,40 @@
         "is-typedarray": "^1.0.0"
       }
     },
+    "typedoc": {
+      "version": "0.20.23",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.20.23.tgz",
+      "integrity": "sha512-RBXuM0MJ2V/7eGg4YrDEmV1bn/ypa3Wx6AO1B0mUBHEQJaOIKEEnNI0Su75J6q7dkB5ksZvGNgsGjvfWL8Myjg==",
+      "dev": true,
+      "requires": {
+        "colors": "^1.4.0",
+        "fs-extra": "^9.1.0",
+        "handlebars": "^4.7.6",
+        "lodash": "^4.17.20",
+        "lunr": "^2.3.9",
+        "marked": "^1.2.9",
+        "minimatch": "^3.0.0",
+        "progress": "^2.0.3",
+        "shelljs": "^0.8.4",
+        "shiki": "^0.9.2",
+        "typedoc-default-themes": "^0.12.7"
+      }
+    },
+    "typedoc-default-themes": {
+      "version": "0.12.7",
+      "resolved": "https://registry.npmjs.org/typedoc-default-themes/-/typedoc-default-themes-0.12.7.tgz",
+      "integrity": "sha512-0XAuGEqID+gon1+fhi4LycOEFM+5Mvm2PjwaiVZNAzU7pn3G2DEpsoXnFOPlLDnHY6ZW0BY0nO7ur9fHOFkBLQ==",
+      "dev": true
+    },
+    "typedoc-plugin-markdown": {
+      "version": "3.4.5",
+      "resolved": "https://registry.npmjs.org/typedoc-plugin-markdown/-/typedoc-plugin-markdown-3.4.5.tgz",
+      "integrity": "sha512-m24mSCGcEk6tQDCHIG4TM3AS2a7e9NtC/YdO0mefyF+z1/bKYnZ/oQswLZmm2zBngiLIoKX6eNdufdBpQNPtrA==",
+      "dev": true,
+      "requires": {
+        "handlebars": "^4.7.6"
+      }
+    },
     "typescript": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.2.tgz",
@@ -16201,6 +16358,13 @@
       "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.23.tgz",
       "integrity": "sha512-m4hvMLxgGHXG3O3fQVAyyAQpZzDOvwnhOTjYz5Xmr7r/+LpkNy3vJXdVRWgd1TkAb7NGROZuSy96CrlNVjA7KA==",
       "dev": true
+    },
+    "uglify-js": {
+      "version": "3.12.7",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.12.7.tgz",
+      "integrity": "sha512-SIZhkoh+U/wjW+BHGhVwE9nt8tWJspncloBcFapkpGRwNPqcH8pzX36BXe3TPBjzHWPMUZotpCigak/udWNr1Q==",
+      "dev": true,
+      "optional": true
     },
     "unc-path-regex": {
       "version": "0.1.2",
@@ -16252,6 +16416,12 @@
         "@types/cookie": "^0.3.3",
         "cookie": "^0.4.0"
       }
+    },
+    "universalify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+      "dev": true
     },
     "unixify": {
       "version": "1.0.0",
@@ -16501,6 +16671,12 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.2.tgz",
       "integrity": "sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==",
+      "dev": true
+    },
+    "vscode-textmate": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-5.2.0.tgz",
+      "integrity": "sha512-Uw5ooOQxRASHgu6C7GVvUxisKXfSgW4oFlO+aa+PAkgmH89O3CXxEEzNRNtHSqtXFTl0nAC1uYj0GMSH27uwtQ==",
       "dev": true
     },
     "w3c-hr-time": {
@@ -17000,6 +17176,12 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
       "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "dev": true
+    },
+    "wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
       "dev": true
     },
     "wordwrapjs": {

--- a/packages/headless/package.json
+++ b/packages/headless/package.json
@@ -12,6 +12,7 @@
     "lint:fix": "run-s clean && tsc --noEmit -p . && eslint **/*.{ts,tsx} --parser-options=project:tsconfig.json --quiet --fix",
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx",
     "prepublish": "run-s build",
+    "generate-docs": "typedoc",
     "generate-graphql": "graphql-codegen",
     "test": "jest --passWithNoTests",
     "test:watch": "jest --watch",
@@ -81,6 +82,8 @@
     "rimraf": "^3.0.2",
     "ts-jest": "^26.4.4",
     "ts-loader": "^8.0.11",
+    "typedoc": "^0.20.23",
+    "typedoc-plugin-markdown": "^3.4.5",
     "typescript": "^4.1.2",
     "webpack": "^5.10.0",
     "webpack-cli": "^4.2.0"

--- a/packages/headless/tsconfig.json
+++ b/packages/headless/tsconfig.json
@@ -23,6 +23,11 @@
 		],
 		"jsx": "react"
 	},
+	"typedocOptions": {
+		"entryPoints": ["src/index.ts"],
+		"out": "../../docs/reference/api/",
+		"excludeExternals": true
+	},
 	"include": [
 		"src",
 		"src/types/wpgraphql.d.ts"


### PR DESCRIPTION
Generates docs in markdown format using [typedoc](https://typedoc.org/) and the [typedoc markdown plugin](https://github.com/tgreyuk/typedoc-plugin-markdown).

Running `npm generate-docs` from the `packages/headless` directory will now generate docs from jsdoc blocks and output markdown files at `docs/reference/api`.

Preview the generated docs root here: https://github.com/wpengine/headless-framework/tree/typedoc/docs/reference/api

Example of the generated HeadlessProvider docs: https://github.com/wpengine/headless-framework/blob/typedoc/docs/reference/api/modules.md#headlessprovider 

For [BH-829](https://wpengine.atlassian.net/browse/BH-829).