### PR TITLE
fix: do not rewrite post links in the GraphQL response

### DIFF
--- a/plugins/wpe-headless/includes/replacement/callbacks.php
+++ b/plugins/wpe-headless/includes/replacement/callbacks.php
@@ -162,7 +162,10 @@ add_filter( 'post_link', 'wpe_headless_post_link', 10 );
  * @return string URL used for the post.
  */
 function wpe_headless_post_link( $link ) {
-	if ( ! wpe_headless_is_rewrites_enabled() ) {
+	if (
+		! wpe_headless_is_rewrites_enabled()
+		|| ( function_exists( 'is_graphql_request' ) && is_graphql_request() )
+	) {
 		return $link;
 	}
 


### PR DESCRIPTION
To prevent an issue where post uris are returned with a localhost prefix but page uris are returned with just the path.

Both post and page uris will now be only the path. For [ORN-253](https://wpengine.atlassian.net/browse/ORN-253).

### To test
1. Fill in the Front-end site URL at Settings → Headless and tick “Enable Post and Category URL rewrites”.
1. Send this request in GraphiQL:

```
{
  posts(first: 1) {
    nodes {
      uri
    }
  }
  pages(first: 1) {
    nodes {
      uri
    }
  }
}
```

You should see only a path in the posts and pages uri (no front-end site URL):

```
{
  "data": {
    "posts": {
      "nodes": [
        {
          "uri": "/regular-post/"
        }
      ]
    },
    "pages": {
      "nodes": [
        {
          "uri": "/test-11/"
        }
      ]
    }
  },
  "extensions": {
    "debug": []
  }
}
```