### PR TITLE
fix: #152, exporting types from non-core modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ cypress/fixtures/*
 cypress/screenshots/*
 cypress/videos/*
 !cypress/fixtures/.gitkeep
+.vscode

--- a/packages/headless/api.d.ts
+++ b/packages/headless/api.d.ts
@@ -1,1 +1,0 @@
-export * from './dist/api';

--- a/packages/headless/api.js
+++ b/packages/headless/api.js
@@ -1,1 +1,0 @@
-module.exports = require('./dist/api');

--- a/packages/headless/auth.d.ts
+++ b/packages/headless/auth.d.ts
@@ -1,1 +1,0 @@
-export * from './dist/auth';

--- a/packages/headless/auth.js
+++ b/packages/headless/auth.js
@@ -1,1 +1,0 @@
-module.exports = require('./dist/auth');

--- a/packages/headless/components.d.ts
+++ b/packages/headless/components.d.ts
@@ -1,1 +1,0 @@
-export * from './dist/components';

--- a/packages/headless/components.js
+++ b/packages/headless/components.js
@@ -1,1 +1,0 @@
-module.exports = require('./dist/components');

--- a/packages/headless/config.d.ts
+++ b/packages/headless/config.d.ts
@@ -1,1 +1,0 @@
-export * from './dist/config';

--- a/packages/headless/config.js
+++ b/packages/headless/config.js
@@ -1,1 +1,0 @@
-module.exports = require('./dist/config');

--- a/packages/headless/next.d.ts
+++ b/packages/headless/next.d.ts
@@ -1,1 +1,6 @@
+/* eslint-disable @typescript-eslint/triple-slash-reference */
+/// <reference path="./src/types/next.d.ts" />
+/// <reference path="./src/types/request.d.ts" />
+/// <reference path="./src/types/wpgraphql.d.ts" />
+
 export * from './dist/next';

--- a/packages/headless/provider.d.ts
+++ b/packages/headless/provider.d.ts
@@ -1,1 +1,0 @@
-export * from './dist/provider';

--- a/packages/headless/provider.js
+++ b/packages/headless/provider.js
@@ -1,1 +1,0 @@
-module.exports = require('./dist/provider');

--- a/packages/headless/react.d.ts
+++ b/packages/headless/react.d.ts
@@ -1,1 +1,5 @@
+/* eslint-disable @typescript-eslint/triple-slash-reference */
+/// <reference path="./src/types/request.d.ts" />
+/// <reference path="./src/types/wpgraphql.d.ts" />
+
 export * from './dist/react';

--- a/packages/headless/src/index.ts
+++ b/packages/headless/src/index.ts
@@ -1,4 +1,6 @@
-// eslint-disable-next-line @typescript-eslint/triple-slash-reference
+/* eslint-disable @typescript-eslint/triple-slash-reference */
+/// <reference path="./types/next.d.ts" />
+/// <reference path="./types/request.d.ts" />
 /// <reference path="./types/wpgraphql.d.ts" />
 
 export * from './api';


### PR DESCRIPTION
This will properly export types from the non-core (i.e. `next` and `react`) modules of the framework. See #152 for details.