### PR TITLE
fix: (#503) remove refresh token upon unsuccessful fetch of tokens

### DIFF
--- a/packages/core/src/auth/server/middleware.ts
+++ b/packages/core/src/auth/server/middleware.ts
@@ -61,6 +61,9 @@ export async function authorizeHandler(
         res.statusCode = result.response.status;
       } else {
         res.statusCode = 401;
+
+        // If the response to the token endpoint is unauthorized, remove the existing refresh token.
+        oauth.setRefreshToken(undefined);
       }
 
       res.end(JSON.stringify(result.result));


### PR DESCRIPTION
Remove the existing refresh token upon an unauthorized response from the fetch token endpoint

Resolves #503 