### PR TITLE
chore: bump headless package to 0.6.0 in examples

### DIFF
--- a/examples/getting-started/package-lock.json
+++ b/examples/getting-started/package-lock.json
@@ -2277,11 +2277,12 @@
       }
     },
     "@wpengine/headless": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@wpengine/headless/-/headless-0.5.0.tgz",
-      "integrity": "sha512-AzNLWjFeApXLMCW9qzAHSXl1S6N7GMYh1geI43aphJg4wfPTu/K2XnMpfHHlQPCVTEydBatM41v7E5tdWRD34g==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@wpengine/headless/-/headless-0.6.0.tgz",
+      "integrity": "sha512-t21EVLtizT6aetqsPQUzVNr4w2KvLHiX+aHXdm7yHAzCgYefed/a+7ZHHA76eFQZ8Htpa4LT/kv8B+UVOthfpA==",
       "requires": {
         "deepmerge": "^4.2.2",
+        "is-number": "^7.0.0",
         "isomorphic-fetch": "^3.0.0",
         "next-transpile-modules": "^6.0.0",
         "universal-cookie": "^4.0.4"

--- a/examples/getting-started/package.json
+++ b/examples/getting-started/package.json
@@ -29,7 +29,7 @@
   "homepage": "https://github.com/wpengine/headless-framework/tree/main/examples/getting-started#readme",
   "dependencies": {
     "@apollo/client": "^3.3.4",
-    "@wpengine/headless": "^0.5.0",
+    "@wpengine/headless": "^0.6.0",
     "graphql": "^15.4.0",
     "next": "^10.0.5",
     "normalize.css": "^8.0.1",

--- a/examples/preview/package-lock.json
+++ b/examples/preview/package-lock.json
@@ -2277,11 +2277,12 @@
       }
     },
     "@wpengine/headless": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@wpengine/headless/-/headless-0.5.0.tgz",
-      "integrity": "sha512-AzNLWjFeApXLMCW9qzAHSXl1S6N7GMYh1geI43aphJg4wfPTu/K2XnMpfHHlQPCVTEydBatM41v7E5tdWRD34g==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@wpengine/headless/-/headless-0.6.0.tgz",
+      "integrity": "sha512-t21EVLtizT6aetqsPQUzVNr4w2KvLHiX+aHXdm7yHAzCgYefed/a+7ZHHA76eFQZ8Htpa4LT/kv8B+UVOthfpA==",
       "requires": {
         "deepmerge": "^4.2.2",
+        "is-number": "^7.0.0",
         "isomorphic-fetch": "^3.0.0",
         "next-transpile-modules": "^6.0.0",
         "universal-cookie": "^4.0.4"

--- a/examples/preview/package.json
+++ b/examples/preview/package.json
@@ -28,7 +28,7 @@
   "homepage": "https://github.com/wpengine/headless-framework/tree/main/examples/preview#readme",
   "dependencies": {
     "@apollo/client": "^3.3.4",
-    "@wpengine/headless": "^0.5.0",
+    "@wpengine/headless": "^0.6.0",
     "graphql": "^15.4.0",
     "next": "^10.0.5",
     "normalize.css": "^8.0.1",


### PR DESCRIPTION
`@wpengine/headless` is now at 0.6.0. https://www.npmjs.com/package/@wpengine/headless 

This PR updates examples to use that version.