### PR TITLE
fix (BH-897): Fetch six posts for the front page template

### DIFF
--- a/examples/getting-started/wp-templates/front-page.tsx
+++ b/examples/getting-started/wp-templates/front-page.tsx
@@ -12,7 +12,7 @@ import styles from '../scss/wp-templates/front-page.module.scss';
 const firstSixInCategory = {
   variables: {
     first: 6,
-    where: { categoryName: 'uncategorized' },
+    where: { categoryName: 'uncategorized' }, // Omit this to get posts from all categories.
   },
 };
 

--- a/examples/getting-started/wp-templates/front-page.tsx
+++ b/examples/getting-started/wp-templates/front-page.tsx
@@ -1,10 +1,23 @@
 import React from 'react';
 import { usePosts, useGeneralSettings } from '@wpengine/headless/react';
+import { GetStaticPropsContext } from 'next';
+import { getApolloClient, getPosts } from '@wpengine/headless';
 import { CTA, Header, Footer, Hero, Posts } from '../components';
 import styles from '../scss/wp-templates/front-page.module.scss';
 
+/**
+ * Example of post variables to query the first six posts in a named category.
+ * @see https://github.com/wpengine/headless-framework/tree/canary/docs/queries
+ */
+const firstSixInCategory = {
+  variables: {
+    first: 6,
+    where: { categoryName: 'uncategorized' },
+  },
+};
+
 export default function FrontPage(props: any): JSX.Element {
-  const posts = usePosts();
+  const posts = usePosts(firstSixInCategory);
   const settings = useGeneralSettings();
 
   return (
@@ -131,4 +144,17 @@ export default function FrontPage(props: any): JSX.Element {
       <Footer copyrightHolder={settings?.title} />
     </>
   );
+}
+
+/**
+ * Get additional data from WordPress that is specific to this template.
+ *
+ * Here we retrieve the latest six WordPress posts in a named category to
+ * display at the bottom of the front page.
+ *
+ * @see https://github.com/wpengine/headless-framework/tree/canary/docs/queries
+ */
+export async function getStaticProps(context: GetStaticPropsContext) {
+  const client = getApolloClient(context);
+  await getPosts(client, firstSixInCategory);
 }


### PR DESCRIPTION
Fixes #144 so the front page template displays posts even if Settings → Reading is using a static page instead of “latest posts”.

Also demonstrates how to use a custom query to fetch n posts from a named category, which is a fairly common pattern for a front page (cc @trevanhetzel — this is what you were looking to achieve with the racing site you started building). I chose 'uncategorized' because posts live there by default, but it would be easy to adapt for other categories now.

With thanks to @wjohnsto for the help and suggested fix.

## To test
1. `npm run bootstrap && npm run dev` from the repo root.
2. Visit http://localhost:3000

You should see posts under “latest posts” when Settings → Reading in WP is set to a named static page or to “latest posts”.