### PR TITLE
refactor (BH-894): WPE_HEADLESS_SECRET to WP_HEADLESS_SECRET

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Eager to try out the Headless Framework? Here's how you can get started:
 4. Create a new Next.js app from our [getting-started project](https://github.com/wpengine/headless-framework/tree/canary/examples/getting-started): `npx create-next-app -e https://github.com/wpengine/headless-framework/tree/canary --example-path examples/getting-started --use-npm`
 6. `cp .env.local.sample .env.local`
 7. Populate `WORDPRESS_URL` in `.env.local` with the full URL to your WordPress site, including the `http://` or `https://` prefix.
-8. Populate `WPE_HEADLESS_SECRET` in `.env.local` with the secret key found at Settings → Headless in your WordPress admin area.
+8. Populate `WP_HEADLESS_SECRET` in `.env.local` with the secret key found at Settings → Headless in your WordPress admin area.
 9. `cd my-app && npm run dev`
 
 ➡️ [Learn more about getting started](/docs/getting-started/)

--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -33,7 +33,7 @@ This config file is where you’ll set the WordPress URL and secret key that tie
 WORDPRESS_URL=http://yourwpsite.com
 
 # Plugin secret found in WordPress Settings->Headless
-WPE_HEADLESS_SECRET=YOUR_PLUGIN_SECRET
+WP_HEADLESS_SECRET=YOUR_PLUGIN_SECRET
 ```
 
 Now you’re ready to run the app!

--- a/docs/previews/README.md
+++ b/docs/previews/README.md
@@ -217,7 +217,7 @@ We need to let the frontend know about our WordPress instance. The framework exp
 NEXT_PUBLIC_WORDPRESS_URL=http://yourwpsite.com
 
 # Plugin secret found in WordPress Settings->Headless
-WPE_HEADLESS_SECRET=YOUR_PLUGIN_SECRET
+WP_HEADLESS_SECRET=YOUR_PLUGIN_SECRET
 
 # Location of the auth handler endpoint
 NEXT_PUBLIC_AUTHORIZATION_URL=/api/authorize

--- a/examples/getting-started/.env.local.sample
+++ b/examples/getting-started/.env.local.sample
@@ -10,4 +10,4 @@ WORDPRESS_URL=http://yourwpsite.com
 # NEXT_PUBLIC_WORDPRESS_URL=http://yourwpsite.com
 
 # Plugin secret found in WordPress Settings->Headless
-WPE_HEADLESS_SECRET=YOUR_PLUGIN_SECRET
+WP_HEADLESS_SECRET=YOUR_PLUGIN_SECRET

--- a/examples/preview/.env.local.sample
+++ b/examples/preview/.env.local.sample
@@ -10,4 +10,4 @@ WORDPRESS_URL=http://yourwpsite.com
 # NEXT_PUBLIC_WORDPRESS_URL=http://yourwpsite.com
 
 # Plugin secret found in WordPress Settings->Headless
-WPE_HEADLESS_SECRET=YOUR_PLUGIN_SECRET
+WP_HEADLESS_SECRET=YOUR_PLUGIN_SECRET

--- a/packages/headless/src/auth/authorize.ts
+++ b/packages/headless/src/auth/authorize.ts
@@ -15,11 +15,11 @@ const AUTH_URL = trimTrailingSlash(
     '/api/auth/wpe-headless',
 );
 
-const API_CLIENT_SECRET = process.env.WPE_HEADLESS_SECRET;
+const API_CLIENT_SECRET = process.env.WP_HEADLESS_SECRET;
 
 if (!API_CLIENT_SECRET && isServerSide()) {
   throw new Error(
-    'WPE_HEADLESS_SECRET environment variable is not set. Please set it to your WPGraphQL endpoint if you wish to use authenticated API calls.',
+    'WP_HEADLESS_SECRET environment variable is not set. Please set it to your WPGraphQL endpoint if you wish to use authenticated API calls.',
   );
 }
 

--- a/plugins/wpe-headless/includes/auth/functions.php
+++ b/plugins/wpe-headless/includes/auth/functions.php
@@ -181,8 +181,8 @@ function wpe_headless_decrypt( $value ) {
  * @return string The default key.
  */
 function wpe_headless_get_default_key() {
-	if ( defined( 'WPE_HEADLESS_SECRET_KEY' ) && WPE_HEADLESS_SECRET_KEY ) {
-		return WPE_HEADLESS_SECRET_KEY;
+	if ( defined( 'WP_HEADLESS_SECRET_KEY' ) && WP_HEADLESS_SECRET_KEY ) {
+		return WP_HEADLESS_SECRET_KEY;
 	}
 
 	if ( defined( 'AUTH_KEY' ) && AUTH_KEY ) {


### PR DESCRIPTION
The `WPE_` prefix is reserved for env vars on the WP Engine hosting platform, so users can't create vars with this name.

cc @matt-landers due to potential impact on new docs.