### PR TITLE
chore: include gqty as a monorepo dev dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "devDependencies": {
         "@types/jest": "^27.0.1",
         "@wordpress/env": "^4.0.0",
+        "gqty": "^2.0.2",
         "rimraf": "^3.0.2"
       },
       "engines": {
@@ -1686,19 +1687,6 @@
       },
       "engines": {
         "node": "^12.20.0 || >=14.13.0"
-      },
-      "peerDependencies": {
-        "graphql": "*"
-      }
-    },
-    "node_modules/@gqty/cli/node_modules/gqty": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/gqty/-/gqty-2.0.1.tgz",
-      "integrity": "sha512-+4yfRR24rzmH0Vb5N6eC03IPxcSNhM6iV0AUV92RJM+RKvCL8sm+pvnoxMiQ9sojUoqjcvL5BQGmVvaEsnqKNw==",
-      "dev": true,
-      "dependencies": {
-        "lodash": "^4.17.21",
-        "lodash-es": "^4.17.21"
       },
       "peerDependencies": {
         "graphql": "*"
@@ -7418,6 +7406,20 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/gqty": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/gqty/-/gqty-2.0.2.tgz",
+      "integrity": "sha512-QvVGY+G0x6Es6tzXNV88XeqRuelGP518qsYXqfe+gC7mZ60UAf2rk3Pf/ypTDXkcDM2V6/9GJd1j8Hm7WPcJdw==",
+      "dependencies": {
+        "lodash": "^4.17.21"
+      },
+      "engines": {
+        "node": "^12.20.0 || >=14.13.0"
+      },
+      "peerDependencies": {
+        "graphql": "*"
+      }
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.8",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.8.tgz",
@@ -9808,11 +9810,6 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
-    },
-    "node_modules/lodash-es": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
-      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
     },
     "node_modules/lodash.clonedeep": {
       "version": "4.5.0",
@@ -14789,18 +14786,6 @@
         "typescript": "^4.4.3"
       }
     },
-    "packages/core/node_modules/gqty": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/gqty/-/gqty-2.0.1.tgz",
-      "integrity": "sha512-+4yfRR24rzmH0Vb5N6eC03IPxcSNhM6iV0AUV92RJM+RKvCL8sm+pvnoxMiQ9sojUoqjcvL5BQGmVvaEsnqKNw==",
-      "dependencies": {
-        "lodash": "^4.17.21",
-        "lodash-es": "^4.17.21"
-      },
-      "peerDependencies": {
-        "graphql": "*"
-      }
-    },
     "packages/next": {
       "name": "@faustjs/next",
       "version": "0.11.0",
@@ -14882,18 +14867,6 @@
         "react": ">=16.8"
       }
     },
-    "packages/next/node_modules/gqty": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/gqty/-/gqty-2.0.1.tgz",
-      "integrity": "sha512-+4yfRR24rzmH0Vb5N6eC03IPxcSNhM6iV0AUV92RJM+RKvCL8sm+pvnoxMiQ9sojUoqjcvL5BQGmVvaEsnqKNw==",
-      "dependencies": {
-        "lodash": "^4.17.21",
-        "lodash-es": "^4.17.21"
-      },
-      "peerDependencies": {
-        "graphql": "*"
-      }
-    },
     "packages/react": {
       "name": "@faustjs/react",
       "version": "0.11.0",
@@ -14955,18 +14928,6 @@
         "gqty": "^2.0.0",
         "graphql": "*",
         "react": ">=16.8"
-      }
-    },
-    "packages/react/node_modules/gqty": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/gqty/-/gqty-2.0.1.tgz",
-      "integrity": "sha512-+4yfRR24rzmH0Vb5N6eC03IPxcSNhM6iV0AUV92RJM+RKvCL8sm+pvnoxMiQ9sojUoqjcvL5BQGmVvaEsnqKNw==",
-      "dependencies": {
-        "lodash": "^4.17.21",
-        "lodash-es": "^4.17.21"
-      },
-      "peerDependencies": {
-        "graphql": "*"
       }
     }
   },
@@ -16208,17 +16169,6 @@
         "ts-jest": "^27.0.5",
         "ts-loader": "^9.2.6",
         "typescript": "^4.4.3"
-      },
-      "dependencies": {
-        "gqty": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/gqty/-/gqty-2.0.1.tgz",
-          "integrity": "sha512-+4yfRR24rzmH0Vb5N6eC03IPxcSNhM6iV0AUV92RJM+RKvCL8sm+pvnoxMiQ9sojUoqjcvL5BQGmVvaEsnqKNw==",
-          "requires": {
-            "lodash": "^4.17.21",
-            "lodash-es": "^4.17.21"
-          }
-        }
       }
     },
     "@faustjs/next": {
@@ -16278,15 +16228,6 @@
           "requires": {
             "react-ssr-prepass": "^1.4.0"
           }
-        },
-        "gqty": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/gqty/-/gqty-2.0.1.tgz",
-          "integrity": "sha512-+4yfRR24rzmH0Vb5N6eC03IPxcSNhM6iV0AUV92RJM+RKvCL8sm+pvnoxMiQ9sojUoqjcvL5BQGmVvaEsnqKNw==",
-          "requires": {
-            "lodash": "^4.17.21",
-            "lodash-es": "^4.17.21"
-          }
         }
       }
     },
@@ -16336,15 +16277,6 @@
           "requires": {
             "react-ssr-prepass": "^1.4.0"
           }
-        },
-        "gqty": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/gqty/-/gqty-2.0.1.tgz",
-          "integrity": "sha512-+4yfRR24rzmH0Vb5N6eC03IPxcSNhM6iV0AUV92RJM+RKvCL8sm+pvnoxMiQ9sojUoqjcvL5BQGmVvaEsnqKNw==",
-          "requires": {
-            "lodash": "^4.17.21",
-            "lodash-es": "^4.17.21"
-          }
         }
       }
     },
@@ -16365,18 +16297,6 @@
         "gqty": "^2.0.1",
         "mkdirp": "^1.0.4",
         "prettier": "^2.4.1"
-      },
-      "dependencies": {
-        "gqty": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/gqty/-/gqty-2.0.1.tgz",
-          "integrity": "sha512-+4yfRR24rzmH0Vb5N6eC03IPxcSNhM6iV0AUV92RJM+RKvCL8sm+pvnoxMiQ9sojUoqjcvL5BQGmVvaEsnqKNw==",
-          "dev": true,
-          "requires": {
-            "lodash": "^4.17.21",
-            "lodash-es": "^4.17.21"
-          }
-        }
       }
     },
     "@graphql-codegen/core": {
@@ -20888,6 +20808,14 @@
         }
       }
     },
+    "gqty": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/gqty/-/gqty-2.0.2.tgz",
+      "integrity": "sha512-QvVGY+G0x6Es6tzXNV88XeqRuelGP518qsYXqfe+gC7mZ60UAf2rk3Pf/ypTDXkcDM2V6/9GJd1j8Hm7WPcJdw==",
+      "requires": {
+        "lodash": "^4.17.21"
+      }
+    },
     "graceful-fs": {
       "version": "4.2.8",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.8.tgz",
@@ -22678,11 +22606,6 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
-    },
-    "lodash-es": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
-      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
     },
     "lodash.clonedeep": {
       "version": "4.5.0",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
   "devDependencies": {
     "@types/jest": "^27.0.1",
     "@wordpress/env": "^4.0.0",
+    "gqty": "^2.0.2",
     "rimraf": "^3.0.2"
   },
   "dependencies": {


### PR DESCRIPTION
Fixes failed module resolution for `gqty` when running the `next/getting-started` example project from the root of the monorepo.