### PR TITLE
Fix: (#422) Use most recent post/page revision if exists

### DIFF
--- a/packages/next/src/client.ts
+++ b/packages/next/src/client.ts
@@ -314,10 +314,10 @@ export function getClient<
       ?.node as ReturnType<Schema['query']['post']> | undefined;
 
     if (hasPageId(args)) {
-      return mostRecentPageRevision || page;
+      return mostRecentPageRevision ?? page;
     }
     if (hasPostId(args)) {
-      return mostRecentPostRevision || post;
+      return mostRecentPostRevision ?? post;
     }
   }
   /* eslint-enable consistent-return */

--- a/packages/next/src/client.ts
+++ b/packages/next/src/client.ts
@@ -297,23 +297,27 @@ export function getClient<
       }
     }, [client]);
 
-    const { post, page } = client.useQuery();
-
-    const pagePreview = page({
+    const page = client.useQuery().page({
       id: (args?.pageId as string) ?? '',
       idType: PageIdType.DATABASE_ID,
     }) as ReturnType<Schema['query']['page']>;
 
-    const postPreview = post({
+    const mostRecentPageRevision = page?.revisions({ first: 1 })?.edges?.[0]
+      ?.node as ReturnType<Schema['query']['page']> | undefined;
+
+    const post = client.useQuery().post({
       id: (args?.postId as string) ?? '',
       idType: PostIdType.DATABASE_ID,
     }) as ReturnType<Schema['query']['post']>;
 
+    const mostRecentPostRevision = post?.revisions({ first: 1 })?.edges?.[0]
+      ?.node as ReturnType<Schema['query']['post']> | undefined;
+
     if (hasPageId(args)) {
-      return pagePreview;
+      return mostRecentPageRevision || page;
     }
     if (hasPostId(args)) {
-      return postPreview;
+      return mostRecentPostRevision || post;
     }
   }
   /* eslint-enable consistent-return */

--- a/packages/react/src/client.ts
+++ b/packages/react/src/client.ts
@@ -16,6 +16,9 @@ import merge from 'lodash/merge';
 
 export interface Node {
   id?: string | null;
+}
+
+export interface WithRevisions {
   revisions: (arg0: { first: number }) => {
     edges?: { node?: Node }[];
   };
@@ -28,10 +31,16 @@ export interface RequiredQuery {
       categoryName?: string;
     };
   }) => unknown;
-  post: (args: { id: string; idType?: PostIdType }) => Node | null | undefined;
+  post: (args: {
+    id: string;
+    idType?: PostIdType;
+  }) => (Node & WithRevisions) | null | undefined;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   pages: (args?: any) => unknown;
-  page: (args: { id: string; idType?: PageIdType }) => Node | null | undefined;
+  page: (args: {
+    id: string;
+    idType?: PageIdType;
+  }) => (Node & WithRevisions) | null | undefined;
   category: (args: {
     id: string;
     idType?: CategoryIdType;

--- a/packages/react/src/client.ts
+++ b/packages/react/src/client.ts
@@ -16,6 +16,9 @@ import merge from 'lodash/merge';
 
 export interface Node {
   id?: string | null;
+  revisions: (arg0: { first: number }) => {
+    edges?: { node?: Node }[];
+  };
 }
 
 export interface RequiredQuery {


### PR DESCRIPTION
This PR resolves #422.

We now check if any revisions exist for the post/page. If they do, that is the most recent preview data for an existing post/page. Otherwise, we display the data from the original post/page query (draft, or new post/page)