### PR TITLE
Updated the link to the guide document on the configuration page of wpe-headless plugin.

### DIFF
--- a/plugins/wpe-headless/includes/settings/callbacks.php
+++ b/plugins/wpe-headless/includes/settings/callbacks.php
@@ -231,7 +231,7 @@ function wpe_headless_display_secret_key_field() {
 		printf(
 			/* translators: %s: Documentation URL. */
 			wp_kses_post( __( 'This key is used to enable <a href="%s" target="_blank" rel="noopener noreferrer">headless post previews</a>.', 'wpe-headless' ) ),
-			'https://github.com/wpengine/faustjs/blob/main/docs/previews/README.md'
+			'https://faustjs.org/docs/next/guides/post-page-previews'
 		);
 		?>
 	</p>


### PR DESCRIPTION
Hi,

The old link no longer exists, so I changed it to a link to the new document.
