### PR TITLE
Update development docs

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -15,13 +15,14 @@ There are many ways to [contribute](/CONTRIBUTING.md) to this project.
 
 ### NPM Packages
 
-When working on the npm packages in this repository, use our Lerna setup from the project root:
+NPM packages are managed from the project root using [Workspaces](https://docs.npmjs.com/cli/v7/using-npm/workspaces). To get started, run:
 
-1. Ensure that `.env.local` exists and is correctly configured in `examples/getting-started` and `examples/preview`.
-2. `npm run bootstrap`
-3. `npm run dev`
+1. `npm install`
+2. `npm run dev`
 
-When switching git branch, run `npm run clean` from the root and then re-run `npm run bootstrap`.
+The local copy of each package is automatically symlinked in `node_modules` when running `npm install` from the project root. Likewise, each package is automatically built when running `npm run dev`.
+
+When switching git branch, run `npm run clean` from the root and then re-run `npm run dev`.
 
 ### Plugins
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -2,9 +2,9 @@
 
 There are many ways to [contribute](/CONTRIBUTING.md) to this project.
 
-* [Discuss open issues](/issues) to help define the future of the project.
-* [Submit bugs](/issues) and help us verify fixes as they are checked in.
-* Review and discuss the [source code changes](pulls).
+* [Discuss open issues](https://github.com/wpengine/faustjs/issues) to help define the future of the project.
+* [Submit bugs](https://github.com/wpengine/faustjs/issues) and help us verify fixes as they are checked in.
+* Review and discuss the [source code changes](https://github.com/wpengine/faustjs/pulls).
 * [Contribute bug fixes](/CONTRIBUTING.md)
 
 ## Project Structure

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Additionally, if you have questions or ideas, please share them on [GitHub Discu
 
 There are many ways to [contribute](/CONTRIBUTING.md) to this project.
 
-- [Discuss open issues](/issues) to help define the future of the project.
-- [Submit bugs](/issues) and help us verify fixes as they are checked in.
-- Review and discuss the [source code changes](pulls).
+- [Discuss open issues](https://github.com/wpengine/faustjs/issues) to help define the future of the project.
+- [Submit bugs](https://github.com/wpengine/faustjs/issues) and help us verify fixes as they are checked in.
+- Review and discuss the [source code changes](https://github.com/wpengine/faustjs/pulls).
 - [Contribute bug fixes](/CONTRIBUTING.md)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,10 @@
 {
   "name": "root",
   "private": true,
+  "engines": {
+    "node": ">=16.0.0",
+    "npm": ">=7.0.0"
+  },
   "workspaces": {
     "packages": [
       "packages/core",


### PR DESCRIPTION
- Updates docs to reflect switch to npm workspaces in place of Learna.
- Workspaces was introduced in npm v7.0.0. I've added an `engines` property and `.npmrc` to show an error during `npm install` if you don't have the proper version. I included a node v16.0.0 requirement there as well, but I don't know how accurate that is.
- Changes some relative URLs that didn't seem to work in GitHub to absolute URLs.