### PR TITLE
Use fully qualified module imports for Next 12 compatibility

### DIFF
--- a/.changeset/wet-fireants-accept.md
+++ b/.changeset/wet-fireants-accept.md
@@ -1,0 +1,8 @@
+---
+'next-headless-getting-started': minor
+'@faustjs/core': minor
+'@faustjs/next': minor
+'@faustjs/react': minor
+---
+
+Use explicit module imports (with full paths and extensions) for Next.js 12 compatibility.

--- a/examples/next/getting-started/package.json
+++ b/examples/next/getting-started/package.json
@@ -14,19 +14,19 @@
   "dependencies": {
     "@faustjs/core": "^0.13.1",
     "@faustjs/next": "^0.13.1",
-    "next": "^11.1.2",
+    "next": "^12.0.3",
     "normalize.css": "^8.0.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "sass": "^1.42.1"
+    "sass": "^1.43.4"
   },
   "devDependencies": {
-    "@gqty/cli": "^2.0.1",
-    "@types/react": "^17.0.24",
+    "@gqty/cli": "^2.3.0",
+    "@types/react": "^17.0.34",
     "dotenv-flow": "3.2.0",
     "eslint": "^7.32.0",
-    "eslint-config-next": "^11.1.2",
+    "eslint-config-next": "^12.0.3",
     "rimraf": "^3.0.2",
-    "typescript": "^4.4.3"
+    "typescript": "^4.4.4"
   }
 }

--- a/examples/next/getting-started/tsconfig.json
+++ b/examples/next/getting-started/tsconfig.json
@@ -17,7 +17,8 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",
-    "baseUrl": "./src"
+    "baseUrl": "./src",
+    "incremental": true
   },
   "include": [
     "next-env.d.ts",

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,22 +30,479 @@
       "name": "next-headless-getting-started",
       "version": "0.1.0",
       "dependencies": {
-        "@faustjs/core": "^0.12.4",
-        "@faustjs/next": "^0.13.0",
-        "next": "^11.1.2",
+        "@faustjs/core": "^0.13.1",
+        "@faustjs/next": "^0.13.1",
+        "next": "^12.0.3",
         "normalize.css": "^8.0.1",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
-        "sass": "^1.42.1"
+        "sass": "^1.43.4"
       },
       "devDependencies": {
-        "@gqty/cli": "^2.0.1",
-        "@types/react": "^17.0.24",
+        "@gqty/cli": "^2.3.0",
+        "@types/react": "^17.0.34",
         "dotenv-flow": "3.2.0",
         "eslint": "^7.32.0",
-        "eslint-config-next": "^11.1.2",
+        "eslint-config-next": "^12.0.3",
         "rimraf": "^3.0.2",
-        "typescript": "^4.4.3"
+        "typescript": "^4.4.4"
+      }
+    },
+    "examples/next/getting-started/node_modules/@babel/code-frame": {
+      "version": "7.12.11",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
+      "integrity": "sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==",
+      "dependencies": {
+        "@babel/highlight": "^7.10.4"
+      }
+    },
+    "examples/next/getting-started/node_modules/@babel/types": {
+      "version": "7.15.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.0.tgz",
+      "integrity": "sha512-OBvfqnllOIdX4ojTHpwZbpvz4j3EWyjkZEdmjH0/cgsd6QOdSgU8rLSk6ard/pcW7rlmjdVSX/AWOaORR1uNOQ==",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.14.9",
+        "to-fast-properties": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "examples/next/getting-started/node_modules/@next/env": {
+      "version": "12.0.3",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-12.0.3.tgz",
+      "integrity": "sha512-QcdlpcwIH9dYcVlNAU+gXaqHA/omskbRlb+R3vN7LlB2EgLt+9WQwbokcHOsNyt4pI7kDM67W4tr9l7dWnlGdQ=="
+    },
+    "examples/next/getting-started/node_modules/@next/polyfill-module": {
+      "version": "12.0.3",
+      "resolved": "https://registry.npmjs.org/@next/polyfill-module/-/polyfill-module-12.0.3.tgz",
+      "integrity": "sha512-fgjVjdCk0Jq627d/N33oQIJjWrcKtzw6Dfa2PfypoIJ35/xFIKgs6mPyvq8cg3Ao5b7dEn9+Rw45PGjlY5e7JA=="
+    },
+    "examples/next/getting-started/node_modules/@next/react-dev-overlay": {
+      "version": "12.0.3",
+      "resolved": "https://registry.npmjs.org/@next/react-dev-overlay/-/react-dev-overlay-12.0.3.tgz",
+      "integrity": "sha512-gHfDEVHFeTUpQMcyytzvkuOu+5DQXjXbCbQHuavFftYrlHqXfzYFsa+wERff+g4/0IzEvcYVp3F4gdmynWfUog==",
+      "dependencies": {
+        "@babel/code-frame": "7.12.11",
+        "anser": "1.4.9",
+        "chalk": "4.0.0",
+        "classnames": "2.2.6",
+        "css.escape": "1.5.1",
+        "data-uri-to-buffer": "3.0.1",
+        "platform": "1.3.6",
+        "shell-quote": "1.7.3",
+        "source-map": "0.8.0-beta.0",
+        "stacktrace-parser": "0.1.10",
+        "strip-ansi": "6.0.1"
+      },
+      "peerDependencies": {
+        "react": "^17.0.2",
+        "react-dom": "^17.0.2",
+        "webpack": "^4 || ^5"
+      },
+      "peerDependenciesMeta": {
+        "webpack": {
+          "optional": true
+        }
+      }
+    },
+    "examples/next/getting-started/node_modules/@next/react-dev-overlay/node_modules/chalk": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.0.0.tgz",
+      "integrity": "sha512-N9oWFcegS0sFr9oh1oz2d7Npos6vNoWW9HvtCg5N1KRFpUhaAhvTv5Y58g880fZaEYSNm3qDz8SU1UrGvp+n7A==",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "examples/next/getting-started/node_modules/@next/react-dev-overlay/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "examples/next/getting-started/node_modules/@next/react-refresh-utils": {
+      "version": "12.0.3",
+      "resolved": "https://registry.npmjs.org/@next/react-refresh-utils/-/react-refresh-utils-12.0.3.tgz",
+      "integrity": "sha512-YPtlfvkYh/4MvNNm5w3uwo+1KPMg67snzr5CuexbRewsu2ITaF7f0bh0Jcayi20wztk8SgWjNz1bmF8j9qbWIw==",
+      "peerDependencies": {
+        "react-refresh": "0.8.3",
+        "webpack": "^4 || ^5"
+      },
+      "peerDependenciesMeta": {
+        "webpack": {
+          "optional": true
+        }
+      }
+    },
+    "examples/next/getting-started/node_modules/@next/swc-darwin-arm64": {
+      "version": "12.0.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-12.0.3.tgz",
+      "integrity": "sha512-iKSe2hCMB51Ft41cNAxZk6St1rBlqSRtBSl4oO0zJlGu7bCxXCGCJ058/OLvYxcNWgz7ODOApObm3Yjv8XEvxg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "examples/next/getting-started/node_modules/@next/swc-darwin-x64": {
+      "version": "12.0.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-12.0.3.tgz",
+      "integrity": "sha512-/BcnfLyhIj4rgU3yVDfD8uXK2TcNYIdflYHKkjFxd3/J1GWOtBN31m0dB8fL0h5LdW11kzaXvVvab3f5ilkEww==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "examples/next/getting-started/node_modules/@next/swc-linux-x64-gnu": {
+      "version": "12.0.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-12.0.3.tgz",
+      "integrity": "sha512-4mkimH9nMzbuQfLmZ152NYSHdrII9AeqrkrHszexL1Lup2TLMPuxlXj55eVnyyeKFXRLlnqbCu7aOIND68RbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "examples/next/getting-started/node_modules/@next/swc-win32-x64-msvc": {
+      "version": "12.0.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-12.0.3.tgz",
+      "integrity": "sha512-eXFwyf46UFFggMQ3k2tJsOmB3SuKjWaSiZJH0tTDUsLw74lyqyzJqMCVA4yY0gWSlEnSjmX5nrCBknVZd3joaA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "examples/next/getting-started/node_modules/acorn": {
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.5.0.tgz",
+      "integrity": "sha512-yXbYeFy+jUuYd3/CDcg2NkIYE991XYX/bje7LmjJigUciaeO1JR4XxXgCIV1/Zc/dRuFEyw1L0pbA+qynJkW5Q==",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "examples/next/getting-started/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "examples/next/getting-started/node_modules/browserslist": {
+      "version": "4.16.6",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.6.tgz",
+      "integrity": "sha512-Wspk/PqO+4W9qp5iUTJsa1B/QrYn1keNCcEP5OvP7WBwT4KaDly0uONYmC6Xa3Z5IqnUgS0KcgLYu1l74x0ZXQ==",
+      "dependencies": {
+        "caniuse-lite": "^1.0.30001219",
+        "colorette": "^1.2.2",
+        "electron-to-chromium": "^1.3.723",
+        "escalade": "^3.1.1",
+        "node-releases": "^1.1.71"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/browserslist"
+      }
+    },
+    "examples/next/getting-started/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "examples/next/getting-started/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "examples/next/getting-started/node_modules/convert-source-map": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
+      "integrity": "sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==",
+      "dependencies": {
+        "safe-buffer": "~5.1.1"
+      }
+    },
+    "examples/next/getting-started/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "examples/next/getting-started/node_modules/jest-worker": {
+      "version": "27.0.0-next.5",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.0.0-next.5.tgz",
+      "integrity": "sha512-mk0umAQ5lT+CaOJ+Qp01N6kz48sJG2kr2n1rX0koqKf6FIygQV0qLOdN9SCYID4IVeSigDOcPeGLozdMLYfb5g==",
+      "dependencies": {
+        "@types/node": "*",
+        "merge-stream": "^2.0.0",
+        "supports-color": "^8.0.0"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "examples/next/getting-started/node_modules/next": {
+      "version": "12.0.3",
+      "resolved": "https://registry.npmjs.org/next/-/next-12.0.3.tgz",
+      "integrity": "sha512-GGdhTBcerdMZbitrO67IVetmB+AHa2X69xrkXKClUT8SRu8pEVto/2QMSnfI+uYc5czCUWPsVtVY3aMoMRMaCA==",
+      "dependencies": {
+        "@babel/runtime": "7.15.4",
+        "@hapi/accept": "5.0.2",
+        "@napi-rs/triples": "1.0.3",
+        "@next/env": "12.0.3",
+        "@next/polyfill-module": "12.0.3",
+        "@next/react-dev-overlay": "12.0.3",
+        "@next/react-refresh-utils": "12.0.3",
+        "acorn": "8.5.0",
+        "assert": "2.0.0",
+        "browserify-zlib": "0.2.0",
+        "browserslist": "4.16.6",
+        "buffer": "5.6.0",
+        "caniuse-lite": "^1.0.30001228",
+        "chalk": "2.4.2",
+        "chokidar": "3.5.1",
+        "constants-browserify": "1.0.0",
+        "crypto-browserify": "3.12.0",
+        "cssnano-simple": "3.0.0",
+        "domain-browser": "4.19.0",
+        "encoding": "0.1.13",
+        "etag": "1.8.1",
+        "events": "3.3.0",
+        "find-cache-dir": "3.3.1",
+        "get-orientation": "1.1.2",
+        "https-browserify": "1.0.0",
+        "image-size": "1.0.0",
+        "jest-worker": "27.0.0-next.5",
+        "node-fetch": "2.6.1",
+        "node-html-parser": "1.4.9",
+        "os-browserify": "0.3.0",
+        "p-limit": "3.1.0",
+        "path-browserify": "1.0.1",
+        "postcss": "8.2.15",
+        "process": "0.11.10",
+        "querystring-es3": "0.2.1",
+        "raw-body": "2.4.1",
+        "react-is": "17.0.2",
+        "react-refresh": "0.8.3",
+        "regenerator-runtime": "0.13.4",
+        "stream-browserify": "3.0.0",
+        "stream-http": "3.1.1",
+        "string_decoder": "1.3.0",
+        "styled-jsx": "5.0.0-beta.3",
+        "timers-browserify": "2.0.12",
+        "tty-browserify": "0.0.1",
+        "use-subscription": "1.5.1",
+        "util": "0.12.4",
+        "vm-browserify": "1.1.2",
+        "watchpack": "2.1.1"
+      },
+      "bin": {
+        "next": "dist/bin/next"
+      },
+      "engines": {
+        "node": ">=12.22.0"
+      },
+      "optionalDependencies": {
+        "@next/swc-android-arm64": "12.0.3",
+        "@next/swc-darwin-arm64": "12.0.3",
+        "@next/swc-darwin-x64": "12.0.3",
+        "@next/swc-linux-arm-gnueabihf": "12.0.3",
+        "@next/swc-linux-arm64-gnu": "12.0.3",
+        "@next/swc-linux-arm64-musl": "12.0.3",
+        "@next/swc-linux-x64-gnu": "12.0.3",
+        "@next/swc-linux-x64-musl": "12.0.3",
+        "@next/swc-win32-arm64-msvc": "12.0.3",
+        "@next/swc-win32-ia32-msvc": "12.0.3",
+        "@next/swc-win32-x64-msvc": "12.0.3"
+      },
+      "peerDependencies": {
+        "fibers": ">= 3.1.0",
+        "node-sass": "^4.0.0 || ^5.0.0 || ^6.0.0",
+        "react": "^17.0.2 || ^18.0.0",
+        "react-dom": "^17.0.2 || ^18.0.0",
+        "sass": "^1.3.0"
+      },
+      "peerDependenciesMeta": {
+        "fibers": {
+          "optional": true
+        },
+        "node-sass": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        }
+      }
+    },
+    "examples/next/getting-started/node_modules/node-releases": {
+      "version": "1.1.77",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.77.tgz",
+      "integrity": "sha512-rB1DUFUNAN4Gn9keO2K1efO35IDK7yKHCdCaIMvFO7yUYmmZYeDjnGKle26G4rwj+LKRQpjyUUvMkPglwGCYNQ=="
+    },
+    "examples/next/getting-started/node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "examples/next/getting-started/node_modules/regenerator-runtime": {
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.4.tgz",
+      "integrity": "sha512-plpwicqEzfEyTQohIKktWigcLzmNStMGwbOUbykx51/29Z3JOGYldaaNGK7ngNXV+UcoqvIMmloZ48Sr74sd+g=="
+    },
+    "examples/next/getting-started/node_modules/shell-quote": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.3.tgz",
+      "integrity": "sha512-Vpfqwm4EnqGdlsBFNmHhxhElJYrdfcxPThu+ryKS5J8L/fhAwLazFZtq+S+TWZ9ANj2piSQLGj6NQg+lKPmxrw=="
+    },
+    "examples/next/getting-started/node_modules/source-map": {
+      "version": "0.8.0-beta.0",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.8.0-beta.0.tgz",
+      "integrity": "sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA==",
+      "dependencies": {
+        "whatwg-url": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "examples/next/getting-started/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "examples/next/getting-started/node_modules/styled-jsx": {
+      "version": "5.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.0.0-beta.3.tgz",
+      "integrity": "sha512-HtDDGSFPvmjHIqWf9n8Oo54tAoY/DTplvlyOH2+YOtD80Sp31Ap8ffSmxhgk5EkUoJ7xepdXMGT650mSffWuRA==",
+      "dependencies": {
+        "@babel/plugin-syntax-jsx": "7.14.5",
+        "@babel/types": "7.15.0",
+        "convert-source-map": "1.7.0",
+        "loader-utils": "1.2.3",
+        "source-map": "0.7.3",
+        "string-hash": "1.1.3",
+        "stylis": "3.5.4",
+        "stylis-rule-sheet": "0.0.10"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8.0 || 17.x.x || 18.x.x"
+      },
+      "peerDependenciesMeta": {
+        "@babel/core": {
+          "optional": true
+        }
+      }
+    },
+    "examples/next/getting-started/node_modules/styled-jsx/node_modules/source-map": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
+      "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "examples/next/getting-started/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "examples/next/getting-started/node_modules/webidl-conversions": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
+      "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg=="
+    },
+    "examples/next/getting-started/node_modules/whatwg-url": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
+      "integrity": "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==",
+      "dependencies": {
+        "lodash.sortby": "^4.7.0",
+        "tr46": "^1.0.1",
+        "webidl-conversions": "^4.0.2"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -2290,12 +2747,13 @@
     "node_modules/@next/env": {
       "version": "11.1.2",
       "resolved": "https://registry.npmjs.org/@next/env/-/env-11.1.2.tgz",
-      "integrity": "sha512-+fteyVdQ7C/OoulfcF6vd1Yk0FEli4453gr8kSFbU8sKseNSizYq6df5MKz/AjwLptsxrUeIkgBdAzbziyJ3mA=="
+      "integrity": "sha512-+fteyVdQ7C/OoulfcF6vd1Yk0FEli4453gr8kSFbU8sKseNSizYq6df5MKz/AjwLptsxrUeIkgBdAzbziyJ3mA==",
+      "dev": true
     },
     "node_modules/@next/eslint-plugin-next": {
-      "version": "11.1.2",
-      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-11.1.2.tgz",
-      "integrity": "sha512-cN+ojHRsufr9Yz0rtvjv8WI5En0RPZRJnt0y16Ha7DD+0n473evz8i1ETEJHmOLeR7iPJR0zxRrxeTN/bJMOjg==",
+      "version": "12.0.3",
+      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-12.0.3.tgz",
+      "integrity": "sha512-P7i+bMypneQcoRN+CX79xssvvIJCaw7Fndzbe7/lB0+LyRbVvGVyMUsFmLLbSxtZq4hvFMJ1p8wML/gsulMZWQ==",
       "dev": true,
       "dependencies": {
         "glob": "7.1.7"
@@ -2324,12 +2782,14 @@
     "node_modules/@next/polyfill-module": {
       "version": "11.1.2",
       "resolved": "https://registry.npmjs.org/@next/polyfill-module/-/polyfill-module-11.1.2.tgz",
-      "integrity": "sha512-xZmixqADM3xxtqBV0TpAwSFzWJP0MOQzRfzItHXf1LdQHWb0yofHHC+7eOrPFic8+ZGz5y7BdPkkgR1S25OymA=="
+      "integrity": "sha512-xZmixqADM3xxtqBV0TpAwSFzWJP0MOQzRfzItHXf1LdQHWb0yofHHC+7eOrPFic8+ZGz5y7BdPkkgR1S25OymA==",
+      "dev": true
     },
     "node_modules/@next/react-dev-overlay": {
       "version": "11.1.2",
       "resolved": "https://registry.npmjs.org/@next/react-dev-overlay/-/react-dev-overlay-11.1.2.tgz",
       "integrity": "sha512-rDF/mGY2NC69mMg2vDqzVpCOlWqnwPUXB2zkARhvknUHyS6QJphPYv9ozoPJuoT/QBs49JJd9KWaAzVBvq920A==",
+      "dev": true,
       "dependencies": {
         "@babel/code-frame": "7.12.11",
         "anser": "1.4.9",
@@ -2352,6 +2812,7 @@
       "version": "7.12.11",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
       "integrity": "sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==",
+      "dev": true,
       "dependencies": {
         "@babel/highlight": "^7.10.4"
       }
@@ -2360,6 +2821,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -2374,6 +2836,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.0.0.tgz",
       "integrity": "sha512-N9oWFcegS0sFr9oh1oz2d7Npos6vNoWW9HvtCg5N1KRFpUhaAhvTv5Y58g880fZaEYSNm3qDz8SU1UrGvp+n7A==",
+      "dev": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -2389,6 +2852,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -2399,12 +2863,14 @@
     "node_modules/@next/react-dev-overlay/node_modules/color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
     },
     "node_modules/@next/react-dev-overlay/node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -2413,6 +2879,7 @@
       "version": "0.8.0-beta.0",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.8.0-beta.0.tgz",
       "integrity": "sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA==",
+      "dev": true,
       "dependencies": {
         "whatwg-url": "^7.0.0"
       },
@@ -2424,6 +2891,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
       "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+      "dev": true,
       "dependencies": {
         "ansi-regex": "^5.0.0"
       },
@@ -2435,6 +2903,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -2445,12 +2914,14 @@
     "node_modules/@next/react-dev-overlay/node_modules/webidl-conversions": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
-      "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg=="
+      "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
+      "dev": true
     },
     "node_modules/@next/react-dev-overlay/node_modules/whatwg-url": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
       "integrity": "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==",
+      "dev": true,
       "dependencies": {
         "lodash.sortby": "^4.7.0",
         "tr46": "^1.0.1",
@@ -2461,6 +2932,7 @@
       "version": "11.1.2",
       "resolved": "https://registry.npmjs.org/@next/react-refresh-utils/-/react-refresh-utils-11.1.2.tgz",
       "integrity": "sha512-hsoJmPfhVqjZ8w4IFzoo8SyECVnN+8WMnImTbTKrRUHOVJcYMmKLL7xf7T0ft00tWwAl/3f3Q3poWIN2Ueql/Q==",
+      "dev": true,
       "peerDependencies": {
         "react-refresh": "0.8.3",
         "webpack": "^4 || ^5"
@@ -2471,6 +2943,21 @@
         }
       }
     },
+    "node_modules/@next/swc-android-arm64": {
+      "version": "12.0.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-12.0.3.tgz",
+      "integrity": "sha512-40sOl9/50aamX0dEMrecqJQcUrRK47D7S9F66ulrZmz+5Ujp0lnP1rBOXngo0PZMecfU1tr7zbNubiAMDxfCxw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/@next/swc-darwin-arm64": {
       "version": "11.1.2",
       "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-11.1.2.tgz",
@@ -2478,10 +2965,12 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -2493,9 +2982,56 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm-gnueabihf": {
+      "version": "12.0.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-12.0.3.tgz",
+      "integrity": "sha512-2HNPhBJuN9L6JzqqqdYB4TKfFFmaKkpF0X3C1s83Xp61mR2sx8gOthHQtZqWDs4ZLnKZU0j2flGU1uuqpHPCpg==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "12.0.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-12.0.3.tgz",
+      "integrity": "sha512-NXTON1XK7zi2i+A+bY1PVLi1g5b8cSwgzbnuVR0vAgOtU+3at7FqAKOWfuFIXY7eBEK65uu0Fu5gADhMj0uanQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-musl": {
+      "version": "12.0.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-12.0.3.tgz",
+      "integrity": "sha512-8D0q22VavhcIl2ZQErEffgh5q6mChaG84uTluAoFfjwrgYtPDZX0M5StqkTZL6T5gA5RLHboNVoscIKGZWMojQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
       ],
       "engines": {
         "node": ">= 10"
@@ -2508,9 +3044,56 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-musl": {
+      "version": "12.0.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-12.0.3.tgz",
+      "integrity": "sha512-MXvx+IDYoSsSM7KcwbQAVo9r+ZeklHeDQiUEmyRRzQE1Q4JvkWwMdPu/NfFdyxur+RfKjRoUoWFdPi5MBKTpkw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "12.0.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-12.0.3.tgz",
+      "integrity": "sha512-8GusumFZLp/mtVix+3JZVTGqzqntTsrTIFZ+GpcLMwyVjB3KkBwHiwJaa38WGleUinJSpJvgmhTWgppsiSKW3A==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-ia32-msvc": {
+      "version": "12.0.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-12.0.3.tgz",
+      "integrity": "sha512-mF7bkxSZ++QiB+E0HFqay/etvPF+ZFcCuG27lSwFIM00J+TE0IRqMyMx66vJ8g1h6khpwXPI0o2hrwIip/r8cQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
       ],
       "engines": {
         "node": ">= 10"
@@ -2523,10 +3106,12 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -2535,6 +3120,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@node-rs/helper/-/helper-1.2.1.tgz",
       "integrity": "sha512-R5wEmm8nbuQU0YGGmYVjEc0OHtYsuXdpRG+Ut/3wZ9XAvQWyThN08bTh2cBJgoZxHQUPtvRfeQuxcAgLuiBISg==",
+      "dev": true,
       "dependencies": {
         "@napi-rs/triples": "^1.0.3"
       }
@@ -3725,6 +4311,7 @@
       "version": "0.13.2",
       "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.2.tgz",
       "integrity": "sha512-uWMHxJxtfj/1oZClOxDEV1sQ1HCDkA4MG8Gr69KKeBjEVH0R84WlejZ0y2DcwyBlpAEMltmVYkVgqfLFb2oyiA==",
+      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -4687,7 +5274,8 @@
     "node_modules/console-browserify": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.2.0.tgz",
-      "integrity": "sha512-ZMkYO/LkF17QvCPqM0gxw8yUzigAOZOSWSHg91FH6orS7vcEj5dVZTidN2fQ14yBSdg97RqhSNwLUXInd52OTA=="
+      "integrity": "sha512-ZMkYO/LkF17QvCPqM0gxw8yUzigAOZOSWSHg91FH6orS7vcEj5dVZTidN2fQ14yBSdg97RqhSNwLUXInd52OTA==",
+      "dev": true
     },
     "node_modules/constant-case": {
       "version": "3.0.4",
@@ -4746,7 +5334,8 @@
     "node_modules/core-util-is": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
-      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "dev": true
     },
     "node_modules/cosmiconfig": {
       "version": "7.0.1",
@@ -5694,12 +6283,12 @@
       }
     },
     "node_modules/eslint-config-next": {
-      "version": "11.1.2",
-      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-11.1.2.tgz",
-      "integrity": "sha512-dFutecxX2Z5/QVlLwdtKt+gIfmNMP8Qx6/qZh3LM/DFVdGJEAnUKrr4VwGmACB2kx/PQ5bx3R+QxnEg4fDPiTg==",
+      "version": "12.0.3",
+      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-12.0.3.tgz",
+      "integrity": "sha512-q+mX6jhk3HrCo39G18MLhiC6f8zJnTA00f30RSuVUWsv45SQUm6r62oXVqrbAgMEybe0yx/GDRvfA6LvSolw6Q==",
       "dev": true,
       "dependencies": {
-        "@next/eslint-plugin-next": "11.1.2",
+        "@next/eslint-plugin-next": "12.0.3",
         "@rushstack/eslint-patch": "^1.0.6",
         "@typescript-eslint/parser": "^4.20.0",
         "eslint-import-resolver-node": "^0.3.4",
@@ -7749,7 +8338,8 @@
     "node_modules/isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -10666,6 +11256,7 @@
       "version": "0.3.4",
       "resolved": "https://registry.npmjs.org/native-url/-/native-url-0.3.4.tgz",
       "integrity": "sha512-6iM8R99ze45ivyH8vybJ7X0yekIcPf5GgLV5K0ENCbmRcaRIDoj37BC8iLEmaaBfqqb8enuZ5p0uhY+lVAbAcA==",
+      "dev": true,
       "dependencies": {
         "querystring": "^0.2.0"
       }
@@ -10687,6 +11278,7 @@
       "version": "11.1.2",
       "resolved": "https://registry.npmjs.org/next/-/next-11.1.2.tgz",
       "integrity": "sha512-azEYL0L+wFjv8lstLru3bgvrzPvK0P7/bz6B/4EJ9sYkXeW8r5Bjh78D/Ol7VOg0EIPz0CXoe72hzAlSAXo9hw==",
+      "dev": true,
       "dependencies": {
         "@babel/runtime": "7.15.3",
         "@hapi/accept": "5.0.2",
@@ -10778,6 +11370,7 @@
       "version": "7.15.3",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.15.3.tgz",
       "integrity": "sha512-OvwMLqNXkCXSz1kSm58sEsNuhqOx/fKpnUnKnFB5v8uDda5bLNEHNgKPvhDN6IU0LDcnHQ90LlJ0Q6jnyBSIBA==",
+      "dev": true,
       "dependencies": {
         "regenerator-runtime": "^0.13.4"
       },
@@ -10789,6 +11382,7 @@
       "version": "4.16.6",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.6.tgz",
       "integrity": "sha512-Wspk/PqO+4W9qp5iUTJsa1B/QrYn1keNCcEP5OvP7WBwT4KaDly0uONYmC6Xa3Z5IqnUgS0KcgLYu1l74x0ZXQ==",
+      "dev": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001219",
         "colorette": "^1.2.2",
@@ -10811,6 +11405,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -10819,6 +11414,7 @@
       "version": "27.0.0-next.5",
       "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.0.0-next.5.tgz",
       "integrity": "sha512-mk0umAQ5lT+CaOJ+Qp01N6kz48sJG2kr2n1rX0koqKf6FIygQV0qLOdN9SCYID4IVeSigDOcPeGLozdMLYfb5g==",
+      "dev": true,
       "dependencies": {
         "@types/node": "*",
         "merge-stream": "^2.0.0",
@@ -10831,12 +11427,14 @@
     "node_modules/next/node_modules/node-releases": {
       "version": "1.1.77",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.77.tgz",
-      "integrity": "sha512-rB1DUFUNAN4Gn9keO2K1efO35IDK7yKHCdCaIMvFO7yUYmmZYeDjnGKle26G4rwj+LKRQpjyUUvMkPglwGCYNQ=="
+      "integrity": "sha512-rB1DUFUNAN4Gn9keO2K1efO35IDK7yKHCdCaIMvFO7yUYmmZYeDjnGKle26G4rwj+LKRQpjyUUvMkPglwGCYNQ==",
+      "dev": true
     },
     "node_modules/next/node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
       "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
       "dependencies": {
         "yocto-queue": "^0.1.0"
       },
@@ -10851,6 +11449,7 @@
       "version": "8.1.1",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
       "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -10897,6 +11496,7 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.2.1.tgz",
       "integrity": "sha512-h/zcD8H9kaDZ9ALUWwlBUDo6TKF8a7qBSCSEGfjTVIYeqsioSKaAX+BN7NgiMGp6iSIXZ3PxgCu8KS3b71YK5Q==",
+      "dev": true,
       "dependencies": {
         "assert": "^1.1.1",
         "browserify-zlib": "^0.2.0",
@@ -10927,6 +11527,7 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/assert/-/assert-1.5.0.tgz",
       "integrity": "sha512-EDsgawzwoun2CZkCgtxJbv392v4nbk9XDD06zI+kQYoBM/3RBWLlEyJARDOmhAAosBjWACEkKL6S+lIZtcAubA==",
+      "dev": true,
       "dependencies": {
         "object-assign": "^4.1.1",
         "util": "0.10.3"
@@ -10935,12 +11536,14 @@
     "node_modules/node-libs-browser/node_modules/assert/node_modules/inherits": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-      "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
+      "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
+      "dev": true
     },
     "node_modules/node-libs-browser/node_modules/assert/node_modules/util": {
       "version": "0.10.3",
       "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
       "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
+      "dev": true,
       "dependencies": {
         "inherits": "2.0.1"
       }
@@ -10949,6 +11552,7 @@
       "version": "4.9.2",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
       "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
+      "dev": true,
       "dependencies": {
         "base64-js": "^1.0.2",
         "ieee754": "^1.1.4",
@@ -10959,6 +11563,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.2.0.tgz",
       "integrity": "sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA==",
+      "dev": true,
       "engines": {
         "node": ">=0.4",
         "npm": ">=1.2"
@@ -10967,17 +11572,20 @@
     "node_modules/node-libs-browser/node_modules/inherits": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
     },
     "node_modules/node-libs-browser/node_modules/path-browserify": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.1.tgz",
-      "integrity": "sha512-BapA40NHICOS+USX9SN4tyhq+A2RrN/Ws5F0Z5aMHDp98Fl86lX8Oti8B7uN93L4Ifv4fHOEA+pQw87gmMO/lQ=="
+      "integrity": "sha512-BapA40NHICOS+USX9SN4tyhq+A2RrN/Ws5F0Z5aMHDp98Fl86lX8Oti8B7uN93L4Ifv4fHOEA+pQw87gmMO/lQ==",
+      "dev": true
     },
     "node_modules/node-libs-browser/node_modules/readable-stream": {
       "version": "2.3.7",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
       "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+      "dev": true,
       "dependencies": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -10992,6 +11600,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.2.tgz",
       "integrity": "sha512-nX6hmklHs/gr2FuxYDltq8fJA1GDlxKQCz8O/IM4atRqBH8OORmBNgfvW5gG10GT/qQ9u0CzIvr2X5Pkt6ntqg==",
+      "dev": true,
       "dependencies": {
         "inherits": "~2.0.1",
         "readable-stream": "^2.0.2"
@@ -11001,6 +11610,7 @@
       "version": "2.8.3",
       "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.8.3.tgz",
       "integrity": "sha512-+TSkfINHDo4J+ZobQLWiMouQYB+UVYFttRA94FpEzzJ7ZdqcL4uUUQ7WkdkI4DSozGmgBUE/a47L+38PenXhUw==",
+      "dev": true,
       "dependencies": {
         "builtin-status-codes": "^3.0.0",
         "inherits": "^2.0.1",
@@ -11013,6 +11623,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
@@ -11020,12 +11631,14 @@
     "node_modules/node-libs-browser/node_modules/tty-browserify": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
-      "integrity": "sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY="
+      "integrity": "sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY=",
+      "dev": true
     },
     "node_modules/node-libs-browser/node_modules/util": {
       "version": "0.11.1",
       "resolved": "https://registry.npmjs.org/util/-/util-0.11.1.tgz",
       "integrity": "sha512-HShAsny+zS2TZfaXxD9tYj4HQGlBezXZMZuM/S5PKLLoZkShZiGk9o5CzukI1LVHZvjdvZ2Sj1aW/Ndn2NB/HQ==",
+      "dev": true,
       "dependencies": {
         "inherits": "2.0.3"
       }
@@ -11591,6 +12204,7 @@
       "version": "1.6.4",
       "resolved": "https://registry.npmjs.org/pnp-webpack-plugin/-/pnp-webpack-plugin-1.6.4.tgz",
       "integrity": "sha512-7Wjy+9E3WwLOEL30D+m8TSTF7qJJUJLONBnwQp0518siuMxUQUbgZwssaFX+QKlZkjHZcw/IpZCt/H0srrntSg==",
+      "dev": true,
       "dependencies": {
         "ts-pnp": "^1.1.6"
       },
@@ -11756,7 +12370,8 @@
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "dev": true
     },
     "node_modules/progress": {
       "version": "2.0.3",
@@ -11838,13 +12453,15 @@
     "node_modules/punycode": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+      "dev": true
     },
     "node_modules/querystring": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.1.tgz",
       "integrity": "sha512-wkvS7mL/JMugcup3/rMitHmd9ecIGd2lhFhK9N3UUQ450h66d1r3Y9nvXzQAW1Lq+wyx61k/1pfKS5KuKiyEbg==",
       "deprecated": "The querystring API is considered Legacy. new code should use the URLSearchParams API instead.",
+      "dev": true,
       "engines": {
         "node": ">=0.4.x"
       }
@@ -12355,9 +12972,9 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "node_modules/sass": {
-      "version": "1.43.2",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.43.2.tgz",
-      "integrity": "sha512-DncYhjl3wBaPMMJR0kIUaH3sF536rVrOcqqVGmTZHQRRzj7LQlyGV7Mb8aCKFyILMr5VsPHwRYtyKpnKYlmQSQ==",
+      "version": "1.43.4",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.43.4.tgz",
+      "integrity": "sha512-/ptG7KE9lxpGSYiXn7Ar+lKOv37xfWsZRtFYal2QHNigyVQDx685VFT/h7ejVr+R8w7H4tmUgtulsKl5YpveOg==",
       "dependencies": {
         "chokidar": ">=3.0.0 <4.0.0"
       },
@@ -12511,7 +13128,8 @@
     "node_modules/shell-quote": {
       "version": "1.7.2",
       "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.2.tgz",
-      "integrity": "sha512-mRz/m/JVscCrkMyPqHc/bczi3OQHkLTqXHEFu0zDhK/qfv3UcOA4SVmRCLmos4bhjr9ekVQubj/R7waKapmiQg=="
+      "integrity": "sha512-mRz/m/JVscCrkMyPqHc/bczi3OQHkLTqXHEFu0zDhK/qfv3UcOA4SVmRCLmos4bhjr9ekVQubj/R7waKapmiQg==",
+      "dev": true
     },
     "node_modules/side-channel": {
       "version": "1.0.4",
@@ -13006,6 +13624,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-4.0.1.tgz",
       "integrity": "sha512-Gcb49/dRB1k8B4hdK8vhW27Rlb2zujCk1fISrizCcToIs+55B4vmUM0N9Gi4nnVfFZWe55jRdWpAqH1ldAKWvQ==",
+      "dev": true,
       "dependencies": {
         "@babel/plugin-syntax-jsx": "7.14.5",
         "@babel/types": "7.15.0",
@@ -13032,6 +13651,7 @@
       "version": "7.15.0",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.0.tgz",
       "integrity": "sha512-OBvfqnllOIdX4ojTHpwZbpvz4j3EWyjkZEdmjH0/cgsd6QOdSgU8rLSk6ard/pcW7rlmjdVSX/AWOaORR1uNOQ==",
+      "dev": true,
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.14.9",
         "to-fast-properties": "^2.0.0"
@@ -13044,6 +13664,7 @@
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
       "integrity": "sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==",
+      "dev": true,
       "dependencies": {
         "safe-buffer": "~5.1.1"
       }
@@ -13052,6 +13673,7 @@
       "version": "0.7.3",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
       "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
+      "dev": true,
       "engines": {
         "node": ">= 8"
       }
@@ -13392,7 +14014,8 @@
     "node_modules/to-arraybuffer": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz",
-      "integrity": "sha1-fSKbH8xjfkZsoIEYCDanqr/4P0M="
+      "integrity": "sha1-fSKbH8xjfkZsoIEYCDanqr/4P0M=",
+      "dev": true
     },
     "node_modules/to-fast-properties": {
       "version": "2.0.0",
@@ -13676,6 +14299,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/ts-pnp/-/ts-pnp-1.2.0.tgz",
       "integrity": "sha512-csd+vJOb/gkzvcCHgTGSChYpy5f1/XKNsmvBGO4JXS+z1v2HobugDz4s1IeFXM3wZB44uczs+eazB5Q/ccdhQw==",
+      "dev": true,
       "engines": {
         "node": ">=6"
       },
@@ -13984,6 +14608,7 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
       "integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
+      "dev": true,
       "dependencies": {
         "punycode": "1.3.2",
         "querystring": "0.2.0"
@@ -13992,13 +14617,15 @@
     "node_modules/url/node_modules/punycode": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
-      "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
+      "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
+      "dev": true
     },
     "node_modules/url/node_modules/querystring": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
       "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
       "deprecated": "The querystring API is considered Legacy. new code should use the URLSearchParams API instead.",
+      "dev": true,
       "engines": {
         "node": ">=0.4.x"
       }
@@ -14596,7 +15223,7 @@
     },
     "packages/core": {
       "name": "@faustjs/core",
-      "version": "0.12.4",
+      "version": "0.13.1",
       "license": "MIT",
       "dependencies": {
         "cookie": "^0.4.1",
@@ -15200,11 +15827,11 @@
     },
     "packages/next": {
       "name": "@faustjs/next",
-      "version": "0.13.0",
+      "version": "0.13.1",
       "license": "MIT",
       "dependencies": {
-        "@faustjs/core": "^0.12.4",
-        "@faustjs/react": "^0.12.4",
+        "@faustjs/core": "^0.13.1",
+        "@faustjs/react": "^0.13.1",
         "@gqty/logger": "^2.0.1",
         "@gqty/react": "^2.1.0",
         "graphql": ">=15.6",
@@ -15829,10 +16456,10 @@
     },
     "packages/react": {
       "name": "@faustjs/react",
-      "version": "0.12.4",
+      "version": "0.13.1",
       "license": "MIT",
       "dependencies": {
-        "@faustjs/core": "^0.12.4",
+        "@faustjs/core": "^0.13.1",
         "@gqty/react": "^2.1.0",
         "gqty": "^2.1.0",
         "graphql": ">=15.6",
@@ -17778,8 +18405,8 @@
     "@faustjs/next": {
       "version": "file:packages/next",
       "requires": {
-        "@faustjs/core": "^0.12.4",
-        "@faustjs/react": "^0.12.4",
+        "@faustjs/core": "^0.13.1",
+        "@faustjs/react": "^0.13.1",
         "@gqty/logger": "^2.0.1",
         "@gqty/react": "^2.1.0",
         "@testing-library/jest-dom": "^5.15.0",
@@ -18207,7 +18834,7 @@
     "@faustjs/react": {
       "version": "file:packages/react",
       "requires": {
-        "@faustjs/core": "^0.12.4",
+        "@faustjs/core": "^0.13.1",
         "@gqty/react": "^2.1.0",
         "@testing-library/jest-dom": "^5.15.0",
         "@testing-library/react": "^12.1.2",
@@ -19417,12 +20044,13 @@
     "@next/env": {
       "version": "11.1.2",
       "resolved": "https://registry.npmjs.org/@next/env/-/env-11.1.2.tgz",
-      "integrity": "sha512-+fteyVdQ7C/OoulfcF6vd1Yk0FEli4453gr8kSFbU8sKseNSizYq6df5MKz/AjwLptsxrUeIkgBdAzbziyJ3mA=="
+      "integrity": "sha512-+fteyVdQ7C/OoulfcF6vd1Yk0FEli4453gr8kSFbU8sKseNSizYq6df5MKz/AjwLptsxrUeIkgBdAzbziyJ3mA==",
+      "dev": true
     },
     "@next/eslint-plugin-next": {
-      "version": "11.1.2",
-      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-11.1.2.tgz",
-      "integrity": "sha512-cN+ojHRsufr9Yz0rtvjv8WI5En0RPZRJnt0y16Ha7DD+0n473evz8i1ETEJHmOLeR7iPJR0zxRrxeTN/bJMOjg==",
+      "version": "12.0.3",
+      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-12.0.3.tgz",
+      "integrity": "sha512-P7i+bMypneQcoRN+CX79xssvvIJCaw7Fndzbe7/lB0+LyRbVvGVyMUsFmLLbSxtZq4hvFMJ1p8wML/gsulMZWQ==",
       "dev": true,
       "requires": {
         "glob": "7.1.7"
@@ -19447,12 +20075,14 @@
     "@next/polyfill-module": {
       "version": "11.1.2",
       "resolved": "https://registry.npmjs.org/@next/polyfill-module/-/polyfill-module-11.1.2.tgz",
-      "integrity": "sha512-xZmixqADM3xxtqBV0TpAwSFzWJP0MOQzRfzItHXf1LdQHWb0yofHHC+7eOrPFic8+ZGz5y7BdPkkgR1S25OymA=="
+      "integrity": "sha512-xZmixqADM3xxtqBV0TpAwSFzWJP0MOQzRfzItHXf1LdQHWb0yofHHC+7eOrPFic8+ZGz5y7BdPkkgR1S25OymA==",
+      "dev": true
     },
     "@next/react-dev-overlay": {
       "version": "11.1.2",
       "resolved": "https://registry.npmjs.org/@next/react-dev-overlay/-/react-dev-overlay-11.1.2.tgz",
       "integrity": "sha512-rDF/mGY2NC69mMg2vDqzVpCOlWqnwPUXB2zkARhvknUHyS6QJphPYv9ozoPJuoT/QBs49JJd9KWaAzVBvq920A==",
+      "dev": true,
       "requires": {
         "@babel/code-frame": "7.12.11",
         "anser": "1.4.9",
@@ -19471,6 +20101,7 @@
           "version": "7.12.11",
           "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
           "integrity": "sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==",
+          "dev": true,
           "requires": {
             "@babel/highlight": "^7.10.4"
           }
@@ -19479,6 +20110,7 @@
           "version": "4.3.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
           "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
           "requires": {
             "color-convert": "^2.0.1"
           }
@@ -19487,6 +20119,7 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.0.0.tgz",
           "integrity": "sha512-N9oWFcegS0sFr9oh1oz2d7Npos6vNoWW9HvtCg5N1KRFpUhaAhvTv5Y58g880fZaEYSNm3qDz8SU1UrGvp+n7A==",
+          "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
             "supports-color": "^7.1.0"
@@ -19496,6 +20129,7 @@
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
           "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
           "requires": {
             "color-name": "~1.1.4"
           }
@@ -19503,17 +20137,20 @@
         "color-name": {
           "version": "1.1.4",
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
         },
         "has-flag": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
         },
         "source-map": {
           "version": "0.8.0-beta.0",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.8.0-beta.0.tgz",
           "integrity": "sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA==",
+          "dev": true,
           "requires": {
             "whatwg-url": "^7.0.0"
           }
@@ -19522,6 +20159,7 @@
           "version": "6.0.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
           "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "dev": true,
           "requires": {
             "ansi-regex": "^5.0.0"
           }
@@ -19530,6 +20168,7 @@
           "version": "7.2.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
           "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
           "requires": {
             "has-flag": "^4.0.0"
           }
@@ -19537,12 +20176,14 @@
         "webidl-conversions": {
           "version": "4.0.2",
           "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
-          "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg=="
+          "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
+          "dev": true
         },
         "whatwg-url": {
           "version": "7.1.0",
           "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
           "integrity": "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==",
+          "dev": true,
           "requires": {
             "lodash.sortby": "^4.7.0",
             "tr46": "^1.0.1",
@@ -19555,36 +20196,88 @@
       "version": "11.1.2",
       "resolved": "https://registry.npmjs.org/@next/react-refresh-utils/-/react-refresh-utils-11.1.2.tgz",
       "integrity": "sha512-hsoJmPfhVqjZ8w4IFzoo8SyECVnN+8WMnImTbTKrRUHOVJcYMmKLL7xf7T0ft00tWwAl/3f3Q3poWIN2Ueql/Q==",
+      "dev": true,
       "requires": {}
+    },
+    "@next/swc-android-arm64": {
+      "version": "12.0.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-12.0.3.tgz",
+      "integrity": "sha512-40sOl9/50aamX0dEMrecqJQcUrRK47D7S9F66ulrZmz+5Ujp0lnP1rBOXngo0PZMecfU1tr7zbNubiAMDxfCxw==",
+      "optional": true
     },
     "@next/swc-darwin-arm64": {
       "version": "11.1.2",
       "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-11.1.2.tgz",
       "integrity": "sha512-hZuwOlGOwBZADA8EyDYyjx3+4JGIGjSHDHWrmpI7g5rFmQNltjlbaefAbiU5Kk7j3BUSDwt30quJRFv3nyJQ0w==",
-      "optional": true
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "@next/swc-darwin-x64": {
       "version": "11.1.2",
       "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-11.1.2.tgz",
       "integrity": "sha512-PGOp0E1GisU+EJJlsmJVGE+aPYD0Uh7zqgsrpD3F/Y3766Ptfbe1lEPPWnRDl+OzSSrSrX1lkyM/Jlmh5OwNvA==",
+      "dev": true,
+      "optional": true,
+      "peer": true
+    },
+    "@next/swc-linux-arm-gnueabihf": {
+      "version": "12.0.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-12.0.3.tgz",
+      "integrity": "sha512-2HNPhBJuN9L6JzqqqdYB4TKfFFmaKkpF0X3C1s83Xp61mR2sx8gOthHQtZqWDs4ZLnKZU0j2flGU1uuqpHPCpg==",
+      "optional": true
+    },
+    "@next/swc-linux-arm64-gnu": {
+      "version": "12.0.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-12.0.3.tgz",
+      "integrity": "sha512-NXTON1XK7zi2i+A+bY1PVLi1g5b8cSwgzbnuVR0vAgOtU+3at7FqAKOWfuFIXY7eBEK65uu0Fu5gADhMj0uanQ==",
+      "optional": true
+    },
+    "@next/swc-linux-arm64-musl": {
+      "version": "12.0.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-12.0.3.tgz",
+      "integrity": "sha512-8D0q22VavhcIl2ZQErEffgh5q6mChaG84uTluAoFfjwrgYtPDZX0M5StqkTZL6T5gA5RLHboNVoscIKGZWMojQ==",
       "optional": true
     },
     "@next/swc-linux-x64-gnu": {
       "version": "11.1.2",
       "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-11.1.2.tgz",
       "integrity": "sha512-YcDHTJjn/8RqvyJVB6pvEKXihDcdrOwga3GfMv/QtVeLphTouY4BIcEUfrG5+26Nf37MP1ywN3RRl1TxpurAsQ==",
+      "dev": true,
+      "optional": true,
+      "peer": true
+    },
+    "@next/swc-linux-x64-musl": {
+      "version": "12.0.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-12.0.3.tgz",
+      "integrity": "sha512-MXvx+IDYoSsSM7KcwbQAVo9r+ZeklHeDQiUEmyRRzQE1Q4JvkWwMdPu/NfFdyxur+RfKjRoUoWFdPi5MBKTpkw==",
+      "optional": true
+    },
+    "@next/swc-win32-arm64-msvc": {
+      "version": "12.0.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-12.0.3.tgz",
+      "integrity": "sha512-8GusumFZLp/mtVix+3JZVTGqzqntTsrTIFZ+GpcLMwyVjB3KkBwHiwJaa38WGleUinJSpJvgmhTWgppsiSKW3A==",
+      "optional": true
+    },
+    "@next/swc-win32-ia32-msvc": {
+      "version": "12.0.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-12.0.3.tgz",
+      "integrity": "sha512-mF7bkxSZ++QiB+E0HFqay/etvPF+ZFcCuG27lSwFIM00J+TE0IRqMyMx66vJ8g1h6khpwXPI0o2hrwIip/r8cQ==",
       "optional": true
     },
     "@next/swc-win32-x64-msvc": {
       "version": "11.1.2",
       "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-11.1.2.tgz",
       "integrity": "sha512-e/pIKVdB+tGQYa1cW3sAeHm8gzEri/HYLZHT4WZojrUxgWXqx8pk7S7Xs47uBcFTqBDRvK3EcQpPLf3XdVsDdg==",
-      "optional": true
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "@node-rs/helper": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@node-rs/helper/-/helper-1.2.1.tgz",
       "integrity": "sha512-R5wEmm8nbuQU0YGGmYVjEc0OHtYsuXdpRG+Ut/3wZ9XAvQWyThN08bTh2cBJgoZxHQUPtvRfeQuxcAgLuiBISg==",
+      "dev": true,
       "requires": {
         "@napi-rs/triples": "^1.0.3"
       }
@@ -20568,7 +21261,8 @@
     "ast-types": {
       "version": "0.13.2",
       "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.2.tgz",
-      "integrity": "sha512-uWMHxJxtfj/1oZClOxDEV1sQ1HCDkA4MG8Gr69KKeBjEVH0R84WlejZ0y2DcwyBlpAEMltmVYkVgqfLFb2oyiA=="
+      "integrity": "sha512-uWMHxJxtfj/1oZClOxDEV1sQ1HCDkA4MG8Gr69KKeBjEVH0R84WlejZ0y2DcwyBlpAEMltmVYkVgqfLFb2oyiA==",
+      "dev": true
     },
     "ast-types-flow": {
       "version": "0.0.7",
@@ -21333,7 +22027,8 @@
     "console-browserify": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.2.0.tgz",
-      "integrity": "sha512-ZMkYO/LkF17QvCPqM0gxw8yUzigAOZOSWSHg91FH6orS7vcEj5dVZTidN2fQ14yBSdg97RqhSNwLUXInd52OTA=="
+      "integrity": "sha512-ZMkYO/LkF17QvCPqM0gxw8yUzigAOZOSWSHg91FH6orS7vcEj5dVZTidN2fQ14yBSdg97RqhSNwLUXInd52OTA==",
+      "dev": true
     },
     "constant-case": {
       "version": "3.0.4",
@@ -21379,7 +22074,8 @@
     "core-util-is": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
-      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "dev": true
     },
     "cosmiconfig": {
       "version": "7.0.1",
@@ -22308,12 +23004,12 @@
       }
     },
     "eslint-config-next": {
-      "version": "11.1.2",
-      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-11.1.2.tgz",
-      "integrity": "sha512-dFutecxX2Z5/QVlLwdtKt+gIfmNMP8Qx6/qZh3LM/DFVdGJEAnUKrr4VwGmACB2kx/PQ5bx3R+QxnEg4fDPiTg==",
+      "version": "12.0.3",
+      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-12.0.3.tgz",
+      "integrity": "sha512-q+mX6jhk3HrCo39G18MLhiC6f8zJnTA00f30RSuVUWsv45SQUm6r62oXVqrbAgMEybe0yx/GDRvfA6LvSolw6Q==",
       "dev": true,
       "requires": {
-        "@next/eslint-plugin-next": "11.1.2",
+        "@next/eslint-plugin-next": "12.0.3",
         "@rushstack/eslint-patch": "^1.0.6",
         "@typescript-eslint/parser": "^4.20.0",
         "eslint-import-resolver-node": "^0.3.4",
@@ -23642,7 +24338,8 @@
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
     },
     "isexe": {
       "version": "2.0.0",
@@ -25844,6 +26541,7 @@
       "version": "0.3.4",
       "resolved": "https://registry.npmjs.org/native-url/-/native-url-0.3.4.tgz",
       "integrity": "sha512-6iM8R99ze45ivyH8vybJ7X0yekIcPf5GgLV5K0ENCbmRcaRIDoj37BC8iLEmaaBfqqb8enuZ5p0uhY+lVAbAcA==",
+      "dev": true,
       "requires": {
         "querystring": "^0.2.0"
       }
@@ -25865,6 +26563,7 @@
       "version": "11.1.2",
       "resolved": "https://registry.npmjs.org/next/-/next-11.1.2.tgz",
       "integrity": "sha512-azEYL0L+wFjv8lstLru3bgvrzPvK0P7/bz6B/4EJ9sYkXeW8r5Bjh78D/Ol7VOg0EIPz0CXoe72hzAlSAXo9hw==",
+      "dev": true,
       "requires": {
         "@babel/runtime": "7.15.3",
         "@hapi/accept": "5.0.2",
@@ -25926,8 +26625,191 @@
           "version": "7.15.3",
           "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.15.3.tgz",
           "integrity": "sha512-OvwMLqNXkCXSz1kSm58sEsNuhqOx/fKpnUnKnFB5v8uDda5bLNEHNgKPvhDN6IU0LDcnHQ90LlJ0Q6jnyBSIBA==",
+          "dev": true,
           "requires": {
             "regenerator-runtime": "^0.13.4"
+          }
+        },
+        "browserslist": {
+          "version": "4.16.6",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.6.tgz",
+          "integrity": "sha512-Wspk/PqO+4W9qp5iUTJsa1B/QrYn1keNCcEP5OvP7WBwT4KaDly0uONYmC6Xa3Z5IqnUgS0KcgLYu1l74x0ZXQ==",
+          "dev": true,
+          "requires": {
+            "caniuse-lite": "^1.0.30001219",
+            "colorette": "^1.2.2",
+            "electron-to-chromium": "^1.3.723",
+            "escalade": "^3.1.1",
+            "node-releases": "^1.1.71"
+          }
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "jest-worker": {
+          "version": "27.0.0-next.5",
+          "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.0.0-next.5.tgz",
+          "integrity": "sha512-mk0umAQ5lT+CaOJ+Qp01N6kz48sJG2kr2n1rX0koqKf6FIygQV0qLOdN9SCYID4IVeSigDOcPeGLozdMLYfb5g==",
+          "dev": true,
+          "requires": {
+            "@types/node": "*",
+            "merge-stream": "^2.0.0",
+            "supports-color": "^8.0.0"
+          }
+        },
+        "node-releases": {
+          "version": "1.1.77",
+          "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.77.tgz",
+          "integrity": "sha512-rB1DUFUNAN4Gn9keO2K1efO35IDK7yKHCdCaIMvFO7yUYmmZYeDjnGKle26G4rwj+LKRQpjyUUvMkPglwGCYNQ==",
+          "dev": true
+        },
+        "p-limit": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+          "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+          "dev": true,
+          "requires": {
+            "yocto-queue": "^0.1.0"
+          }
+        },
+        "supports-color": {
+          "version": "8.1.1",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+          "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "next-headless-getting-started": {
+      "version": "file:examples/next/getting-started",
+      "requires": {
+        "@faustjs/core": "^0.13.1",
+        "@faustjs/next": "^0.13.1",
+        "@gqty/cli": "^2.3.0",
+        "@types/react": "^17.0.34",
+        "dotenv-flow": "3.2.0",
+        "eslint": "^7.32.0",
+        "eslint-config-next": "^12.0.3",
+        "next": "^12.0.3",
+        "normalize.css": "^8.0.1",
+        "react": "^17.0.2",
+        "react-dom": "^17.0.2",
+        "rimraf": "^3.0.2",
+        "sass": "^1.43.4",
+        "typescript": "^4.4.4"
+      },
+      "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.12.11",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
+          "integrity": "sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==",
+          "requires": {
+            "@babel/highlight": "^7.10.4"
+          }
+        },
+        "@babel/types": {
+          "version": "7.15.0",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.0.tgz",
+          "integrity": "sha512-OBvfqnllOIdX4ojTHpwZbpvz4j3EWyjkZEdmjH0/cgsd6QOdSgU8rLSk6ard/pcW7rlmjdVSX/AWOaORR1uNOQ==",
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.14.9",
+            "to-fast-properties": "^2.0.0"
+          }
+        },
+        "@next/env": {
+          "version": "12.0.3",
+          "resolved": "https://registry.npmjs.org/@next/env/-/env-12.0.3.tgz",
+          "integrity": "sha512-QcdlpcwIH9dYcVlNAU+gXaqHA/omskbRlb+R3vN7LlB2EgLt+9WQwbokcHOsNyt4pI7kDM67W4tr9l7dWnlGdQ=="
+        },
+        "@next/polyfill-module": {
+          "version": "12.0.3",
+          "resolved": "https://registry.npmjs.org/@next/polyfill-module/-/polyfill-module-12.0.3.tgz",
+          "integrity": "sha512-fgjVjdCk0Jq627d/N33oQIJjWrcKtzw6Dfa2PfypoIJ35/xFIKgs6mPyvq8cg3Ao5b7dEn9+Rw45PGjlY5e7JA=="
+        },
+        "@next/react-dev-overlay": {
+          "version": "12.0.3",
+          "resolved": "https://registry.npmjs.org/@next/react-dev-overlay/-/react-dev-overlay-12.0.3.tgz",
+          "integrity": "sha512-gHfDEVHFeTUpQMcyytzvkuOu+5DQXjXbCbQHuavFftYrlHqXfzYFsa+wERff+g4/0IzEvcYVp3F4gdmynWfUog==",
+          "requires": {
+            "@babel/code-frame": "7.12.11",
+            "anser": "1.4.9",
+            "chalk": "4.0.0",
+            "classnames": "2.2.6",
+            "css.escape": "1.5.1",
+            "data-uri-to-buffer": "3.0.1",
+            "platform": "1.3.6",
+            "shell-quote": "1.7.3",
+            "source-map": "0.8.0-beta.0",
+            "stacktrace-parser": "0.1.10",
+            "strip-ansi": "6.0.1"
+          },
+          "dependencies": {
+            "chalk": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.0.0.tgz",
+              "integrity": "sha512-N9oWFcegS0sFr9oh1oz2d7Npos6vNoWW9HvtCg5N1KRFpUhaAhvTv5Y58g880fZaEYSNm3qDz8SU1UrGvp+n7A==",
+              "requires": {
+                "ansi-styles": "^4.1.0",
+                "supports-color": "^7.1.0"
+              }
+            },
+            "supports-color": {
+              "version": "7.2.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+              "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+              "requires": {
+                "has-flag": "^4.0.0"
+              }
+            }
+          }
+        },
+        "@next/react-refresh-utils": {
+          "version": "12.0.3",
+          "resolved": "https://registry.npmjs.org/@next/react-refresh-utils/-/react-refresh-utils-12.0.3.tgz",
+          "integrity": "sha512-YPtlfvkYh/4MvNNm5w3uwo+1KPMg67snzr5CuexbRewsu2ITaF7f0bh0Jcayi20wztk8SgWjNz1bmF8j9qbWIw==",
+          "requires": {}
+        },
+        "@next/swc-darwin-arm64": {
+          "version": "12.0.3",
+          "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-12.0.3.tgz",
+          "integrity": "sha512-iKSe2hCMB51Ft41cNAxZk6St1rBlqSRtBSl4oO0zJlGu7bCxXCGCJ058/OLvYxcNWgz7ODOApObm3Yjv8XEvxg==",
+          "optional": true
+        },
+        "@next/swc-darwin-x64": {
+          "version": "12.0.3",
+          "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-12.0.3.tgz",
+          "integrity": "sha512-/BcnfLyhIj4rgU3yVDfD8uXK2TcNYIdflYHKkjFxd3/J1GWOtBN31m0dB8fL0h5LdW11kzaXvVvab3f5ilkEww==",
+          "optional": true
+        },
+        "@next/swc-linux-x64-gnu": {
+          "version": "12.0.3",
+          "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-12.0.3.tgz",
+          "integrity": "sha512-4mkimH9nMzbuQfLmZ152NYSHdrII9AeqrkrHszexL1Lup2TLMPuxlXj55eVnyyeKFXRLlnqbCu7aOIND68RbOA==",
+          "optional": true
+        },
+        "@next/swc-win32-x64-msvc": {
+          "version": "12.0.3",
+          "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-12.0.3.tgz",
+          "integrity": "sha512-eXFwyf46UFFggMQ3k2tJsOmB3SuKjWaSiZJH0tTDUsLw74lyqyzJqMCVA4yY0gWSlEnSjmX5nrCBknVZd3joaA==",
+          "optional": true
+        },
+        "acorn": {
+          "version": "8.5.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.5.0.tgz",
+          "integrity": "sha512-yXbYeFy+jUuYd3/CDcg2NkIYE991XYX/bje7LmjJigUciaeO1JR4XxXgCIV1/Zc/dRuFEyw1L0pbA+qynJkW5Q=="
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "requires": {
+            "color-convert": "^2.0.1"
           }
         },
         "browserslist": {
@@ -25940,6 +26822,27 @@
             "electron-to-chromium": "^1.3.723",
             "escalade": "^3.1.1",
             "node-releases": "^1.1.71"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
+        "convert-source-map": {
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
+          "integrity": "sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==",
+          "requires": {
+            "safe-buffer": "~5.1.1"
           }
         },
         "has-flag": {
@@ -25957,6 +26860,73 @@
             "supports-color": "^8.0.0"
           }
         },
+        "next": {
+          "version": "12.0.3",
+          "resolved": "https://registry.npmjs.org/next/-/next-12.0.3.tgz",
+          "integrity": "sha512-GGdhTBcerdMZbitrO67IVetmB+AHa2X69xrkXKClUT8SRu8pEVto/2QMSnfI+uYc5czCUWPsVtVY3aMoMRMaCA==",
+          "requires": {
+            "@babel/runtime": "7.15.4",
+            "@hapi/accept": "5.0.2",
+            "@napi-rs/triples": "1.0.3",
+            "@next/env": "12.0.3",
+            "@next/polyfill-module": "12.0.3",
+            "@next/react-dev-overlay": "12.0.3",
+            "@next/react-refresh-utils": "12.0.3",
+            "@next/swc-android-arm64": "12.0.3",
+            "@next/swc-darwin-arm64": "12.0.3",
+            "@next/swc-darwin-x64": "12.0.3",
+            "@next/swc-linux-arm-gnueabihf": "12.0.3",
+            "@next/swc-linux-arm64-gnu": "12.0.3",
+            "@next/swc-linux-arm64-musl": "12.0.3",
+            "@next/swc-linux-x64-gnu": "12.0.3",
+            "@next/swc-linux-x64-musl": "12.0.3",
+            "@next/swc-win32-arm64-msvc": "12.0.3",
+            "@next/swc-win32-ia32-msvc": "12.0.3",
+            "@next/swc-win32-x64-msvc": "12.0.3",
+            "acorn": "8.5.0",
+            "assert": "2.0.0",
+            "browserify-zlib": "0.2.0",
+            "browserslist": "4.16.6",
+            "buffer": "5.6.0",
+            "caniuse-lite": "^1.0.30001228",
+            "chalk": "2.4.2",
+            "chokidar": "3.5.1",
+            "constants-browserify": "1.0.0",
+            "crypto-browserify": "3.12.0",
+            "cssnano-simple": "3.0.0",
+            "domain-browser": "4.19.0",
+            "encoding": "0.1.13",
+            "etag": "1.8.1",
+            "events": "3.3.0",
+            "find-cache-dir": "3.3.1",
+            "get-orientation": "1.1.2",
+            "https-browserify": "1.0.0",
+            "image-size": "1.0.0",
+            "jest-worker": "27.0.0-next.5",
+            "node-fetch": "2.6.1",
+            "node-html-parser": "1.4.9",
+            "os-browserify": "0.3.0",
+            "p-limit": "3.1.0",
+            "path-browserify": "1.0.1",
+            "postcss": "8.2.15",
+            "process": "0.11.10",
+            "querystring-es3": "0.2.1",
+            "raw-body": "2.4.1",
+            "react-is": "17.0.2",
+            "react-refresh": "0.8.3",
+            "regenerator-runtime": "0.13.4",
+            "stream-browserify": "3.0.0",
+            "stream-http": "3.1.1",
+            "string_decoder": "1.3.0",
+            "styled-jsx": "5.0.0-beta.3",
+            "timers-browserify": "2.0.12",
+            "tty-browserify": "0.0.1",
+            "use-subscription": "1.5.1",
+            "util": "0.12.4",
+            "vm-browserify": "1.1.2",
+            "watchpack": "2.1.1"
+          }
+        },
         "node-releases": {
           "version": "1.1.77",
           "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.77.tgz",
@@ -25970,6 +26940,54 @@
             "yocto-queue": "^0.1.0"
           }
         },
+        "regenerator-runtime": {
+          "version": "0.13.4",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.4.tgz",
+          "integrity": "sha512-plpwicqEzfEyTQohIKktWigcLzmNStMGwbOUbykx51/29Z3JOGYldaaNGK7ngNXV+UcoqvIMmloZ48Sr74sd+g=="
+        },
+        "shell-quote": {
+          "version": "1.7.3",
+          "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.3.tgz",
+          "integrity": "sha512-Vpfqwm4EnqGdlsBFNmHhxhElJYrdfcxPThu+ryKS5J8L/fhAwLazFZtq+S+TWZ9ANj2piSQLGj6NQg+lKPmxrw=="
+        },
+        "source-map": {
+          "version": "0.8.0-beta.0",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.8.0-beta.0.tgz",
+          "integrity": "sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA==",
+          "requires": {
+            "whatwg-url": "^7.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+          "requires": {
+            "ansi-regex": "^5.0.1"
+          }
+        },
+        "styled-jsx": {
+          "version": "5.0.0-beta.3",
+          "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.0.0-beta.3.tgz",
+          "integrity": "sha512-HtDDGSFPvmjHIqWf9n8Oo54tAoY/DTplvlyOH2+YOtD80Sp31Ap8ffSmxhgk5EkUoJ7xepdXMGT650mSffWuRA==",
+          "requires": {
+            "@babel/plugin-syntax-jsx": "7.14.5",
+            "@babel/types": "7.15.0",
+            "convert-source-map": "1.7.0",
+            "loader-utils": "1.2.3",
+            "source-map": "0.7.3",
+            "string-hash": "1.1.3",
+            "stylis": "3.5.4",
+            "stylis-rule-sheet": "0.0.10"
+          },
+          "dependencies": {
+            "source-map": {
+              "version": "0.7.3",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
+              "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ=="
+            }
+          }
+        },
         "supports-color": {
           "version": "8.1.1",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
@@ -25977,26 +26995,22 @@
           "requires": {
             "has-flag": "^4.0.0"
           }
+        },
+        "webidl-conversions": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
+          "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg=="
+        },
+        "whatwg-url": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
+          "integrity": "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==",
+          "requires": {
+            "lodash.sortby": "^4.7.0",
+            "tr46": "^1.0.1",
+            "webidl-conversions": "^4.0.2"
+          }
         }
-      }
-    },
-    "next-headless-getting-started": {
-      "version": "file:examples/next/getting-started",
-      "requires": {
-        "@faustjs/core": "^0.12.4",
-        "@faustjs/next": "^0.13.0",
-        "@gqty/cli": "^2.0.1",
-        "@types/react": "^17.0.24",
-        "dotenv-flow": "3.2.0",
-        "eslint": "^7.32.0",
-        "eslint-config-next": "^11.1.2",
-        "next": "^11.1.2",
-        "normalize.css": "^8.0.1",
-        "react": "^17.0.2",
-        "react-dom": "^17.0.2",
-        "rimraf": "^3.0.2",
-        "sass": "^1.42.1",
-        "typescript": "^4.4.3"
       }
     },
     "no-case": {
@@ -26032,6 +27046,7 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.2.1.tgz",
       "integrity": "sha512-h/zcD8H9kaDZ9ALUWwlBUDo6TKF8a7qBSCSEGfjTVIYeqsioSKaAX+BN7NgiMGp6iSIXZ3PxgCu8KS3b71YK5Q==",
+      "dev": true,
       "requires": {
         "assert": "^1.1.1",
         "browserify-zlib": "^0.2.0",
@@ -26062,6 +27077,7 @@
           "version": "1.5.0",
           "resolved": "https://registry.npmjs.org/assert/-/assert-1.5.0.tgz",
           "integrity": "sha512-EDsgawzwoun2CZkCgtxJbv392v4nbk9XDD06zI+kQYoBM/3RBWLlEyJARDOmhAAosBjWACEkKL6S+lIZtcAubA==",
+          "dev": true,
           "requires": {
             "object-assign": "^4.1.1",
             "util": "0.10.3"
@@ -26070,12 +27086,14 @@
             "inherits": {
               "version": "2.0.1",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-              "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
+              "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
+              "dev": true
             },
             "util": {
               "version": "0.10.3",
               "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
               "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
+              "dev": true,
               "requires": {
                 "inherits": "2.0.1"
               }
@@ -26086,6 +27104,7 @@
           "version": "4.9.2",
           "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
           "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
+          "dev": true,
           "requires": {
             "base64-js": "^1.0.2",
             "ieee754": "^1.1.4",
@@ -26095,22 +27114,26 @@
         "domain-browser": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.2.0.tgz",
-          "integrity": "sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA=="
+          "integrity": "sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA==",
+          "dev": true
         },
         "inherits": {
           "version": "2.0.3",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+          "dev": true
         },
         "path-browserify": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.1.tgz",
-          "integrity": "sha512-BapA40NHICOS+USX9SN4tyhq+A2RrN/Ws5F0Z5aMHDp98Fl86lX8Oti8B7uN93L4Ifv4fHOEA+pQw87gmMO/lQ=="
+          "integrity": "sha512-BapA40NHICOS+USX9SN4tyhq+A2RrN/Ws5F0Z5aMHDp98Fl86lX8Oti8B7uN93L4Ifv4fHOEA+pQw87gmMO/lQ==",
+          "dev": true
         },
         "readable-stream": {
           "version": "2.3.7",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
           "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "dev": true,
           "requires": {
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.3",
@@ -26125,6 +27148,7 @@
           "version": "2.0.2",
           "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.2.tgz",
           "integrity": "sha512-nX6hmklHs/gr2FuxYDltq8fJA1GDlxKQCz8O/IM4atRqBH8OORmBNgfvW5gG10GT/qQ9u0CzIvr2X5Pkt6ntqg==",
+          "dev": true,
           "requires": {
             "inherits": "~2.0.1",
             "readable-stream": "^2.0.2"
@@ -26134,6 +27158,7 @@
           "version": "2.8.3",
           "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.8.3.tgz",
           "integrity": "sha512-+TSkfINHDo4J+ZobQLWiMouQYB+UVYFttRA94FpEzzJ7ZdqcL4uUUQ7WkdkI4DSozGmgBUE/a47L+38PenXhUw==",
+          "dev": true,
           "requires": {
             "builtin-status-codes": "^3.0.0",
             "inherits": "^2.0.1",
@@ -26146,6 +27171,7 @@
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "dev": true,
           "requires": {
             "safe-buffer": "~5.1.0"
           }
@@ -26153,12 +27179,14 @@
         "tty-browserify": {
           "version": "0.0.0",
           "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
-          "integrity": "sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY="
+          "integrity": "sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY=",
+          "dev": true
         },
         "util": {
           "version": "0.11.1",
           "resolved": "https://registry.npmjs.org/util/-/util-0.11.1.tgz",
           "integrity": "sha512-HShAsny+zS2TZfaXxD9tYj4HQGlBezXZMZuM/S5PKLLoZkShZiGk9o5CzukI1LVHZvjdvZ2Sj1aW/Ndn2NB/HQ==",
+          "dev": true,
           "requires": {
             "inherits": "2.0.3"
           }
@@ -26591,6 +27619,7 @@
       "version": "1.6.4",
       "resolved": "https://registry.npmjs.org/pnp-webpack-plugin/-/pnp-webpack-plugin-1.6.4.tgz",
       "integrity": "sha512-7Wjy+9E3WwLOEL30D+m8TSTF7qJJUJLONBnwQp0518siuMxUQUbgZwssaFX+QKlZkjHZcw/IpZCt/H0srrntSg==",
+      "dev": true,
       "requires": {
         "ts-pnp": "^1.1.6"
       }
@@ -26699,7 +27728,8 @@
     "process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "dev": true
     },
     "progress": {
       "version": "2.0.3",
@@ -26779,12 +27809,14 @@
     "punycode": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+      "dev": true
     },
     "querystring": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.1.tgz",
-      "integrity": "sha512-wkvS7mL/JMugcup3/rMitHmd9ecIGd2lhFhK9N3UUQ450h66d1r3Y9nvXzQAW1Lq+wyx61k/1pfKS5KuKiyEbg=="
+      "integrity": "sha512-wkvS7mL/JMugcup3/rMitHmd9ecIGd2lhFhK9N3UUQ450h66d1r3Y9nvXzQAW1Lq+wyx61k/1pfKS5KuKiyEbg==",
+      "dev": true
     },
     "querystring-es3": {
       "version": "0.2.1",
@@ -27149,9 +28181,9 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "sass": {
-      "version": "1.43.2",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.43.2.tgz",
-      "integrity": "sha512-DncYhjl3wBaPMMJR0kIUaH3sF536rVrOcqqVGmTZHQRRzj7LQlyGV7Mb8aCKFyILMr5VsPHwRYtyKpnKYlmQSQ==",
+      "version": "1.43.4",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.43.4.tgz",
+      "integrity": "sha512-/ptG7KE9lxpGSYiXn7Ar+lKOv37xfWsZRtFYal2QHNigyVQDx685VFT/h7ejVr+R8w7H4tmUgtulsKl5YpveOg==",
       "requires": {
         "chokidar": ">=3.0.0 <4.0.0"
       }
@@ -27267,7 +28299,8 @@
     "shell-quote": {
       "version": "1.7.2",
       "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.2.tgz",
-      "integrity": "sha512-mRz/m/JVscCrkMyPqHc/bczi3OQHkLTqXHEFu0zDhK/qfv3UcOA4SVmRCLmos4bhjr9ekVQubj/R7waKapmiQg=="
+      "integrity": "sha512-mRz/m/JVscCrkMyPqHc/bczi3OQHkLTqXHEFu0zDhK/qfv3UcOA4SVmRCLmos4bhjr9ekVQubj/R7waKapmiQg==",
+      "dev": true
     },
     "side-channel": {
       "version": "1.0.4",
@@ -27673,6 +28706,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-4.0.1.tgz",
       "integrity": "sha512-Gcb49/dRB1k8B4hdK8vhW27Rlb2zujCk1fISrizCcToIs+55B4vmUM0N9Gi4nnVfFZWe55jRdWpAqH1ldAKWvQ==",
+      "dev": true,
       "requires": {
         "@babel/plugin-syntax-jsx": "7.14.5",
         "@babel/types": "7.15.0",
@@ -27688,6 +28722,7 @@
           "version": "7.15.0",
           "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.0.tgz",
           "integrity": "sha512-OBvfqnllOIdX4ojTHpwZbpvz4j3EWyjkZEdmjH0/cgsd6QOdSgU8rLSk6ard/pcW7rlmjdVSX/AWOaORR1uNOQ==",
+          "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.14.9",
             "to-fast-properties": "^2.0.0"
@@ -27697,6 +28732,7 @@
           "version": "1.7.0",
           "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
           "integrity": "sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==",
+          "dev": true,
           "requires": {
             "safe-buffer": "~5.1.1"
           }
@@ -27704,7 +28740,8 @@
         "source-map": {
           "version": "0.7.3",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
-          "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ=="
+          "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
+          "dev": true
         }
       }
     },
@@ -27962,7 +28999,8 @@
     "to-arraybuffer": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz",
-      "integrity": "sha1-fSKbH8xjfkZsoIEYCDanqr/4P0M="
+      "integrity": "sha1-fSKbH8xjfkZsoIEYCDanqr/4P0M=",
+      "dev": true
     },
     "to-fast-properties": {
       "version": "2.0.0",
@@ -28159,7 +29197,8 @@
     "ts-pnp": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/ts-pnp/-/ts-pnp-1.2.0.tgz",
-      "integrity": "sha512-csd+vJOb/gkzvcCHgTGSChYpy5f1/XKNsmvBGO4JXS+z1v2HobugDz4s1IeFXM3wZB44uczs+eazB5Q/ccdhQw=="
+      "integrity": "sha512-csd+vJOb/gkzvcCHgTGSChYpy5f1/XKNsmvBGO4JXS+z1v2HobugDz4s1IeFXM3wZB44uczs+eazB5Q/ccdhQw==",
+      "dev": true
     },
     "tsconfig-paths": {
       "version": "3.11.0",
@@ -28385,6 +29424,7 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
       "integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
+      "dev": true,
       "requires": {
         "punycode": "1.3.2",
         "querystring": "0.2.0"
@@ -28393,12 +29433,14 @@
         "punycode": {
           "version": "1.3.2",
           "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
-          "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
+          "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
+          "dev": true
         },
         "querystring": {
           "version": "0.2.0",
           "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
-          "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
+          "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
+          "dev": true
         }
       }
     },

--- a/packages/core/src/auth/authorize.ts
+++ b/packages/core/src/auth/authorize.ts
@@ -1,8 +1,8 @@
 import 'isomorphic-fetch';
-import isString from 'lodash/isString';
-import { config } from '../config';
-import { getQueryParam, removeURLParam } from '../utils';
-import { fetchAccessToken } from './client/accessToken';
+import isString from 'lodash/isString.js';
+import { config } from '../config/index.js';
+import { getQueryParam, removeURLParam } from '../utils/index.js';
+import { fetchAccessToken } from './client/accessToken.js';
 
 export interface EnsureAuthorizationOptions {
   redirectUri?: string;

--- a/packages/core/src/auth/client/accessToken.ts
+++ b/packages/core/src/auth/client/accessToken.ts
@@ -1,7 +1,7 @@
-import { config, TOKEN_ENDPOINT_PARTIAL_PATH } from '../../config';
-import { isServerSide } from '../../utils';
-import isNil from 'lodash/isNil';
-import isString from 'lodash/isString';
+import { config, TOKEN_ENDPOINT_PARTIAL_PATH } from '../../config/index.js';
+import { isServerSide } from '../../utils/index.js';
+import isNil from 'lodash/isNil.js';
+import isString from 'lodash/isString.js';
 
 export interface AccessToken {
   token: string | undefined;

--- a/packages/core/src/auth/index.ts
+++ b/packages/core/src/auth/index.ts
@@ -1,2 +1,2 @@
-export * from './authorize';
-export * from './client/accessToken';
+export * from './authorize.js';
+export * from './client/accessToken.js';

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -1,12 +1,12 @@
-import isString from 'lodash/isString';
-import defaults from 'lodash/defaults';
-import trimEnd from 'lodash/trimEnd';
-import extend from 'lodash/extend';
-import isObject from 'lodash/isObject';
-import type { RequestContext } from '../gqty';
-import isNil from 'lodash/isNil';
-import trim from 'lodash/trim';
-import { isValidUrl } from '../utils';
+import isString from 'lodash/isString.js';
+import defaults from 'lodash/defaults.js';
+import trimEnd from 'lodash/trimEnd.js';
+import extend from 'lodash/extend.js';
+import isObject from 'lodash/isObject.js';
+import type { RequestContext } from '../gqty/index.js';
+import isNil from 'lodash/isNil.js';
+import trim from 'lodash/trim.js';
+import { isValidUrl } from '../utils/index.js';
 
 export const TOKEN_ENDPOINT_PARTIAL_PATH = 'auth/token';
 export const LOGOUT_ENDPOINT_PARTIAL_PATH = 'auth/logout';

--- a/packages/core/src/config/index.ts
+++ b/packages/core/src/config/index.ts
@@ -4,4 +4,4 @@ export {
   getGqlUrl,
   TOKEN_ENDPOINT_PARTIAL_PATH,
   LOGOUT_ENDPOINT_PARTIAL_PATH,
-} from './config';
+} from './config.js';

--- a/packages/core/src/export/api.ts
+++ b/packages/core/src/export/api.ts
@@ -1,1 +1,1 @@
-export * from '../server';
+export * from '../server/index.js';

--- a/packages/core/src/export/auth.ts
+++ b/packages/core/src/export/auth.ts
@@ -1,1 +1,1 @@
-export * from '../auth';
+export * from '../auth/index.js';

--- a/packages/core/src/export/client.ts
+++ b/packages/core/src/export/client.ts
@@ -1,1 +1,1 @@
-export * from '../gqty';
+export * from '../gqty/index.js';

--- a/packages/core/src/export/config.ts
+++ b/packages/core/src/export/config.ts
@@ -1,1 +1,1 @@
-export * from '../config';
+export * from '../config/index.js';

--- a/packages/core/src/export/index.ts
+++ b/packages/core/src/export/index.ts
@@ -4,5 +4,5 @@ export {
   ApiClient,
   WithClient,
   GqlClientSchema,
-} from '../gqty';
-export { Config, config } from '../config';
+} from '../gqty/index.js';
+export { Config, config } from '../config/index.js';

--- a/packages/core/src/export/utils.ts
+++ b/packages/core/src/export/utils.ts
@@ -1,1 +1,1 @@
-export * from '../utils';
+export * from '../utils/index.js';

--- a/packages/core/src/gqty/index.ts
+++ b/packages/core/src/gqty/index.ts
@@ -1,4 +1,4 @@
-export * from './schema.generated';
+export * from './schema.generated.js';
 import {
   ClientOptions,
   createClient,
@@ -9,12 +9,12 @@ import {
 } from 'gqty';
 import type { IncomingMessage } from 'http';
 import fetch from 'isomorphic-fetch';
-import isFunction from 'lodash/isFunction';
-import isNil from 'lodash/isNil';
-import isObject from 'lodash/isObject';
-import omit from 'lodash/omit';
-import { getAccessToken } from '../auth';
-import { getGqlUrl } from '../config/config';
+import isFunction from 'lodash/isFunction.js';
+import isNil from 'lodash/isNil.js';
+import isObject from 'lodash/isObject.js';
+import omit from 'lodash/omit.js';
+import { getAccessToken } from '../auth/index.js';
+import { getGqlUrl } from '../config/index.js';
 
 export interface GqlClientSchema {
   query: any;

--- a/packages/core/src/server/auth/cookie.ts
+++ b/packages/core/src/server/auth/cookie.ts
@@ -1,7 +1,7 @@
 import { IncomingMessage, ServerResponse } from 'http';
-import isString from 'lodash/isString';
+import isString from 'lodash/isString.js';
 import cookie, { CookieSerializeOptions } from 'cookie';
-import { base64Decode, base64Encode } from '../../utils';
+import { base64Decode, base64Encode } from '../../utils/index.js';
 
 export interface CookieOptions {
   encoded?: boolean;

--- a/packages/core/src/server/auth/middleware.ts
+++ b/packages/core/src/server/auth/middleware.ts
@@ -1,8 +1,8 @@
 import 'isomorphic-fetch';
 import { IncomingMessage, ServerResponse } from 'http';
-import { getQueryParam, log } from '../../utils';
-import { Cookies } from './cookie';
-import { OAuth } from './token';
+import { getQueryParam, log } from '../../utils/index.js';
+import { Cookies } from './cookie.js';
+import { OAuth } from './token.js';
 
 export function redirect(res: ServerResponse, url: string): void {
   res.writeHead(302, {

--- a/packages/core/src/server/auth/token.ts
+++ b/packages/core/src/server/auth/token.ts
@@ -1,9 +1,9 @@
 import 'isomorphic-fetch';
-import { Cookies } from './cookie';
-import { config } from '../../config';
-import isNil from 'lodash/isNil';
-import isString from 'lodash/isString';
-import isNumber from 'lodash/isNumber';
+import { Cookies } from './cookie.js';
+import { config } from '../../config/index.js';
+import isNil from 'lodash/isNil.js';
+import isString from 'lodash/isString.js';
+import isNumber from 'lodash/isNumber.js';
 
 export type OAuthTokenResponse =
   | OAuthTokens

--- a/packages/core/src/server/index.ts
+++ b/packages/core/src/server/index.ts
@@ -1,3 +1,3 @@
-export * from './auth/cookie';
-export { authorizeHandler, logoutHandler } from './auth/middleware';
-export * from './router';
+export * from './auth/cookie.js';
+export { authorizeHandler, logoutHandler } from './auth/middleware.js';
+export * from './router/index.js';

--- a/packages/core/src/server/router/index.ts
+++ b/packages/core/src/server/router/index.ts
@@ -1,12 +1,12 @@
 import { IncomingMessage, ServerResponse } from 'http';
-import { isUndefined } from 'lodash';
-import { authorizeHandler, logoutHandler } from '../auth/middleware';
-import { parseUrl } from '../../utils';
+import isUndefined from 'lodash/isUndefined.js';
+import { authorizeHandler, logoutHandler } from '../auth/middleware.js';
+import { parseUrl } from '../../utils/index.js';
 import {
   LOGOUT_ENDPOINT_PARTIAL_PATH,
   TOKEN_ENDPOINT_PARTIAL_PATH,
   config,
-} from '../../config';
+} from '../../config/index.js';
 
 /**
  * A node handler for processing all incoming Faust.js API requests.

--- a/packages/core/src/utils/assert.ts
+++ b/packages/core/src/utils/assert.ts
@@ -1,4 +1,4 @@
-import isString from 'lodash/isString';
+import isString from 'lodash/isString.js';
 
 /**
  * Returns whether or not the app execution context is currently Server-Side or Client-Side

--- a/packages/core/src/utils/convert.ts
+++ b/packages/core/src/utils/convert.ts
@@ -1,8 +1,8 @@
-import isArrayLike from 'lodash/isArrayLike';
-import isEmpty from 'lodash/isEmpty';
-import isString from 'lodash/isString';
-import isUndefined from 'lodash/isUndefined';
-import { isBase64, isServerSide, previewRegex } from './assert';
+import isArrayLike from 'lodash/isArrayLike.js';
+import isEmpty from 'lodash/isEmpty.js';
+import isString from 'lodash/isString.js';
+import isUndefined from 'lodash/isUndefined.js';
+import { isBase64, isServerSide, previewRegex } from './assert.js';
 
 /**
  * The result of parsing a URL into its parts

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -1,3 +1,3 @@
-export * from './assert';
-export * from './convert';
-export * from './log';
+export * from './assert.js';
+export * from './convert.js';
+export * from './log.js';

--- a/packages/core/src/utils/log.ts
+++ b/packages/core/src/utils/log.ts
@@ -1,4 +1,4 @@
-import { config } from '../config';
+import { config } from '../config/index.js';
 
 export const log: typeof console.log = (...args) => {
   if (config().disableLogging) {

--- a/packages/next/src/components/FaustProvider.tsx
+++ b/packages/next/src/components/FaustProvider.tsx
@@ -1,12 +1,12 @@
-import isNil from 'lodash/isNil';
+import isNil from 'lodash/isNil.js';
 import React from 'react';
-import type { getClient } from '../gqty/client';
+import type { getClient } from '../gqty/client.js';
 import {
   AUTH_CLIENT_CACHE_PROP,
   CLIENT_CACHE_PROP,
   PageProps,
-} from '../server/getProps';
-import { FaustContext } from '../gqty/client';
+} from '../server/getProps.js';
+import { FaustContext } from '../gqty/client.js';
 
 /**
  * The FaustProvider is a React component required to properly facilitate SSR and SSG for Faust.js.

--- a/packages/next/src/components/index.ts
+++ b/packages/next/src/components/index.ts
@@ -1,1 +1,1 @@
-export * from './FaustProvider';
+export * from './FaustProvider.js';

--- a/packages/next/src/config/config.ts
+++ b/packages/next/src/config/config.ts
@@ -1,4 +1,4 @@
-import defaults from 'lodash/defaults';
+import defaults from 'lodash/defaults.js';
 
 export interface Config {
   revalidate: number | boolean;

--- a/packages/next/src/config/index.ts
+++ b/packages/next/src/config/index.ts
@@ -1,2 +1,2 @@
-export * from './config';
-export * from './withFaust';
+export * from './config.js';
+export * from './withFaust.js';

--- a/packages/next/src/config/withFaust.ts
+++ b/packages/next/src/config/withFaust.ts
@@ -1,5 +1,5 @@
 import { trim } from 'lodash';
-import isFunction from 'lodash/isFunction';
+import isFunction from 'lodash/isFunction.js';
 import { NextConfig } from 'next';
 import { Redirect } from 'next/dist/lib/load-custom-routes';
 

--- a/packages/next/src/export/client.ts
+++ b/packages/next/src/export/client.ts
@@ -1,1 +1,1 @@
-export * from '../gqty';
+export * from '../gqty/index.js';

--- a/packages/next/src/export/components.ts
+++ b/packages/next/src/export/components.ts
@@ -1,1 +1,1 @@
-export * from '../components';
+export * from '../components/index.js';

--- a/packages/next/src/export/config.ts
+++ b/packages/next/src/export/config.ts
@@ -1,1 +1,1 @@
-export * from '../config';
+export * from '../config/index.js';

--- a/packages/next/src/export/index.ts
+++ b/packages/next/src/export/index.ts
@@ -1,6 +1,6 @@
-export { Config, WithFaustConfig, config, withFaust } from '../config';
-export { getClient, NextClient } from '../gqty';
-export { logQueries } from '../log';
+export { Config, WithFaustConfig, config, withFaust } from '../config/index.js';
+export { getClient, NextClient } from '../gqty/index.js';
+export { logQueries } from '../log/index.js';
 export {
   GetNextServerSidePropsConfig,
   GetNextStaticPropsConfig,
@@ -8,5 +8,5 @@ export {
   getNextServerSideProps,
   getNextStaticProps,
   is404,
-} from '../server';
-export { FaustProvider } from '../components';
+} from '../server/index.js';
+export { FaustProvider } from '../components/index.js';

--- a/packages/next/src/export/log.ts
+++ b/packages/next/src/export/log.ts
@@ -1,1 +1,1 @@
-export * from '../log';
+export * from '../log/index.js';

--- a/packages/next/src/export/server.ts
+++ b/packages/next/src/export/server.ts
@@ -1,1 +1,1 @@
-export * from '../server';
+export * from '../server/index.js';

--- a/packages/next/src/export/utils.ts
+++ b/packages/next/src/export/utils.ts
@@ -1,1 +1,1 @@
-export * from '../utils';
+export * from '../utils/index.js';

--- a/packages/next/src/gqty/client.ts
+++ b/packages/next/src/gqty/client.ts
@@ -12,9 +12,9 @@ import {
 } from '@gqty/react';
 import type { GQtyClient } from 'gqty';
 import type { IncomingMessage } from 'http';
-import noop from 'lodash/noop';
-import isObject from 'lodash/isObject';
-import merge from 'lodash/merge';
+import noop from 'lodash/noop.js';
+import isObject from 'lodash/isObject.js';
+import merge from 'lodash/merge.js';
 import React, { useContext } from 'react';
 
 import {
@@ -22,7 +22,7 @@ import {
   createHooks,
   NextClientHooks,
   NextClientHooksWithAuth,
-} from './hooks';
+} from './hooks/index.js';
 
 export interface NextClient<
   Schema extends RequiredSchema,

--- a/packages/next/src/gqty/hooks/index.ts
+++ b/packages/next/src/gqty/hooks/index.ts
@@ -1,23 +1,23 @@
 import type { RequiredSchema } from '@faustjs/react';
 import { ReactClient } from '@gqty/react';
 import type { GQtyError } from 'gqty';
-import type { NextClient } from '../client';
+import type { NextClient } from '../client.js';
 
-import { create as createAuthHook, UseAuthOptions } from './useAuth';
-import { create as createLazyQueryHook } from './useLazyQuery';
-import { create as createMutationHook } from './useMutation';
-import { create as createPaginatedQueryHook } from './usePaginatedQuery';
-import { create as createQueryHook } from './useQuery';
-import { create as createSubscriptionHook } from './useSubscription';
-import { create as createTransactionQueryHook } from './useTransactionQuery';
-import { create as createHydrateCacheHook } from './useHydrateCache';
-import { create as createCategoryHook } from './useCategory';
-import { create as createPostsHook } from './usePosts';
-import { create as createPostHook } from './usePost';
-import { create as createPageHook } from './usePage';
-import { create as createPreviewHook, UsePreviewResponse } from './usePreview';
-import { create as createLoginHook, UseLoginOptions } from './useLogin';
-import { create as createLogoutHook } from './useLogout';
+import { create as createAuthHook, UseAuthOptions } from './useAuth.js';
+import { create as createLazyQueryHook } from './useLazyQuery.js';
+import { create as createMutationHook } from './useMutation.js';
+import { create as createPaginatedQueryHook } from './usePaginatedQuery.js';
+import { create as createQueryHook } from './useQuery.js';
+import { create as createSubscriptionHook } from './useSubscription.js';
+import { create as createTransactionQueryHook } from './useTransactionQuery.js';
+import { create as createHydrateCacheHook } from './useHydrateCache.js';
+import { create as createCategoryHook } from './useCategory.js';
+import { create as createPostsHook } from './usePosts.js';
+import { create as createPostHook } from './usePost.js';
+import { create as createPageHook } from './usePage.js';
+import { create as createPreviewHook, UsePreviewResponse } from './usePreview.js';
+import { create as createLoginHook, UseLoginOptions } from './useLogin.js';
+import { create as createLogoutHook } from './useLogout.js';
 
 export type UseClient<
   Schema extends RequiredSchema,

--- a/packages/next/src/gqty/hooks/useAuth.ts
+++ b/packages/next/src/gqty/hooks/useAuth.ts
@@ -1,13 +1,13 @@
 import { config } from '@faustjs/core';
 import { ensureAuthorization } from '@faustjs/core/auth';
 import type { RequiredSchema } from '@faustjs/react';
-import defaults from 'lodash/defaults';
-import isObject from 'lodash/isObject';
-import isUndefined from 'lodash/isUndefined';
-import noop from 'lodash/noop';
-import trim from 'lodash/trim';
+import defaults from 'lodash/defaults.js';
+import isObject from 'lodash/isObject.js';
+import isUndefined from 'lodash/isUndefined.js';
+import noop from 'lodash/noop.js';
+import trim from 'lodash/trim.js';
 import { useEffect, useState } from 'react';
-import type { NextClient } from '../client';
+import type { NextClient } from '../client.js';
 
 export interface UseAuthOptions {
   /**

--- a/packages/next/src/gqty/hooks/useCategory.ts
+++ b/packages/next/src/gqty/hooks/useCategory.ts
@@ -1,9 +1,9 @@
 import { CategoryIdType } from '@faustjs/core/client';
 import type { RequiredSchema } from '@faustjs/react';
 import { useRouter } from 'next/router';
-import isString from 'lodash/isString';
-import defaults from 'lodash/defaults';
-import { hasCategoryId, hasCategorySlug } from '../../utils';
+import isString from 'lodash/isString.js';
+import defaults from 'lodash/defaults.js';
+import { hasCategoryId, hasCategorySlug } from '../../utils/index.js';
 import type { NextClientHooks } from '.';
 
 export function create<Schema extends RequiredSchema>(

--- a/packages/next/src/gqty/hooks/useHydrateCache.ts
+++ b/packages/next/src/gqty/hooks/useHydrateCache.ts
@@ -1,8 +1,8 @@
 import type { RequiredSchema } from '@faustjs/react';
 import { useEffect, useRef } from 'react';
-import isString from 'lodash/isString';
-import isObject from 'lodash/isObject';
-import isFunction from 'lodash/isFunction';
+import isString from 'lodash/isString.js';
+import isObject from 'lodash/isObject.js';
+import isFunction from 'lodash/isFunction.js';
 import type { NextClientHooks, UseClient } from '.';
 
 export function create<

--- a/packages/next/src/gqty/hooks/useLogin.ts
+++ b/packages/next/src/gqty/hooks/useLogin.ts
@@ -3,7 +3,7 @@ import { fetchAccessToken } from '@faustjs/core/auth';
 import { getQueryParam, isValidEmail } from '@faustjs/core/utils';
 import type { RequiredSchema } from '@faustjs/react';
 import { UseMutationOptions } from '@gqty/react';
-import noop from 'lodash/noop';
+import noop from 'lodash/noop.js';
 import { useEffect } from 'react';
 import type { NextClientHooks, NextClientHooksWithAuth } from '.';
 

--- a/packages/next/src/gqty/hooks/useLogout.ts
+++ b/packages/next/src/gqty/hooks/useLogout.ts
@@ -3,7 +3,7 @@ import { LOGOUT_ENDPOINT_PARTIAL_PATH } from '@faustjs/core/config';
 import type { RequiredSchema } from '@faustjs/react';
 import { isNil } from 'lodash';
 import { useState } from 'react';
-import type { NextClient } from '../client';
+import type { NextClient } from '../client.js';
 
 export function create<
   Schema extends RequiredSchema,

--- a/packages/next/src/gqty/hooks/usePage.ts
+++ b/packages/next/src/gqty/hooks/usePage.ts
@@ -1,9 +1,9 @@
 import { PageIdType } from '@faustjs/core/client';
 import type { RequiredSchema } from '@faustjs/react';
 import { useRouter } from 'next/router';
-import defaults from 'lodash/defaults';
-import isString from 'lodash/isString';
-import { hasPageId, hasPageUri } from '../../utils';
+import defaults from 'lodash/defaults.js';
+import isString from 'lodash/isString.js';
+import { hasPageId, hasPageUri } from '../../utils/index.js';
 import type { NextClientHooks } from '.';
 
 export function create<Schema extends RequiredSchema>(

--- a/packages/next/src/gqty/hooks/usePost.ts
+++ b/packages/next/src/gqty/hooks/usePost.ts
@@ -1,9 +1,9 @@
 import { PostIdType } from '@faustjs/core/client';
 import type { RequiredSchema } from '@faustjs/react';
 import { useRouter } from 'next/router';
-import defaults from 'lodash/defaults';
-import isString from 'lodash/isString';
-import { hasPostId, hasPostSlug, hasPostUri } from '../../utils';
+import defaults from 'lodash/defaults.js';
+import isString from 'lodash/isString.js';
+import { hasPostId, hasPostSlug, hasPostUri } from '../../utils/index.js';
 import type { NextClientHooks } from '.';
 
 export function create<Schema extends RequiredSchema>(

--- a/packages/next/src/gqty/hooks/usePosts.ts
+++ b/packages/next/src/gqty/hooks/usePosts.ts
@@ -1,7 +1,7 @@
 import type { RequiredSchema } from '@faustjs/react';
 import { useRouter } from 'next/router';
-import defaults from 'lodash/defaults';
-import { hasCategoryId, hasCategorySlug } from '../../utils';
+import defaults from 'lodash/defaults.js';
+import { hasCategoryId, hasCategorySlug } from '../../utils/index.js';
 import type { NextClientHooks } from '.';
 
 export function create<Schema extends RequiredSchema>(

--- a/packages/next/src/gqty/hooks/usePreview.ts
+++ b/packages/next/src/gqty/hooks/usePreview.ts
@@ -1,8 +1,8 @@
 import { PageIdType, PostIdType } from '@faustjs/core/client';
 import type { RequiredSchema } from '@faustjs/react';
-import isUndefined from 'lodash/isUndefined';
+import isUndefined from 'lodash/isUndefined.js';
 import { useRouter } from 'next/router';
-import { hasPageId, hasPostId } from '../../utils';
+import { hasPageId, hasPostId } from '../../utils/index.js';
 import type { NextClientHooks, NextClientHooksWithAuth } from '.';
 
 export type UsePreviewResponse<Schema extends RequiredSchema> =

--- a/packages/next/src/gqty/index.ts
+++ b/packages/next/src/gqty/index.ts
@@ -1,2 +1,2 @@
-export * from './client';
-export * from './hooks';
+export * from './client.js';
+export * from './hooks/index.js';

--- a/packages/next/src/log/index.ts
+++ b/packages/next/src/log/index.ts
@@ -1,1 +1,1 @@
-export * from './log';
+export * from './log.js';

--- a/packages/next/src/log/log.ts
+++ b/packages/next/src/log/log.ts
@@ -1,6 +1,6 @@
 import type { LoggerOptions } from '@gqty/logger';
-import defaults from 'lodash/defaults';
-import type { NextClient } from '../gqty/client';
+import defaults from 'lodash/defaults.js';
+import type { NextClient } from '../gqty/client.js';
 
 export async function logQueries(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/next/src/server/getProps.tsx
+++ b/packages/next/src/server/getProps.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable react/no-children-prop */
 import { CategoryIdType, PageIdType, PostIdType } from '@faustjs/core/client';
 import { isBoolean, isObject } from 'lodash';
-import isNil from 'lodash/isNil';
+import isNil from 'lodash/isNil.js';
 import {
   GetServerSidePropsContext,
   GetStaticPropsContext,
@@ -12,8 +12,8 @@ import {
 import { RouterContext } from 'next/dist/shared/lib/router-context';
 
 import React, { FunctionComponent, ComponentClass } from 'react';
-import { config } from '../config/config';
-import { getClient, FaustContext } from '../gqty/client';
+import { config } from '../config/config.js';
+import { getClient, FaustContext } from '../gqty/client.js';
 
 import {
   hasCategoryId,
@@ -23,7 +23,7 @@ import {
   hasPostId,
   hasPostSlug,
   hasPostUri,
-} from '../utils';
+} from '../utils/index.js';
 
 export const CLIENT_CACHE_PROP = '__CLIENT_CACHE_PROP';
 export const AUTH_CLIENT_CACHE_PROP = '__AUTH_CLIENT_CACHE_PROP';

--- a/packages/next/src/server/index.ts
+++ b/packages/next/src/server/index.ts
@@ -1,1 +1,1 @@
-export * from './getProps';
+export * from './getProps.js';

--- a/packages/next/src/utils/assert.ts
+++ b/packages/next/src/utils/assert.ts
@@ -1,7 +1,7 @@
-import isArray from 'lodash/isArray';
-import isObject from 'lodash/isObject';
-import isString from 'lodash/isString';
-import trim from 'lodash/trim';
+import isArray from 'lodash/isArray.js';
+import isObject from 'lodash/isObject.js';
+import isString from 'lodash/isString.js';
+import trim from 'lodash/trim.js';
 
 export type HasObject = Record<string, string | string[] | undefined>;
 

--- a/packages/next/src/utils/index.ts
+++ b/packages/next/src/utils/index.ts
@@ -1,1 +1,1 @@
-export * from './assert';
+export * from './assert.js';

--- a/packages/react/src/client.ts
+++ b/packages/react/src/client.ts
@@ -11,8 +11,8 @@ import {
   ReactClient as GQtyReactClient,
 } from '@gqty/react';
 import { GQtyClient } from 'gqty';
-import isObject from 'lodash/isObject';
-import merge from 'lodash/merge';
+import isObject from 'lodash/isObject.js';
+import merge from 'lodash/merge.js';
 
 export interface Node {
   id?: string | null;

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,1 +1,1 @@
-export * from './client';
+export * from './client.js';


### PR DESCRIPTION
## Related issues: 
- #622 
## Related PRs: 
- #623 (if merged this would supersede [#623](https://github.com/wpengine/faustjs/pull/623))

## Description:
This PR updates imports on all 3 packages:
- @faustjs/core
- @faustjs/next
- @faustjs/react

It also updates dependencies in `examples/next/getting-started` (Next is obviously bumped to major, others to minor/patch).

Next 12 will automatically extend `tsconfig.json` to include `incremental: true`, so I've added that as well.

All relative imports had to have full paths (with indexes - no directory resolution) [including extensions](https://github.com/nodejs/node/issues/30927).

For whatever reason I had to include extensions even to lodash imports (it wouldn't compile without it).