### PR TITLE
Deactivate WPE Headless on FaustWP activation

### DIFF
--- a/plugins/faustwp/includes/utilities/callbacks.php
+++ b/plugins/faustwp/includes/utilities/callbacks.php
@@ -21,9 +21,10 @@ register_activation_hook( FAUSTWP_FILE, __NAMESPACE__ . '\\handle_activation' );
 /**
  * Callback for WordPress register_activation_hook() function.
  *
- * 1. Set default settings if no settings exist.
- * 2. Set secret_key if does not exist.
- * 3. Flush rewrite rules.
+ * 1. Deactivate the WPE Headless plugin if it's active.
+ * 2. Set default settings if no settings exist.
+ * 3. Set secret_key if does not exist.
+ * 4. Flush rewrite rules.
  *
  * @todo is flush_rewrite_rules() needed?
  *
@@ -32,6 +33,10 @@ register_activation_hook( FAUSTWP_FILE, __NAMESPACE__ . '\\handle_activation' );
  * @return void
  */
 function handle_activation() {
+	if ( is_plugin_active( 'wpe-headless/wpe-headless.php' ) ) {
+		deactivate_plugins( 'wpe-headless/wpe-headless.php', true );
+	}
+
 	$secret_key = get_secret_key();
 	$settings   = faustwp_get_settings();
 


### PR DESCRIPTION
## Description

While there shouldn't be any fatal conflicts between WPE Headless and FaustWP, running both plugins could lead to some unexpected behavior. We can try to prevent this by deactivating WPE Headless automatically during activation of FaustWP. Props @blakewilson for the idea!

## Testing

1. Run this PR's copy of FaustWP, but make sure the plugin is deactivated.
2. [Download the latest copy of WPE Headless](https://wp-product-info.wpesvc.net/v1/plugins/wpe-headless?download)
3. Install WPE Headless as a zip and activate.
4. Go to the Plugins page in the WordPress dashboard.
5. Click activate on FaustWP.
6. See that WPE Headless is deactivated.