### PR TITLE
⚙️ chore(examples): Use Next.js 12

### DIFF
--- a/examples/next/getting-started/package.json
+++ b/examples/next/getting-started/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "@faustjs/core": "^0.15.0",
     "@faustjs/next": "^0.15.0",
-    "next": "^11.1.2",
+    "next": "^12.0.5",
     "normalize.css": "^8.0.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",

--- a/examples/next/getting-started/tsconfig.json
+++ b/examples/next/getting-started/tsconfig.json
@@ -17,7 +17,8 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",
-    "baseUrl": "./src"
+    "baseUrl": "./src",
+    "incremental": true
   },
   "include": [
     "next-env.d.ts",


### PR DESCRIPTION
## Description

Upgrade `examples/next/getting-started` to use Next.js 12. Also set the `incremental` flag in `tsconfig.json` to `true` as Next.js 12 does this automatically.

## Testing

1. Checkout the PR
2. `npm install` from the monorepo root
3. `npm run dev:next:getting-started` to start the dev server
4. Ensure example works as intended
