### PR TITLE
Deprecate `wpac/v1` api namespace in favor of `faustwp/v1`

### DIFF
--- a/.changeset/three-crabs-protect.md
+++ b/.changeset/three-crabs-protect.md
@@ -3,3 +3,8 @@
 ---
 
 Updated internal auth endpoints and headers for WPE Headless plugin rename.
+
+The FaustWP plugin has deprecated the REST endpoint that `@faustjs/core` uses for authorization.
+Both the plugin and the `@faustjs/core` package will continue to work with the deprecated endpoint
+until it is removed in a future version. Make sure to always update your FaustWP plugin and `@faustjs`
+packages together to avoid any issues that may arise from incompatible versions.

--- a/packages/core/src/server/auth/token.ts
+++ b/packages/core/src/server/auth/token.ts
@@ -90,7 +90,9 @@ export class OAuth {
 
       if (response.status !== 404) {
         log(
-          'The FaustWP WordPress plugin is out of date. Please update to the latest version.',
+          'Authentication and post previews will soon be incompatible with ' +
+            'your version of the FaustWP plugin. Please update to the latest' +
+            ' version.',
         );
       }
     }

--- a/packages/core/src/server/auth/token.ts
+++ b/packages/core/src/server/auth/token.ts
@@ -4,6 +4,7 @@ import { config } from '../../config';
 import isNil from 'lodash/isNil';
 import isString from 'lodash/isString';
 import isNumber from 'lodash/isNumber';
+import { log } from '../../utils';
 
 export type OAuthTokenResponse =
   | OAuthTokens
@@ -87,10 +88,9 @@ export class OAuth {
         }),
       });
 
-      if (response.status !== 404 && process.env.NODE_ENV !== 'production') {
-        process.emitWarning(
+      if (response.status !== 404) {
+        log(
           'The FaustWP WordPress plugin is out of date. Please update to the latest version.',
-          'DeprecationWarning',
         );
       }
     }

--- a/packages/core/test/server/auth/middleware.test.ts
+++ b/packages/core/test/server/auth/middleware.test.ts
@@ -139,7 +139,7 @@ describe('auth/middleware', () => {
     } as any;
 
     const endSpy = jest.spyOn(res, 'end');
-    const warningSpy = jest.spyOn(process, 'emitWarning').mockImplementation(jest.fn());
+    const warningSpy = jest.spyOn(console, 'log').mockImplementation(jest.fn());
     const successResponse = {
       message: 'Successfully called deprecated endpoint.',
       accessToken: 'valid-at',

--- a/packages/core/test/server/auth/middleware.test.ts
+++ b/packages/core/test/server/auth/middleware.test.ts
@@ -118,4 +118,57 @@ describe('auth/middleware', () => {
     endSpy.mockRestore();
     fetchMock.restore();
   });
+
+  test('authorizeHandler will fallback to deprecated authorize endpoint if first attempt is 404', async () => {
+    config({
+      wpUrl: 'http://test.local',
+      authType: 'redirect',
+      loginPagePath: '/login',
+      apiClientSecret: 'secret',
+    });
+
+    const req: IncomingMessage = {
+      url: 'https://developers.wpengine.com/?code=code',
+      headers: {},
+    } as any;
+
+    const res: ServerResponse = {
+      setHeader() { },
+      writeHead() { },
+      end() { },
+    } as any;
+
+    const endSpy = jest.spyOn(res, 'end');
+    const warningSpy = jest.spyOn(process, 'emitWarning').mockImplementation(jest.fn());
+    const successResponse = {
+      message: 'Successfully called deprecated endpoint.',
+      accessToken: 'valid-at',
+      refreshToken: 'valid-rt',
+      accessTokenExpiration: 10000,
+      refreshTokenExpiration: 10000,
+    };
+
+    const { wpUrl } = config();
+
+    fetchMock
+      .post(`${wpUrl}/wp-json/faustwp/v1/authorize`, {
+        status: 404,
+        body: JSON.stringify({ error: 'Plugin out of date.' }),
+      })
+      .post(`${wpUrl}/wp-json/wpac/v1/authorize`, {
+        status: 200,
+        body: JSON.stringify(successResponse),
+      });
+
+    await authorizeHandler(req, res);
+
+    expect(warningSpy).toBeCalled();
+    expect(endSpy).toBeCalled();
+    expect(res.statusCode).toBe(200);
+    expect(endSpy).toBeCalledWith(JSON.stringify(successResponse));
+
+    endSpy.mockRestore();
+    warningSpy.mockRestore();
+    fetchMock.restore();
+  });
 });

--- a/plugins/faustwp/includes/rest/callbacks.php
+++ b/plugins/faustwp/includes/rest/callbacks.php
@@ -77,7 +77,11 @@ function register_rest_routes() {
 		)
 	);
 
-	// Deprecated. Faust.js packages now use faustwp/v1/authorize.
+	/**
+	 * Faust.js packages now use `faustwp/v1/authorize`.
+	 *
+	 * @deprecated
+	 */
 	register_rest_route(
 		'wpac/v1',
 		'/authorize',

--- a/plugins/faustwp/includes/rest/callbacks.php
+++ b/plugins/faustwp/includes/rest/callbacks.php
@@ -76,6 +76,17 @@ function register_rest_routes() {
 			'permission_callback' => __NAMESPACE__ . '\\rest_authorize_permission_callback',
 		)
 	);
+
+	// Deprecated. Faust.js packages now use faustwp/v1/authorize.
+	register_rest_route(
+		'wpac/v1',
+		'/authorize',
+		array(
+			'methods'             => 'POST',
+			'callback'            => __NAMESPACE__ . '\\handle_rest_authorize_callback',
+			'permission_callback' => __NAMESPACE__ . '\\wpac_authorize_permission_callback',
+		)
+	);
 }
 
 /**
@@ -125,7 +136,7 @@ function handle_rest_authorize_callback( \WP_REST_Request $request ) {
 }
 
 /**
- * Callback for WordPress register_rest_route() 'permission_callback' parameter.
+ * Callback to check permissions for requests to `faustwp/v1/authorize`.
  *
  * Authorized if the 'secret_key' settings value and http header 'x-faustwp-secret' match.
  *
@@ -139,6 +150,31 @@ function handle_rest_authorize_callback( \WP_REST_Request $request ) {
 function rest_authorize_permission_callback( \WP_REST_Request $request ) {
 	$secret_key = get_secret_key();
 	$header_key = $request->get_header( 'x-faustwp-secret' );
+
+	if ( $secret_key && $header_key ) {
+		return $secret_key === $header_key;
+	}
+
+	return false;
+}
+
+/**
+ * Callback to check permissions for requests to `wpac/v1/authorize`.
+ *
+ * Authorized if the 'secret_key' settings value and http header 'x-wpe-headless-secret' match.
+ *
+ * @deprecated The `wpac/v1/authorize` route is deprecated. Use `faustwp/v1/authorize` instead.
+ *
+ * @link https://developer.wordpress.org/reference/functions/register_rest_route/
+ * @link https://developer.wordpress.org/rest-api/extending-the-rest-api/routes-and-endpoints/#permissions-callback
+ *
+ * @param \WP_REST_Request $request The current WP_REST_Request object.
+ *
+ * @return bool True if current user can, false if else.
+ */
+function wpac_authorize_permission_callback( \WP_REST_Request $request ) {
+	$secret_key = get_secret_key();
+	$header_key = $request->get_header( 'x-wpe-headless-secret' );
 
 	if ( $secret_key && $header_key ) {
 		return $secret_key === $header_key;


### PR DESCRIPTION
When work on the `wp-org` branch began, we decided to remove the `wpac/v1/authorize` endpoint in favor of `faustwp/v1/authorize`. In an effort to reduce the likelihood of errors due to a mismatch between a site's WordPress plugin version and it's front-end packages, this PR reintroduces the `wpac/v1/authorize` endpoint in a deprecated capacity.

It shouldn't matter whether a user updates their packages first or their WordPress plugin first -- their site should not break in either case. Achieving this cross-compatibility requires us to maintain deprecations that cover both cases.

While this PR should cover our immediate needs, I'm hoping to continue working on a more complete solution. Ideally, we could quickly and clearly warn developers about plugin/package incompatibilities (i.e. dashboard warning during FaustWP plugin update; some kind of npm post-update script; etc.). I have some concern that if we don't come up with a more complete solution, we could end up with a tangle of cross-compatibility deprecations that would be hard to reason about.

## Testing

- The existing e2e test for previews should cover the happy path (using the new auth endpoint).
- The core package will fallback to the deprecated auth endpoint when the new one returns a 404. This could happen when a user has updated `@faustjs/core` before updating the WordPress plugin. A unit test has been added to cover this behavior.
- Manual testing:
    1. Comment out the new [route registration in the FaustWP plugin](https://github.com/wpengine/faustjs/blob/dff41355deb1cfc21efef4da76338c039dd1eb28/plugins/faustwp/includes/rest/callbacks.php#L70-L78). (this will trigger both the package to execute its fallback behavior and the plugin to resolve the request using the deprecated route.)
    2. Ensure `FAUSTWP_SECRET` is set in your `.env.local`
    2. Verify that accessing a post or page preview still works.

