### PR TITLE
Prep WP Engine Headless 0.5.2 and @wpengine/headless 0.6.2 for release

### DIFF
--- a/packages/headless/CHANGELOG.md
+++ b/packages/headless/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.2] - 2021-03-02
+
+Requires the [WP Engine Headless plugin](https://wp-product-info.wpesvc.net/v1/plugins/wpe-headless?download) [zip] version 0.5.2 or higher for features such as post previews.
+
+### Fixed
+- Fixes an issue that could cause a 404 response for post previews.
+
 ## [0.6.1] - 2021-02-25
 
 Requires the [WP Engine Headless plugin](https://wp-product-info.wpesvc.net/v1/plugins/wpe-headless?download) [zip] version 0.5.1 or higher for features such as post previews.

--- a/packages/headless/package.json
+++ b/packages/headless/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpengine/headless",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "This module helps you use WordPress as a Headless CMS",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/plugins/wpe-headless/readme.txt
+++ b/plugins/wpe-headless/readme.txt
@@ -4,7 +4,7 @@ Tags:
 Requires at least: 5.3
 Tested up to: 5.5
 Requires PHP: 5.6
-Stable tag: 0.5.1
+Stable tag: 0.5.2
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 Author: WP Engine
@@ -22,6 +22,11 @@ Transform your WordPress site to a powerful Headless API.
 == Screenshots ==
 
 == Changelog ==
+
+= 0.5.2 =
+Requires the @wpengine/headless package 0.6.2+ for features such as post previews. https://www.npmjs.com/package/@wpengine/headless
+
+- Fixes an issue that could cause a 404 response for post previews.
 
 = 0.5.1 =
 Requires the @wpengine/headless package 0.6.1+ for features such as post previews. https://www.npmjs.com/package/@wpengine/headless

--- a/plugins/wpe-headless/wpe-headless.php
+++ b/plugins/wpe-headless/wpe-headless.php
@@ -7,7 +7,7 @@
  * Author URI: https://wpengine.com/
  * Text Domain: wpe-headless
  * Domain Path: /languages
- * Version: 0.5.1
+ * Version: 0.5.2
  *
  * @package WPE_Headless
  */


### PR DESCRIPTION
⚠️⚠️⚠️ **Do not release until https://github.com/wpengine/headless-framework/pull/167 is also merged.** ⚠️⚠️⚠️