### PR TITLE
chore: prepare release of WPE Headless 0.5.4

### DIFF
--- a/plugins/wpe-headless/readme.txt
+++ b/plugins/wpe-headless/readme.txt
@@ -4,7 +4,7 @@ Tags:
 Requires at least: 5.3
 Tested up to: 5.5
 Requires PHP: 5.6
-Stable tag: 0.5.3
+Stable tag: 0.5.4
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 Author: WP Engine
@@ -22,6 +22,10 @@ Transform your WordPress site to a powerful Headless API.
 == Screenshots ==
 
 == Changelog ==
+
+= 0.5.4 =
+
+- Prevents authentication failures when using an authorization header to authenticate with WPGraphQL JWT Authentication or similar.
 
 = 0.5.3 =
 Requires the @wpengine/headless package 0.6.3+ for features such as post previews. https://www.npmjs.com/package/@wpengine/headless

--- a/plugins/wpe-headless/wpe-headless.php
+++ b/plugins/wpe-headless/wpe-headless.php
@@ -7,7 +7,7 @@
  * Author URI: https://wpengine.com/
  * Text Domain: wpe-headless
  * Domain Path: /languages
- * Version: 0.5.3
+ * Version: 0.5.4
  *
  * @package WPE_Headless
  */


### PR DESCRIPTION
To release the bug fix in https://github.com/wpengine/headless-framework/pull/190.

This will be a plugin release only. There have been no changes to the JS package.