### PR TITLE
feat: add link to Settings page on Installed Plugins list page

### DIFF
--- a/.changeset/cyan-wasps-sell.md
+++ b/.changeset/cyan-wasps-sell.md
@@ -1,0 +1,5 @@
+---
+'faustwp': minor
+---
+
+feat: add link to Settings page on Installed Plugins list page

--- a/plugins/faustwp/includes/settings/callbacks.php
+++ b/plugins/faustwp/includes/settings/callbacks.php
@@ -353,3 +353,14 @@ function add_settings_assets() {
 		);
 	}
 }
+
+add_filter( 'plugin_action_links_faustwp/faustwp.php', __NAMESPACE__ . '\\add_action_link_settings' );
+/**
+ * Adds a link to the Settings page on the Installed Plugins page.
+ */
+function add_action_link_settings( $links ) {
+	$url = add_query_arg( 'page', 'faustwp-settings', get_admin_url() . 'admin.php' );
+	return array_merge( [
+		'<a href="' . esc_url( $url ) . '">' . esc_html__( 'Settings', 'faustwp' ) . '</a>'
+	], $links );
+}

--- a/plugins/faustwp/tests/integration/settings/test-functions.php
+++ b/plugins/faustwp/tests/integration/settings/test-functions.php
@@ -115,4 +115,11 @@ class FunctionsTest extends \WP_UnitTestCase {
 	public function faustwp_get_setting_test_filtered_value() {
 		return 'filtered value';
 	}
+
+	/**
+	 * Tests that plugin_action_links_faustwp/faustwp.php has callback attached.
+	 */
+	public function test_plugin_action_links_has_settings_callback_attached() {
+		$this->assertSame( 10, has_action( 'plugin_action_links_faustwp/faustwp.php', 'WPE\FaustWP\Settings\add_action_link_settings' ) );
+	}
 }


### PR DESCRIPTION
## Description
Adds a link to the plugin's Settings page when viewing the Plugins > Installed Plugins page.

I noticed someone saying they had a hard time finding the settings page and thought this might be helpful.

## Testing
Verified the link appears and works. Wrote unit test to check for callback.

## Screenshots
![image](https://user-images.githubusercontent.com/1254870/145621490-c5aaaf09-49a8-450d-9130-088ba44942c8.png)

## Documentation Changes
Added Settings page link to Installed Plugins list.
