### PR TITLE
Implement `logoutHandler` middleware

### DIFF
--- a/.changeset/fresh-ads-know.md
+++ b/.changeset/fresh-ads-know.md
@@ -1,0 +1,5 @@
+---
+'@faustjs/core': minor
+---
+
+Implement `logoutHandler` middleware

--- a/packages/core/src/auth/index.ts
+++ b/packages/core/src/auth/index.ts
@@ -1,4 +1,4 @@
 export * from './server/cookie';
-export { authorizeHandler } from './server/middleware';
+export { authorizeHandler, logoutHandler } from './server/middleware';
 export * from './authorize';
 export * from './client/accessToken';

--- a/packages/core/src/auth/server/middleware.ts
+++ b/packages/core/src/auth/server/middleware.ts
@@ -75,3 +75,28 @@ export async function authorizeHandler(
     res.end(JSON.stringify({ error: 'Internal Server Error' }));
   }
 }
+
+/**
+ * A Node handler for processing incoming requests to logout an authenticated user.
+ * This handler clears the refresh token from the cookie and returns a response.
+ *
+ * @param {IncomingMessage} req
+ * @param {ServerResponse} res
+ *
+ * @see https://faustjs.org/docs/next/guides/auth
+ */
+export function logoutHandler(req: IncomingMessage, res: ServerResponse): void {
+  // Only allow POST requests, as browsers may pre-fetch GET requests.
+  if (req.method !== 'POST') {
+    res.statusCode = 405;
+    res.end();
+
+    return;
+  }
+
+  const oauth = new OAuth(new Cookies(req, res));
+  oauth.setRefreshToken(undefined);
+
+  res.statusCode = 205;
+  res.end();
+}


### PR DESCRIPTION
This PR technically closes #517.

This PR will implement a `logoutHandler` middleware to clear the refresh token from the cookie.

Ideally we'll want a `useLogout` hook as well that can help facilitate this, however, I think we should implement https://github.com/wpengine/faustjs/issues/518#issuecomment-929771017 prior to avoid/reduce any breaking changes.