### PR TITLE
fix: Use ESM syntax for Faust config

### DIFF
--- a/examples/next/getting-started/src/faust.config.js
+++ b/examples/next/getting-started/src/faust.config.js
@@ -1,4 +1,4 @@
-const { headlessConfig } = require('@faustjs/core');
+import { headlessConfig } from '@faustjs/core';
 
 if (!process.env.NEXT_PUBLIC_WORDPRESS_URL) {
   console.error(
@@ -9,7 +9,7 @@ if (!process.env.NEXT_PUBLIC_WORDPRESS_URL) {
 /**
  * @type {import("@faustjs/core").HeadlessConfig}
  */
-module.exports = headlessConfig({
+export default headlessConfig({
   wpUrl: process.env.NEXT_PUBLIC_WORDPRESS_URL,
   apiClientSecret: process.env.WP_HEADLESS_SECRET,
 });


### PR DESCRIPTION
This is a **breaking change**. We will need to notify existing users that their `faust.config.js` need to be updated to use ESM syntax opposed to CJS syntax