### PR TITLE
fix: prevent errors for JWT authenticated requests

### DIFF
--- a/plugins/wpe-headless/includes/rest/callbacks.php
+++ b/plugins/wpe-headless/includes/rest/callbacks.php
@@ -9,44 +9,12 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-add_filter( 'graphql_authentication_errors', 'wpe_headless_rest_validate_access_token' );
-/**
- * Callback for WPGraphQL 'graphql_authentication_errors' filter.
- *
- * If an Authorization header exists, validate it. If it is invalid return a response error. Note
- * that we are returning a WP_Error, but currently WPGraphQL ignores this and sends its own error.
- *
- * @link https://www.wpgraphql.com/filters/graphql_authentication_errors/
- *
- * @param bool $authentication_errors Whether there are authentication errors with the request.
- *
- * @return bool True if the Authorization header exists and is invalid, false otherwise.
- */
-function wpe_headless_rest_validate_access_token( $authentication_errors ) {
-	if ( empty( $_SERVER['HTTP_AUTHORIZATION'] ) ) {
-		return $authentication_errors;
-	}
-
-	$parts = explode( ' ', trim( $_SERVER['HTTP_AUTHORIZATION'] ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput
-	if ( count( $parts ) < 2 ) {
-		return true;
-	}
-
-	$wp_user = wpe_headless_get_user_from_access_token( $parts[1], 5 * MONTH_IN_SECONDS );
-	if ( $wp_user ) {
-		return false;
-	}
-
-	return true;
-}
-
 add_filter( 'determine_current_user', 'wpe_headless_rest_determine_current_user', 20 );
 /**
  * Callback for WordPress 'determine_current_user' filter.
  *
  * Determine the current user based on authentication token from http header.
- *
- * @todo Does the request type matter? rest, graphql, etc?
+ * Runs during GraphQL, REST and plain requests.
  *
  * @link https://developer.wordpress.org/reference/hooks/determine_current_user/
  *


### PR DESCRIPTION
Removes the `graphql_authentication_errors` filter and callback, which cause an error for JWT authenticated requests.

Authentication already happens in `wpe_headless_rest_determine_current_user`, which is hooked to `determine_current_user` and runs during GraphQL, REST and regular requests.

Fixes #189.

## To test
1. Follow instructions in https://github.com/wpengine/headless-framework/issues/189 to send a JWT authenticated request. It should return data without an authentication error.
2. `wp plugin deactivate wp-graphql-jwt-authentication` (The plugin seems to cause our preview pages to display empty content, even in the canary branch. This is a separate issue to the one addressed here.)
3. Test that previewing a post still works when logged in.
4. Test that previewing a post does not work when logged out. (Follow a link such as `http://localhost:3000/preview?p=[your_post_id]&preview=true` in incognito mode.)