### PR TITLE
fix(tests): Fix repo path to E2E Next.js example

### DIFF
--- a/.github/workflows/e2e-next-example.yml
+++ b/.github/workflows/e2e-next-example.yml
@@ -4,6 +4,7 @@ jobs:
   e2e-test-next-getting-started-example:
     runs-on: ubuntu-latest
     env:
+      PR_REPO: ${{github.event.pull_request.head.repo.full_name}}
       PR_BRANCH: ${{github.event.pull_request.head.ref}}
     defaults:
       run:
@@ -19,12 +20,16 @@ jobs:
     - name: echo current pr branch name
       run: |
         echo $PR_BRANCH
+    # Get the PR repo so we can pull the correct Next.js example path
+    - name: echo current pr repo
+      run: |
+        echo $PR_REPO
     # Install the Faust.js Next getting started example via npx create next app
     # and use the PR branch to pull the correct example URL
     - name: npx create next app
       run: |
         npx create-next-app \
-          -e https://github.com/wpengine/faustjs/tree/${PR_BRANCH} \
+          -e https://github.com/${PR_REPO}/tree/${PR_BRANCH} \
           --example-path examples/next/getting-started \
           --use-npm \
           e2e-app


### PR DESCRIPTION
## Description

Fixes the path to the E2E example repo in the Next.js E2E Example Action

https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads#webhook-payload-example-32
