### PR TITLE
ci: BH-763 npm publish job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -208,6 +208,26 @@ jobs:
           command: |
             npm run test
 
+  package-publish:
+    executor:
+      name: node/default
+      tag: lts
+    working_directory: ~/project/packages/headless
+    parameters:
+      args:
+        type: string
+        default: --dry-run
+    steps:
+      - attach_workspace:
+          at: ~/project
+      - run:
+          name: Authenticate with registry
+          command: echo "//registry.npmjs.org/:_authToken=$NPM_API_KEY" > ~/project/packages/headless/.npmrc
+      - run:
+          name: NPM package publish
+          command: |
+            npm publish <<parameters.args>>
+
   test-e2e:
     machine:
       image: ubuntu-2004:202010-01
@@ -414,6 +434,30 @@ workflows:
           filters:
             tags:
               only: /.*/
+      - package-publish:
+          name: "NPM Publish (Dry Run)"
+          requires:
+            - package-test
+          filters:
+            branches:
+              only:
+                - main
+                - canary
+            tags:
+              only: /.*/
+          context: wpe-npm-creds
+      - package-publish:
+          name: "NPM Publish"
+          requires:
+            - "NPM Publish (Dry Run)"
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              # tag ex. package/headless/1.0.0
+              only: /^package\/headless\/\S+/
+          context: wpe-npm-creds
+          args: ""
 
   test-end-2-end:
     jobs:


### PR DESCRIPTION
Add npm package publish for headless.
Add a '--dry-run' step which runs when merged to main or canary branches.
Real publish is triggered on tag in the format 'package/headless/1.0.0'.