### PR TITLE
fix: correct admin url for plugin settings link

### DIFF
--- a/plugins/faustwp/includes/settings/callbacks.php
+++ b/plugins/faustwp/includes/settings/callbacks.php
@@ -359,7 +359,7 @@ add_filter( 'plugin_action_links_faustwp/faustwp.php', __NAMESPACE__ . '\\add_ac
  * Adds a link to the Settings page on the Installed Plugins page.
  */
 function add_action_link_settings( $links ) {
-	$url = add_query_arg( 'page', 'faustwp-settings', get_admin_url() . 'admin.php' );
+	$url = add_query_arg( 'page', 'faustwp-settings', admin_url('options-general.php') );
 	return array_merge( [
 		'<a href="' . esc_url( $url ) . '">' . esc_html__( 'Settings', 'faustwp' ) . '</a>'
 	], $links );


### PR DESCRIPTION
## Description

<!--
Include a summary of the change and some contextual information.
-->

Small update to the URL we use for the settings link on the plugin page. The former one got you to the right screen, but wasn't recognized and highlighted in the sidebar. We use `options-general.php?page=faustwp-settings` everywhere else, so this just keeps us consistent and restores the menu item's active state in the sidebar.