### PR TITLE
docs: update changelogs for 0.6.4-0.6.5

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,2 +1,16 @@
 # Changelog
+
 All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.6.5] - 2021-05-25
+
+Version bumped to remain in lockstep with `@wpengine/headless-react` and `@wpengine/headless-next`. No changes.
+
+## [0.6.4] - 2021-05-18
+
+Initial release of `@wpengine/headless-core`

--- a/packages/next/CHANGELOG.md
+++ b/packages/next/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.6.5] - 2021-05-25
+
+### Refactor
+
+- Removed `nextConfig.js` & `next-transpile-modules` as a dependency
+- Removed unnecessary re-exports from `@wpengine/headless-core` and `@wpengine/headless-react`
+
+## [0.6.4] - 2021-05-18
+
+Initial release of `@wpengine/headless-next`

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.6.5] - 2021-05-25
+
+Version bumped to remain in lockstep with `@wpengine/headless-core` and `@wpengine/headless-next`. No changes.
+
+## [0.6.4] - 2021-05-18
+
+Initial release of `@wpengine/headless-react`


### PR DESCRIPTION
This PR resolves #244.

Updated changelogs to reflect the initial release (`0.6.4`) of the broken out packages, as well as version `0.6.5`.