### PR TITLE
doc(post-page-previews.mdx) Update docs using `usePreviewNode` hook

### DIFF
--- a/internal/website/docs/next/guides/post-page-previews.mdx
+++ b/internal/website/docs/next/guides/post-page-previews.mdx
@@ -69,65 +69,69 @@ export default apiRouter;
 
 With your headless secret set and the `authorizeHandler` ready to handle requests, you can now create a Next.js [page](https://nextjs.org/docs/basic-features/pages) for previews. Create a file at `/src/pages/preview.tsx` with the following:
 
+> **NOTE**: The `usePreviewNode` was introduced in `v0.15.1` and replaces the `usePreview` hook.
+From now on you should be using this hook for showing preview content.
+
+
 ```tsx title=src/pages/preview.tsx
 import { PageComponent } from './[...pageUri]';
 import { PostComponent } from './posts/[postSlug]';
+import type { Page, Post } from 'client';
 import { client } from 'client';
 
 export default function Preview() {
-  const { usePreview } = client.auth;
-  const result = usePreview();
+  const { typeName, node } = client.auth.usePreviewNode();
 
-  if (client.useIsLoading() || !result) {
+  if (client.useIsLoading() || node === undefined) {
     return <p>loading...</p>;
   }
 
-  if (result.type === 'page') {
-    if (!result.page) {
-      return <>Not Found</>;
+  if (node === null) {
+    return <p>Post not found</p>;
+  }
+
+  switch (typeName) {
+    case 'Page': {
+      return <PageComponent page={node as Page} />
     }
-
-    return <PageComponent page={result.page} />;
+    case 'Post': {
+      return <PostComponent post={node as Post} />
+    }
+    // Add custom post types here as needed
+    default: {
+      throw new Error(`Unknown post type: ${typeName}`);
+    }
   }
-
-  if (!result.post) {
-    return <>Not Found</>;
-  }
-
-  return <PostComponent post={result.post} />;
 }
 ```
 
 Let's break down what is going on here:
 
-First, we are getting the `usePreview` hook from the `auth` property of the `client`:
+First, we are getting the `usePreviewNode` hook from the `auth` property of the `client` and we extract the typeName and node properties.
 
 ```tsx
-const { usePreview } = client.auth;
+const { typeName, node } = client.auth.usePreviewNode();
 ```
 
-We can then get the result of the `usePreview` hook:
-
-```tsx
-const result = usePreview();
-```
+The `typeName` specifies the type of the node content (`Page`, `Post` or any `Custom Post Type`).
+The `node` on the other hand represents the actual data for that particular node content.
+Since Typescript cannot infer the type correctly (since it thinks that it's still a `Node` type), we need to cast it to the correct type before we pass it on as a property to the component.
 
 From there, we can make a determination if the result is a page or post, and render the appropriate component:
 
 ```tsx
-if (result.type === 'page') {
-  if (!result.page) {
-    return <>Not Found</>;
+switch (typeName) {
+  case 'Page': {
+    return <PageComponent page={node as Page} />
   }
-
-  return <PageComponent page={result.page} />;
+  case 'Post': {
+    return <PostComponent post={node as Post} />
+  }
+  // Add custom post types here as needed
+  default: {
+    throw new Error(`Unknown post type: ${typeName}`);
+  }
 }
-
-if (!result.post) {
-  return <>Not Found</>;
-}
-
-return <PostComponent post={result.post} />;
 ```
 
 We abstract the page and post layouts into components to be reusable so there is no divergence between preview pages/posts and actual pages/posts.


### PR DESCRIPTION
Signed-off-by: theodesp <theo.despoudis@wpengine.com>

## Description

The Custom Post Types guid demonstrates now how to create single pages for each custom post type post using the new `usePreviewNode` hook.

## Related Issue(s):

Closes #544

## Testing

* Run the docs locally and observe the new content.

<!--
Describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Also list any relevant details for your test configuration such as how to test the changes locally or in staging.
-->

## Screenshots

<!--
If this is a visual change include relevant screenshots about the behavior of the application before and after this change.
-->

<img width="1077" alt="Screenshot 2021-12-14 at 15 03 53" src="https://user-images.githubusercontent.com/328805/146023861-a392259e-816b-4025-8fc7-37002eecbbeb.png">

<img width="1090" alt="Screenshot 2021-12-14 at 15 03 59" src="https://user-images.githubusercontent.com/328805/146023835-f895cbed-48ed-4385-82fb-eaf8a4c5a15e.png">


## Documentation Changes

<!--
List corresponding changes to the documentation.
-->

See commit changes 

## Dependant PRs

<!--
List any dependent PR's that are awaiting review. Use the following syntax:

- #1234
-->
