### PR TITLE
fix: (#354) warning on widgets.php due to previewlinks.js

### DIFF
--- a/plugins/wpe-headless/includes/replacement/callbacks.php
+++ b/plugins/wpe-headless/includes/replacement/callbacks.php
@@ -204,14 +204,13 @@ function wpe_headless_term_link( $term_link ) {
 }
 
 
+add_action( 'load-post-new.php', 'wpe_headless_enqueue_preview_scripts' );
+add_action( 'load-post.php', 'wpe_headless_enqueue_preview_scripts' );
 /**
- * Adds JavaScript file to the Gutenberg editor page that prepends /preview to the preview link
+ * Adds JavaScript file to the Gutenberg editor page that prepends /preview to the preview link.
  *
  * XXX: Please remove this once this issue is resolved: https://github.com/WordPress/gutenberg/issues/13998
  */
-add_action(
-	'enqueue_block_editor_assets',
-	function() {
-		wp_enqueue_script( 'awp-gutenberg-filters', plugins_url( '/previewlinks.js', __FILE__ ), array( 'wp-edit-post' ), '1.0.0', true );
-	}
-);
+function wpe_headless_enqueue_preview_scripts() {
+	wp_enqueue_script( 'awp-gutenberg-filters', plugins_url( '/previewlinks.js', __FILE__ ), array(), '1.0.0', true );
+}

--- a/plugins/wpe-headless/includes/replacement/previewlinks.js
+++ b/plugins/wpe-headless/includes/replacement/previewlinks.js
@@ -9,7 +9,7 @@ window.addEventListener('DOMContentLoaded', function () {
         'button[class~="block-editor-post-preview__button-toggle"]',
       );
 
-      if (!previewButton) {
+      if (!previewButton.length) {
         return;
       }
 
@@ -20,7 +20,7 @@ window.addEventListener('DOMContentLoaded', function () {
             'a[target*="wp-preview"]',
           );
 
-		  if (!links) {
+		  if (!links.length) {
 			  return;
 		  }
 

--- a/plugins/wpe-headless/tests/integration/replacement/test-replacement-callbacks.php
+++ b/plugins/wpe-headless/tests/integration/replacement/test-replacement-callbacks.php
@@ -38,6 +38,11 @@ class ReplacementCallbacksTestCases extends WP_UnitTestCase {
 		$this->assertSame( 10, has_action( 'graphql_request_results', 'wpe_headless_url_replacement' ) );
 	}
 
+	public function test_enqueue_preview_scripts_action() {
+		$this->assertSame( 10, has_action( 'load-post-new.php', 'wpe_headless_enqueue_preview_scripts' ) );
+		$this->assertSame( 10, has_action( 'load-post.php', 'wpe_headless_enqueue_preview_scripts' ) );
+	}
+
 	/**
 	 * Tests wpe_headless_content_replacement() returns original value when content replacement is not enabled.
 	 */


### PR DESCRIPTION
This PR fixes the warning found in #354 by adding the `previewlinks.js` file to `load-post-new.php` and `load-post.php` actions, instead of `enqueue_block_editor_assets`.

Something to note: Enqueueing `previewlinks.js` with `wp-edit-post` as a dependency using these new actions causes the ACM editor/fields to not be displayed properly. The following error is consoled:

```js
react-dom.min.js?ver=16.13.1:125 TypeError: Dn.oldEditor.getDefaultSettings is not a function
    at index.js?ver=0.5.0:1
    at Bh (react-dom.min.js?ver=16.13.1:126)
    at Dj (react-dom.min.js?ver=16.13.1:162)
    at unstable_runWithPriority (react.min.js?ver=16.13.1:25)
    at Da (react-dom.min.js?ver=16.13.1:60)
    at xb (react-dom.min.js?ver=16.13.1:162)
    at react-dom.min.js?ver=16.13.1:162
    at U (react.min.js?ver=16.13.1:16)
    at MessagePort.B.port1.onmessage (react.min.js?ver=16.13.1:24)
Me @ react-dom.min.js?ver=16.13.1:125
Ih.c.callback @ react-dom.min.js?ver=16.13.1:138
Wg @ react-dom.min.js?ver=16.13.1:67
oj @ react-dom.min.js?ver=16.13.1:127
Aj @ react-dom.min.js?ver=16.13.1:160
unstable_runWithPriority @ react.min.js?ver=16.13.1:25
Da @ react-dom.min.js?ver=16.13.1:60
ab @ react-dom.min.js?ver=16.13.1:154
Te @ react-dom.min.js?ver=16.13.1:146
(anonymous) @ react-dom.min.js?ver=16.13.1:61
unstable_runWithPriority @ react.min.js?ver=16.13.1:25
Da @ react-dom.min.js?ver=16.13.1:60
Pg @ react-dom.min.js?ver=16.13.1:61
ha @ react-dom.min.js?ver=16.13.1:60
Dj @ react-dom.min.js?ver=16.13.1:163
unstable_runWithPriority @ react.min.js?ver=16.13.1:25
Da @ react-dom.min.js?ver=16.13.1:60
xb @ react-dom.min.js?ver=16.13.1:162
(anonymous) @ react-dom.min.js?ver=16.13.1:162
U @ react.min.js?ver=16.13.1:16
B.port1.onmessage @ react.min.js?ver=16.13.1:24
react.min.js?ver=16.13.1:24 Uncaught TypeError: Dn.oldEditor.getDefaultSettings is not a function
    at index.js?ver=0.5.0:1
    at Bh (react-dom.min.js?ver=16.13.1:126)
    at Dj (react-dom.min.js?ver=16.13.1:162)
    at unstable_runWithPriority (react.min.js?ver=16.13.1:25)
    at Da (react-dom.min.js?ver=16.13.1:60)
    at xb (react-dom.min.js?ver=16.13.1:162)
    at react-dom.min.js?ver=16.13.1:162
    at U (react.min.js?ver=16.13.1:16)
    at MessagePort.B.port1.onmessage (react.min.js?ver=16.13.1:24)
(anonymous) @ index.js?ver=0.5.0:1
Bh @ react-dom.min.js?ver=16.13.1:126
Dj @ react-dom.min.js?ver=16.13.1:162
unstable_runWithPriority @ react.min.js?ver=16.13.1:25
Da @ react-dom.min.js?ver=16.13.1:60
xb @ react-dom.min.js?ver=16.13.1:162
(anonymous) @ react-dom.min.js?ver=16.13.1:162
U @ react.min.js?ver=16.13.1:16
B.port1.onmessage @ react.min.js?ver=16.13.1:24
```

This may be related to this code:
https://github.com/wpengine/atlas-content-modeler/blob/68dee28361343b32d9ebc5b4ab05c05601cc0787/includes/publisher/js/src/components/RichTextEditor.jsx#L23

As a result of this, I've removed the `wp-edit-post` dependency from enqueueing `previewlinks.js` and all works as expected.