### PR TITLE
chore: use @wpengine/headless 0.6.3 in examples

### DIFF
--- a/examples/getting-started/package-lock.json
+++ b/examples/getting-started/package-lock.json
@@ -2277,9 +2277,9 @@
       }
     },
     "@wpengine/headless": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/@wpengine/headless/-/headless-0.6.2.tgz",
-      "integrity": "sha512-tdXpTFwVVXsYMLCuvKB8mH0HEDk7/LS61zNPKUoviYB8rXCNGwwEPVjpHH8OtX2JmXCwH7ARwO/CyTRv04r/bQ==",
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/@wpengine/headless/-/headless-0.6.3.tgz",
+      "integrity": "sha512-jxb6xhMvLTBxHe6PvG0Y057IzHDhPom44yWl4j65wtB3TCgKzqG2LVBPagrszYYmq0VPoqZHnGUUkC9Vd2FF3w==",
       "requires": {
         "deepmerge": "^4.2.2",
         "is-number": "^7.0.0",

--- a/examples/getting-started/package.json
+++ b/examples/getting-started/package.json
@@ -29,7 +29,7 @@
   "homepage": "https://github.com/wpengine/headless-framework/tree/main/examples/getting-started#readme",
   "dependencies": {
     "@apollo/client": "^3.3.4",
-    "@wpengine/headless": "^0.6.2",
+    "@wpengine/headless": "^0.6.3",
     "graphql": "^15.4.0",
     "next": "^10.0.5",
     "normalize.css": "^8.0.1",

--- a/examples/preview/package-lock.json
+++ b/examples/preview/package-lock.json
@@ -2277,9 +2277,9 @@
       }
     },
     "@wpengine/headless": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/@wpengine/headless/-/headless-0.6.2.tgz",
-      "integrity": "sha512-tdXpTFwVVXsYMLCuvKB8mH0HEDk7/LS61zNPKUoviYB8rXCNGwwEPVjpHH8OtX2JmXCwH7ARwO/CyTRv04r/bQ==",
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/@wpengine/headless/-/headless-0.6.3.tgz",
+      "integrity": "sha512-jxb6xhMvLTBxHe6PvG0Y057IzHDhPom44yWl4j65wtB3TCgKzqG2LVBPagrszYYmq0VPoqZHnGUUkC9Vd2FF3w==",
       "requires": {
         "deepmerge": "^4.2.2",
         "is-number": "^7.0.0",

--- a/examples/preview/package.json
+++ b/examples/preview/package.json
@@ -28,7 +28,7 @@
   "homepage": "https://github.com/wpengine/headless-framework/tree/main/examples/preview#readme",
   "dependencies": {
     "@apollo/client": "^3.3.4",
-    "@wpengine/headless": "^0.6.2",
+    "@wpengine/headless": "^0.6.3",
     "graphql": "^15.4.0",
     "next": "^10.0.5",
     "normalize.css": "^8.0.1",


### PR DESCRIPTION
0.6.3 is now live. https://www.npmjs.com/package/@wpengine/headless

This updates examples to use it.