### PR TITLE
Suggestions for git workflow guidelines

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -182,10 +182,12 @@ We use the [feature branch workflow](https://www.atlassian.com/git/tutorials/com
 
 ### Staging Site Deployment
 
-With your existing feature branch:
+When your feature branch includes changes to the documentation website, it's helpful to include a live preview link in the PR description. The [staging site](https://hcixzyt38dn5ak04xxcqc36lf.js.wpenginepowered.com/) is used for this purpose. You can deploy your changes to the staging site using the following steps:
 
-- Create a PR to the `site-dev` branch
-- Merge the PR into the `site-dev` branch
+- Checkout and switch to the `site-dev` branch.
+- Merge your feature branch into `site-dev`.
+- Push your merge commit to `site-dev`.
+- Within about 10 minutes, the docs changes from your feature branch should be visible on the [staging site](https://hcixzyt38dn5ak04xxcqc36lf.js.wpenginepowered.com/).
 
 ### Prod Site Deployment
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -195,4 +195,4 @@ When your feature branch includes changes to the documentation website, it's hel
 - Create a PR to the `main` branch from `canary`
 - Merge the PR into the `main` branch
 
-**Important**: Be sure to make a Merge Commit, and not "Squash and Merge", as this can lead to [merge conflicts](https://medium.com/@guilhermerios/the-agony-and-the-ecstasy-of-git-squash-7f91c8da20af).
+**Important**: Be sure to use the "Create a merge commit" option, and not "Squash and merge", as this can lead to [merge conflicts](https://medium.com/@guilhermerios/the-agony-and-the-ecstasy-of-git-squash-7f91c8da20af).


### PR DESCRIPTION
@blakewilson A diff seemed easier than review comments on #671.

The main thing I wanted to suggest was in regards to the staging workflow. I was thinking we would just merge the feature branch into `site-dev` locally and push to deploy. The changes would already be under review in the PR that targets `canary`, so we don't need the duplicate PR just to get things to the staging site. This could obviously leave staging in a potentially dirty or conflicted state, but I think that's a limitation of only being able to publish with branch pushes right now.

Everything else looks great!