### PR TITLE
Prep WP Engine Headless 0.5.1 and @wpengine/headless 0.6.1 for release

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -103,7 +103,7 @@ Developers with full GitHub repository access can create public releases:
 ### Release the wpe-headless plugin
 
 1. Update the `Version` in the file header at `plugins/wpe-headless/wpe-headless.php`.
-2. Update the changelog in `plugins/wpe-headless/readme.txt`.
+2. Update the changelog and 'stable tag' in `plugins/wpe-headless/readme.txt`.
 3. Commit and push your changes for review.
 4. Tag the approved commit with `plugin/wpe-headless/[version]`, for example: `plugin/wpe-headless/0.3.5-alpha.1` and push the tag. Or use GitHub to [create a new release](https://github.com/wpengine/headless-framework/releases/new) with that tag.
 

--- a/packages/headless/CHANGELOG.md
+++ b/packages/headless/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.6.1] - 2021-02-25
 
-Requires the [WP Headless Plugin](https://wp-product-info.wpesvc.net/v1/plugins/wpe-headless?download) version 0.5.1 or higher for features such as post previews.
+Requires the [WP Engine Headless plugin](https://wp-product-info.wpesvc.net/v1/plugins/wpe-headless?download) [zip] version 0.5.1 or higher for features such as post previews.
 
 ### Added
 - Pagination component and example in https://github.com/wpengine/headless-framework/blob/canary/examples/getting-started/wp-templates/category.tsx.

--- a/packages/headless/CHANGELOG.md
+++ b/packages/headless/CHANGELOG.md
@@ -1,0 +1,23 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.6.1] - 2021-02-25
+
+Requires the [WP Headless Plugin](https://wp-product-info.wpesvc.net/v1/plugins/wpe-headless?download) version 0.5.1 or higher for features such as post previews.
+
+### Added
+- Pagination component and example in https://github.com/wpengine/headless-framework/blob/canary/examples/getting-started/wp-templates/category.tsx.
+- `WORDPRESS_URL` falls back to a live demo site at https://headlessfw.wpengine.com if unset.
+
+### Changed
+- Missing `WORDPRESS_URL` and `WP_HEADLESS_SECRET` environment variables now soft-fail with a console warning instead of throwing an exception.
+
+### Fixed
+- Types are now exported from non-core modules.
+- Prevent an issue with post previews that could result in “Additional keys were returned from `getServerSideProps`”.
+

--- a/packages/headless/package.json
+++ b/packages/headless/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpengine/headless",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "This module helps you use WordPress as a Headless CMS",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/plugins/wpe-headless/readme.txt
+++ b/plugins/wpe-headless/readme.txt
@@ -4,7 +4,7 @@ Tags:
 Requires at least: 5.3
 Tested up to: 5.5
 Requires PHP: 5.6
-Stable tag: 0.5.0
+Stable tag: 0.5.1
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 Author: WP Engine
@@ -22,6 +22,11 @@ Transform your WordPress site to a powerful Headless API.
 == Screenshots ==
 
 == Changelog ==
+
+= 0.5.1 =
+Requires the @wpengine/headless package 0.6.1+ for features such as post previews. https://www.npmjs.com/package/@wpengine/headless
+
+- The site URL is longer rewritten as the app URL in WPGraphQL responses for general settings queries.
 
 = 0.5.0 =
 - WPE_HEADLESS_SECRET_KEY has been renamed to WP_HEADLESS_SECRET_KEY.

--- a/plugins/wpe-headless/wpe-headless.php
+++ b/plugins/wpe-headless/wpe-headless.php
@@ -3,11 +3,11 @@
  * Plugin Name: WPEngine Headless
  * Plugin URI: https://wpengine.com/
  * Description: Plugin for working with headless WordPress.
- * Author: WPEngine
+ * Author: WP Engine
  * Author URI: https://wpengine.com/
  * Text Domain: wpe-headless
  * Domain Path: /languages
- * Version: 0.5.0
+ * Version: 0.5.1
  *
  * @package WPE_Headless
  */


### PR DESCRIPTION
- Preps the new plugin and package versions.
- Adds a changelog for the package.
- Adds compatibility notes to the package changelog and plugin readme (for [BH-858](https://wpengine.atlassian.net/browse/BH-858)).