### PR TITLE
Use `.env.local` instead of `.env`

### DIFF
--- a/.github/workflows/e2e-next-example.yml
+++ b/.github/workflows/e2e-next-example.yml
@@ -47,7 +47,7 @@ jobs:
     - name: copy env
       working-directory: e2e-app
       run: |
-        cp .env.sample .env
+        cp .env.local.sample .env.local
     # Generate the schema to ensure no type collisions
     - name: Generate Schema
       working-directory: e2e-app

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,6 @@ process.yml
 .next
 .env
 .env.*
-!.env.sample
+!.env.local.sample
 .docusaurus
 build/

--- a/docs/next/getting-started.mdx
+++ b/docs/next/getting-started.mdx
@@ -35,7 +35,7 @@ npx create-next-app `
 Now, copy the sample environment template:
 
 ```bash
-cp .env.sample .env
+cp .env.local.sample .env.local
 ```
 
 Finally, run the dev server:
@@ -65,7 +65,7 @@ The example app above loads WordPress content from the demo site at [https://hea
 
 To point it to a different WordPress site, first, [make sure you have setup the necessary WordPress plugins.](../tutorial/setup-faustjs#installing-plugins-on-wordpress)
 
-Once the necessary plugins have been installed, open the `.env` file you created earlier, it should look something like this:
+Once the necessary plugins have been installed, open the `.env.local` file you created earlier, it should look something like this:
 
 ```bash
 # Your WordPress site URL

--- a/docs/next/guides/authentication.mdx
+++ b/docs/next/guides/authentication.mdx
@@ -55,7 +55,7 @@ import { headlessConfig } from '@faustjs/core';
 
 if (!process.env.NEXT_PUBLIC_WORDPRESS_URL) {
   console.error(
-    'You must provide a NEXT_PUBLIC_WORDPRESS_URL environment variable, did you forget to load your .env file?',
+    'You must provide a NEXT_PUBLIC_WORDPRESS_URL environment variable, did you forget to load your .env.local file?',
   );
 }
 

--- a/docs/next/guides/post-page-previews.mdx
+++ b/docs/next/guides/post-page-previews.mdx
@@ -19,11 +19,11 @@ Your headless secret can be found in WP Admin -> Settings -> Headless. Copy this
   alt="The Headless WordPress admin interface with a red rectangle around the Secret Key field"
 />
 
-### Add your Headless Secret to your `.env` File
+### Add your Headless Secret to your `.env.local` File
 
-Add the `WP_HEADLESS_SECRET` key to your `.env` file with the headless secret as the value. Your `.env` file should already have a value for `NEXT_PUBLIC_WORDPRESS_URL`. The file should look something like this:
+Add the `WP_HEADLESS_SECRET` key to your `.env.local` file with the headless secret as the value. Your `.env.local` file should already have a value for `NEXT_PUBLIC_WORDPRESS_URL`. The file should look something like this:
 
-```bash title=.env {13}
+```bash title=.env.local {13}
 # Your WordPress site URL
 NEXT_PUBLIC_WORDPRESS_URL=http://localhost:8080
 

--- a/docs/tutorial/setup-faustjs.mdx
+++ b/docs/tutorial/setup-faustjs.mdx
@@ -68,7 +68,7 @@ import { headlessConfig } from '@faustjs/core';
 
 if (!process.env.NEXT_PUBLIC_WORDPRESS_URL) {
   console.error(
-    'You must provide a NEXT_PUBLIC_WORDPRESS_URL environment variable, did you forget to load your .env file?',
+    'You must provide a NEXT_PUBLIC_WORDPRESS_URL environment variable, did you forget to load your .env.local file?',
   );
 }
 
@@ -81,9 +81,9 @@ export default headlessConfig({
 });
 ```
 
-### Create `.env`
+### Create `.env.local`
 
-You'll also need a `.env` file to hold your environment variables:
+You'll also need a `.env.local` file to hold your environment variables:
 
 ```bash
 # Your WordPress site URL
@@ -249,7 +249,7 @@ my-app/
     _app.tsx
     index.tsx
     posts.tsx
-  .env
+  .env.local
   faust.config.js
   gqty.config.js
   next-env.d.ts

--- a/examples/next/getting-started/.env.local.sample
+++ b/examples/next/getting-started/.env.local.sample
@@ -1,0 +1,5 @@
+# Your WordPress site URL
+NEXT_PUBLIC_WORDPRESS_URL=https://headlessfw.wpengine.com
+
+# Plugin secret found in WordPress Settings->Headless
+WP_HEADLESS_SECRET=YOUR_PLUGIN_SECRET

--- a/examples/next/getting-started/.env.sample
+++ b/examples/next/getting-started/.env.sample
@@ -1,5 +1,0 @@
-# Your WordPress site URL
-NEXT_PUBLIC_WORDPRESS_URL=https://headlessfw.wpengine.com
-
-# Plugin secret found in WordPress Settings->Headless
-WP_HEADLESS_SECRET=YOUR_PLUGIN_SECRET

--- a/examples/next/getting-started/gqty.config.js
+++ b/examples/next/getting-started/gqty.config.js
@@ -1,4 +1,4 @@
-require('dotenv').config();
+require('dotenv-flow').config();
 
 /**
  * @type {import("@gqty/cli").GQtyConfig}

--- a/examples/next/getting-started/package.json
+++ b/examples/next/getting-started/package.json
@@ -23,7 +23,7 @@
   "devDependencies": {
     "@gqty/cli": "^2.0.1",
     "@types/react": "^17.0.24",
-    "dotenv": "^10.0.0",
+    "dotenv-flow": "3.2.0",
     "eslint": "^7.32.0",
     "eslint-config-next": "^11.1.2",
     "rimraf": "^3.0.2",

--- a/examples/next/getting-started/src/faust.config.js
+++ b/examples/next/getting-started/src/faust.config.js
@@ -2,7 +2,7 @@ import { headlessConfig } from '@faustjs/core';
 
 if (!process.env.NEXT_PUBLIC_WORDPRESS_URL) {
   console.error(
-    'You must provide a NEXT_PUBLIC_WORDPRESS_URL environment variable, did you forget to load your .env file?',
+    'You must provide a NEXT_PUBLIC_WORDPRESS_URL environment variable, did you forget to load your .env.local file?',
   );
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
       "dependencies": {
         "@faustjs/core": "^0.11.0",
         "@faustjs/next": "^0.11.0",
+        "dotenv-flow": "3.2.0",
         "next": "^11.1.2",
         "normalize.css": "^8.0.1",
         "react": "^17.0.2",
@@ -38,7 +39,6 @@
       "devDependencies": {
         "@gqty/cli": "^2.0.1",
         "@types/react": "^17.0.24",
-        "dotenv": "^10.0.0",
         "eslint": "^7.32.0",
         "eslint-config-next": "^11.1.2",
         "rimraf": "^3.0.2",
@@ -4730,11 +4730,21 @@
         "tslib": "^2.0.3"
       }
     },
-    "node_modules/dotenv": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
-      "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==",
-      "dev": true,
+    "node_modules/dotenv-flow": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/dotenv-flow/-/dotenv-flow-3.2.0.tgz",
+      "integrity": "sha512-GEB6RrR4AbqDJvNSFrYHqZ33IKKbzkvLYiD5eo4+9aFXr4Y4G+QaFrB/fNp0y6McWBmvaPn3ZNjIufnj8irCtg==",
+      "dependencies": {
+        "dotenv": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
+    },
+    "node_modules/dotenv-flow/node_modules/dotenv": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.6.0.tgz",
+      "integrity": "sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==",
       "engines": {
         "node": ">=10"
       }
@@ -16870,11 +16880,20 @@
         "tslib": "^2.0.3"
       }
     },
-    "dotenv": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
-      "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==",
-      "dev": true
+    "dotenv-flow": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/dotenv-flow/-/dotenv-flow-3.2.0.tgz",
+      "integrity": "sha512-GEB6RrR4AbqDJvNSFrYHqZ33IKKbzkvLYiD5eo4+9aFXr4Y4G+QaFrB/fNp0y6McWBmvaPn3ZNjIufnj8irCtg==",
+      "requires": {
+        "dotenv": "^8.0.0"
+      },
+      "dependencies": {
+        "dotenv": {
+          "version": "8.6.0",
+          "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.6.0.tgz",
+          "integrity": "sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g=="
+        }
+      }
     },
     "duplexer3": {
       "version": "0.1.4",
@@ -20275,7 +20294,7 @@
         "@faustjs/next": "^0.11.0",
         "@gqty/cli": "^2.0.1",
         "@types/react": "^17.0.24",
-        "dotenv": "^10.0.0",
+        "dotenv-flow": "3.2.0",
         "eslint": "^7.32.0",
         "eslint-config-next": "^11.1.2",
         "next": "^11.1.2",


### PR DESCRIPTION
This PR allows users of the `next/getting-started` example to use any naming of their environment files with the help of [`dotenv-flow`](https://www.npmjs.com/package/dotenv-flow).

Also changed the example to use `.env.local` by default instead of `.env`, as this is what Next.js prefers.

Resolves #447 