### PR TITLE
Simplify public route redirection by using template_redirect

### DIFF
--- a/plugins/wpe-headless/includes/deny-public-access/callbacks.php
+++ b/plugins/wpe-headless/includes/deny-public-access/callbacks.php
@@ -9,31 +9,20 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-add_action( 'parse_request', 'wpe_headless_deny_public_access', 99 );
+add_action( 'template_redirect', 'wpe_headless_deny_public_access', 99 );
 /**
  * Redirects non-API requests for public URLs to the specified front-end URL.
  *
- * @param object $query The current query.
- *
  * @return void
  */
-function wpe_headless_deny_public_access( $query ) {
-	if ( ! wpe_headless_is_redirects_enabled() ) {
+function wpe_headless_deny_public_access() {
+	if ( ! wpe_headless_is_redirects_enabled() || is_customize_preview() ) {
 		return;
 	}
 
 	$frontend_uri = wpe_headless_get_setting( 'frontend_uri' );
 
-	if (
-		defined( 'DOING_CRON' ) ||
-		defined( 'REST_REQUEST' ) ||
-		is_admin() ||
-		is_customize_preview() ||
-		( function_exists( 'is_graphql_http_request' ) && is_graphql_http_request() ) || // From https://wordpress.org/plugins/wp-graphql/.
-		! empty( $query->query_vars['rest_oauth1'] ) || // From https://oauth1.wp-api.org/.
-		! property_exists( $query, 'request' ) ||
-		! $frontend_uri
-	) {
+	if ( ! $frontend_uri ) {
 		return;
 	}
 


### PR DESCRIPTION
Fixes #389 

In testing, it appears switching from `parse_request` to `template_redirect` works as intended and allows us to remove most of the complexity in the callback. The only conditional check that could not be avoided was `is_customize_preview()`. I'm not sure that accessing the customizer preview is really necessary or useful in a headless environment, but I left it in place since we were already making the exception.