### PR TITLE
fix: Do not replace URLs in generalSettings query

### DIFF
--- a/plugins/wpe-headless/includes/replacement/graphql-callbacks.php
+++ b/plugins/wpe-headless/includes/replacement/graphql-callbacks.php
@@ -28,7 +28,8 @@ function wpe_headless_url_replacement( $response ) {
 		is_object( $response ) &&
 		property_exists( $response, 'data' ) &&
 		is_array( $response->data ) &&
-		wpe_headless_domain_replacement_enabled()
+		wpe_headless_domain_replacement_enabled() &&
+		! array_key_exists( 'generalSettings', $response->data )
 	) {
 		array_walk_recursive(
 			$response->data,


### PR DESCRIPTION
So that a query like this:

```
query GeneralSettings {
  generalSettings {
    title
    description
    url
  }
}
```

Will give the expected WP url instead of the frontend site url if “Enable Post and Category URL rewrites” is enabled at Settings → Headless.

## To test
1. Fill in a frontend site URL at Settings → Headless.
2. Tick `Enable Post and Category URL rewrites`.
3. Use the above query in GraphiQL.

You should see your WP URL in the response instead of the frontend app URL.

This fixes an issue where frontend stylesheets enqueued by WPHead were incorrectly using the frontend app domain instead of the WP one.