### PR TITLE
fix: headless post previews URL

### DIFF
--- a/plugins/faustwp/includes/settings/callbacks.php
+++ b/plugins/faustwp/includes/settings/callbacks.php
@@ -233,7 +233,7 @@ function display_secret_key_field() {
 		printf(
 			/* translators: %s: Documentation URL. */
 			wp_kses_post( __( 'This key is used to enable <a href="%s" target="_blank" rel="noopener noreferrer">headless post previews</a>.', 'faustwp' ) ),
-			'https://github.com/wpengine/faustjs/blob/main/docs/previews/README.md'
+			'https://faustjs.org/docs/next/guides/post-page-previews'
 		);
 		?>
 	</p>


### PR DESCRIPTION
Fix the "headless post preview" link in FaustWP