### PR TITLE
Generate readme.txt changelog during versioning

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "wp:destroy": "wp-env destroy",
     "wpe-build": "cd internal/website && npm i && cd .. && npm run docs:build",
     "changeset": "changeset",
-    "version": "changeset version",
+    "version": "changeset version && node scripts/buildPluginReadme.js",
     "version:status": "changeset status",
     "release": "npm run build && changeset publish"
   },

--- a/scripts/buildPluginReadme.js
+++ b/scripts/buildPluginReadme.js
@@ -1,0 +1,71 @@
+/**
+ * Updates the FaustWP plugin's readme.txt changelog with the
+ * latest release found in the plugin's CHANGELOG.md file.
+ */
+
+const fs = require("fs");
+const path = require("path");
+const util = require("util");
+const readFile = (fileName) => util.promisify(fs.readFile)(fileName, "utf8");
+const pluginPath = path.join(__dirname, '../plugins/faustwp');
+const changelogPath = path.join(pluginPath, "CHANGELOG.md");
+const readmePath = path.join(pluginPath, "readme.txt");
+
+async function buildPluginReadme() {
+  let output = "";
+  let changelog = "";
+
+  changelog = await readFile(changelogPath);
+
+  changelog = changelog.replace(
+    "# FaustWP",
+    "== Changelog =="
+  );
+
+  // split the contents by new line
+  const origLines = changelog.split(/\r?\n/);
+  const processedLines = [];
+  let inLatestVersion = false;
+
+  // print all lines in current version
+  origLines.every((line) => {
+    // Version numbers in CHANGELOG.md are h2
+    if (line.startsWith("## ")) {
+      if (inLatestVersion) {
+        return false;
+      }
+      // Format version number for WordPress
+      line = line.replace("## ", "= ") + " =";
+      inLatestVersion = true;
+    }
+
+    processedLines.push(line);
+
+    return true;
+  });
+
+  changelog = processedLines.join("\n");
+
+  fs.readFile(
+    readmePath,
+    'utf-8',
+    function (err, data) {
+      if (err) throw err;
+
+      const changelogStart = data.indexOf('== Changelog ==');
+      output = data.substring(0, changelogStart) + changelog;
+      output += "\nFor the full changelog, visit https://faustjs.org/docs/changelog/faustwp";
+
+      fs.writeFile(
+        readmePath,
+        output,
+        (err) => {
+          if (err) throw err;
+          console.log("Plugin readme.txt has been updated!");
+        }
+      );
+    }
+  );
+}
+
+buildPluginReadme();

--- a/scripts/buildPluginReadme.js
+++ b/scripts/buildPluginReadme.js
@@ -1,6 +1,6 @@
 /**
  * Updates the FaustWP plugin's readme.txt changelog with the
- * latest release found in the plugin's CHANGELOG.md file.
+ * latest 3 releases found in the plugin's CHANGELOG.md file.
  */
 
 const fs = require("fs");
@@ -25,18 +25,18 @@ async function buildPluginReadme() {
   // split the contents by new line
   const origLines = changelog.split(/\r?\n/);
   const processedLines = [];
-  let inLatestVersion = false;
+  let versionCount = 0;
 
   // print all lines in current version
   origLines.every((line) => {
     // Version numbers in CHANGELOG.md are h2
     if (line.startsWith("## ")) {
-      if (inLatestVersion) {
+      if (versionCount == 3) {
         return false;
       }
       // Format version number for WordPress
       line = line.replace("## ", "= ") + " =";
-      inLatestVersion = true;
+      versionCount++;
     }
 
     processedLines.push(line);
@@ -54,7 +54,7 @@ async function buildPluginReadme() {
 
       const changelogStart = data.indexOf('== Changelog ==');
       output = data.substring(0, changelogStart) + changelog;
-      output += "\nFor the full changelog, visit https://faustjs.org/docs/changelog/faustwp";
+      output += "\n[View the full changelog](https://faustjs.org/docs/changelog/faustwp)";
 
       fs.writeFile(
         readmePath,


### PR DESCRIPTION
## Description

<!--
Include a summary of the change and some contextual information.
-->

- Adds `scripts/buildPluginReadme.js`, which pulls the notes for the latest three versions in CHANGELOG.md into `readme.txt`.
- Runs the script automatically during versioning with `npm run version`.

## Testing

You can test the script by manually adding a new version section to the plugin's CHANGELOG.md, running `node scripts/buildPluginReadme.js`, and confirming that the changelog section of `readme.txt` is correctly updated.