### PR TITLE
chore(examples): Git ignore `package-lock.json`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ process.yml
 !.env.local.sample
 .docusaurus
 build/
+examples/next/getting-started/package-lock.json


### PR DESCRIPTION
## Description

We do not want the `package-lock.json` file to be tracked in the `examples`. This PR Git ignores it from the monorepo root so it isn't tracked during development, but users who clone the example via `npx create-next-app` are able to track it.