### PR TITLE
fix: improvements to the Posts getting-started component

### DIFF
--- a/examples/getting-started/components/Posts.tsx
+++ b/examples/getting-started/components/Posts.tsx
@@ -7,7 +7,6 @@ interface Props {
   posts: WPGraphQL.Post[] | undefined;
   intro?: string;
   id?: string;
-  count?: number;
   heading?: string;
   headingLevel?: HeadingProps['level'];
   postTitleLevel?: HeadingProps['level'];
@@ -19,13 +18,10 @@ function Posts({
   intro,
   heading,
   id,
-  count = 0,
   headingLevel = 'h1',
   postTitleLevel = 'h2',
   readMoreText = 'Read more',
 }: Props): JSX.Element {
-  // TODO: deprecate `count` and limit posts at the query level instead.
-  const thePosts = count > 0 ? posts?.slice(0, count) : posts;
   return (
     // eslint-disable-next-line react/jsx-props-no-spreading
     <section className={styles['posts-block']} {...(id && { id })}>
@@ -37,8 +33,8 @@ function Posts({
         )}
         {intro && <p className={styles.intro}>{intro}</p>}
         <div className="posts">
-          {thePosts &&
-            thePosts.map((post) => (
+          {posts &&
+            posts.map((post) => (
               <div
                 className={styles.single}
                 key={post.id}
@@ -65,7 +61,7 @@ function Posts({
                 </div>
               </div>
             ))}
-          {thePosts && thePosts?.length < 1 && <p>No posts found.</p>}
+          {posts && posts?.length < 1 && <p>No posts found.</p>}
         </div>
       </div>
     </section>

--- a/examples/getting-started/components/Posts.tsx
+++ b/examples/getting-started/components/Posts.tsx
@@ -54,11 +54,14 @@ function Posts({
                     // eslint-disable-next-line react/no-danger
                     dangerouslySetInnerHTML={{ __html: post.excerpt ?? '' }}
                   />
-                  <a
-                    href={post.uri}
-                    aria-label={`Read more about ${post.title}`}>
-                    {readMoreText}
-                  </a>
+                  <Link href={post.uri}>
+                    <a
+                      aria-label={`Read more about ${
+                        post.title || ' the post'
+                      }`}>
+                      {readMoreText}
+                    </a>
+                  </Link>
                 </div>
               </div>
             ))}

--- a/examples/getting-started/components/Posts.tsx
+++ b/examples/getting-started/components/Posts.tsx
@@ -42,7 +42,7 @@ function Posts({
                 <div>
                   <Heading level={postTitleLevel} className={styles.title}>
                     <Link href={post.uri}>
-                      <a href={post.uri}>{post.title}</a>
+                      <a>{post.title}</a>
                     </Link>
                   </Heading>
                   <div

--- a/examples/getting-started/components/Posts.tsx
+++ b/examples/getting-started/components/Posts.tsx
@@ -53,7 +53,7 @@ function Posts({
                   <Link href={post.uri}>
                     <a
                       aria-label={`Read more about ${
-                        post.title || ' the post'
+                        post.title || 'the post'
                       }`}>
                       {readMoreText}
                     </a>

--- a/examples/getting-started/wp-templates/front-page.tsx
+++ b/examples/getting-started/wp-templates/front-page.tsx
@@ -124,7 +124,6 @@ export default function FrontPage(props: any): JSX.Element {
           intro="The Posts component in wp-templates/front-page.tsx shows the latest six posts from the connected WordPress site."
           headingLevel="h2"
           postTitleLevel="h3"
-          count={6}
           id={styles.post_list}
         />
         <CTA


### PR DESCRIPTION
- Wraps “read more” anchor in a Next.js Link (props @trevanhetzel for spotting this)
- Removes `count` prop. We don't need to artificially filter posts now that we can pass a post count in the query (example in front-page.tsx).