### PR TITLE
Correct domain replacement for GraphQL fields

### DIFF
--- a/plugins/faustwp/tests/integration/replacement/test-graphql-callbacks.php
+++ b/plugins/faustwp/tests/integration/replacement/test-graphql-callbacks.php
@@ -1,0 +1,136 @@
+<?php
+/**
+ * Class GraphQLCallbacksTestCases
+ *
+ * @package FaustWP
+ */
+
+namespace WPE\FaustWP\Tests\Replacement;
+
+use function WPE\FaustWP\Replacement\{ url_replacement };
+use function WPE\FaustWP\Settings\faustwp_update_setting;
+
+class GraphQLCallbacksTestCases extends \WP_UnitTestCase {
+
+	private $graphqlResponse;
+
+	private $responseData = [
+		'generalSettings' => [
+			'url' => 'http://example.org'
+		],
+		'menuItems' => [
+			'nodes' => [
+				[
+					'label' => 'Hello World',
+					'url'   => 'http://example.org/hello-world/'
+				],
+				[
+					'label' => 'External Site',
+					'url'   => 'http://external.site/no-replacement'
+				]
+			]
+		],
+		'menus' => [
+			'nodes' => [
+				[
+					'menuItems' => [
+						'nodes' => [
+							[
+								'label' => 'Hello World',
+								'url'   => 'http://example.org/hello-world/'
+							]
+						]
+					]
+				]
+			]
+		],
+		'aThingWithHref' => [
+			'nodes' => [
+				[
+					'label' => "This uses href instead of url fields",
+					'href'  => 'http://example.org/href'
+				]
+			]
+		]
+	];
+
+	private $expectedData = [
+		'generalSettings' => [
+			'url' => 'http://example.org'
+		],
+		'menuItems' => [
+			'nodes' => [
+				[
+					'label' => 'Hello World',
+					'url'   => 'http://frontend/hello-world/'
+				],
+				[
+					'label' => 'External Site',
+					'url'   => 'http://external.site/no-replacement'
+				]
+			]
+		],
+		'menus' => [
+			'nodes' => [
+				[
+					'menuItems' => [
+						'nodes' => [
+							[
+								'label' => 'Hello World',
+								'url'   => 'http://frontend/hello-world/'
+							]
+						]
+					]
+				]
+			]
+		],
+		'aThingWithHref' => [
+			'nodes' => [
+				[
+					'label' => "This uses href instead of url fields",
+					'href'  => 'http://frontend/href'
+				]
+			]
+		]
+	];
+
+	public function setUp() {
+		parent::setUp();
+
+		faustwp_update_setting( 'frontend_uri', 'http://frontend' );
+
+		$this->graphqlResponse = new \stdClass();
+		$this->graphqlResponse->data = $this->responseData;
+	}
+
+	public function test_graphql_request_results_filter() {
+		$this->assertSame( 10, has_action( 'graphql_request_results', 'WPE\FaustWP\Replacement\url_replacement' ) );
+	}
+
+	/**
+	 * Tests url_replacement() returns original data when rewrites are not enabled.
+	 */
+	public function test_url_replacement_does_not_alter_response_when_rewrites_are_not_enabled() {
+		faustwp_update_setting( 'enable_rewrites', '0' );
+		$filteredRespone = url_replacement( $this->graphqlResponse );
+		$this->assertSame( $this->responseData, $filteredRespone->data );
+	}
+
+	/**
+	 * Tests url_replacement() does not modify generalSettings even when rewrites are enabled.
+	 */
+	public function test_url_replacement_does_not_alter_generalSettings_when_rewrites_are_enabled() {
+		faustwp_update_setting( 'enable_rewrites', '1' );
+		$filteredRespone = url_replacement( $this->graphqlResponse );
+		$this->assertSame( $this->responseData['generalSettings'], $filteredRespone->data['generalSettings'] );
+	}
+
+	/**
+	 * Tests url_replacement() modifies url and href fields when rewrites are enabled.
+	 */
+	public function test_url_replacement_replaces_url_fields_when_rewrites_are_enabled() {
+		faustwp_update_setting( 'enable_rewrites', '1' );
+		$filteredRespone = url_replacement( $this->graphqlResponse );
+		$this->assertSame( $this->expectedData, $filteredRespone->data );
+	}
+}


### PR DESCRIPTION
Resolves #541

As mentioned in #541, it appeared we were not doing domain replacement on menu item URLs. Upon investigation, it appears we _are_ performing replacements that should cover menu item URLs, but these replacements were short-circuited by the presence of `generalSettings` in the response data. I believe the intention here was to skip replacements inside of `generalSettings`, as queries for `generalSettings.url` should accurately report the URL of the WordPress instance rather than the front-end application.

With the way GQty assembles queries, it's likely `generalSettings` will be included in most requests. This PR changes the replacement callback to skip `generalSettings` without preventing replacements elsewhere in the response data.

## Testing

- Unit tests have been added.

### Manual Testing

1. Before pulling this branch, make a simple menu in Appearance->Menus and assign it to the Primary menu location.
2. Run the following query in GraphiQL:
```graphql
query MyQuery {
  generalSettings {
    url
  }
  menuItems(where: {location: PRIMARY}) {
    nodes {
      label
      url
    }
  }
  menus(where: {location: PRIMARY}) {
    nodes {
      menuItems {
        nodes {
          label
          url
        }
      }
    }
  }
}
```
3. See that no `url` fields receive domain replacements
4. Pull the branch
5. Run the same query as above
6. See that `generalSettings.url` is unchanged, but all menu item urls have been rewritten:
```json
{
  "data": {
    "generalSettings": {
      "url": "http://faustjs.local"
    },
    "menuItems": {
      "nodes": [
        {
          "label": "Hello World",
          "url": "http://localhost:3000/hello-world/"
        }
      ]
    },
    "menus": {
      "nodes": [
        {
          "menuItems": {
            "nodes": [
              {
                "label": "Hello World",
                "url": "http://localhost:3000/hello-world/"
              }
            ]
          }
        }
      ]
    }
  }
}
```
