### PR TITLE
Fix a minor import issue in the docs

### DIFF
--- a/internal/website/docs/next/guides/logging-queries.mdx
+++ b/internal/website/docs/next/guides/logging-queries.mdx
@@ -13,7 +13,10 @@ In a development environment, you may want to log GraphQL queries that are being
  * GQTY: You can safely modify this file and Query Fetcher based on your needs
  */
 import type { IncomingMessage } from 'http';
-import { getClient } from '@faustjs/next';
+import {
+  getClient,
+  logQueries,
+} from '@faustjs/next';
 import {
   generatedSchema,
   scalarsEnumsHash,


### PR DESCRIPTION
## Description
If we run the example code in the doc [Logging Queries](https://faustjs.org/docs/next/guides/logging-queries), we get this error
```typescript
ReferenceError: logQueries is not defined
  22 | 
  23 | if (process.env.NODE_ENV === 'development') {
> 24 |   logQueries(client);
     |  ^
  25 | }
  26 | 
  27 | export function serverClient(req: IncomingMessage) {
ReferenceError: logQueries is not defined
    at eval (webpack-internal:///./src/client/index.ts:22:3)
    at Object../src/client/index.ts (/var/www/next-nefrock-web/.next/server/pages/_app.js:22:1)
    at __webpack_require__ (/var/www/next-nefrock-web/.next/server/webpack-runtime.js:33:42)
    at eval (webpack-internal:///./src/pages/_app.tsx:13:64)
    at Object../src/pages/_app.tsx (/var/www/next-nefrock-web/.next/server/pages/_app.js:55:1)
    at __webpack_require__ (/var/www/next-nefrock-web/.next/server/webpack-runtime.js:33:42)
    at __webpack_exec__ (/var/www/next-nefrock-web/.next/server/pages/_app.js:668:39)
    at /var/www/next-nefrock-web/.next/server/pages/_app.js:669:28
    at Object.<anonymous> (/var/www/next-nefrock-web/.next/server/pages/_app.js:672:3)
    at Module._compile (node:internal/modules/cjs/loader:1101:14)
```

This change fixes the `import` of the example.
```
import {
  getClient,
  logQueries, // added
} from '@faustjs/next';
```

## Related Issue(s):
N/A

## Testing
No test for the docs

## Screenshots
N/A

## Documentation Changes
As described in the Description section

## Dependant PRs
N/A
