### PR TITLE
Add simulated workflow for post release tasks

### DIFF
--- a/.github/actions/post-release/index.js
+++ b/.github/actions/post-release/index.js
@@ -1,0 +1,16 @@
+async function mergeToMain({github, context}) {
+  console.log("TEST: Merging canary to main...");
+
+  const result = await github.rest.repos.merge({
+      ...context.repo,
+      base: "TEST_main",
+      head: "TEST_canary",
+      commit_message: "TEST: Merge release from branch `canary` into `main`"
+  });
+
+  return result;
+}
+
+module.exports = {
+  mergeToMain
+}

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -1,0 +1,37 @@
+name: Post-release jobs
+
+on:
+  workflow_dispatch:
+    inputs:
+      published:
+        description: "Simulates whether changesets did or did not publish a release."
+        required: true
+        default: "false"
+
+jobs:
+  simulate_output:
+    name: "Simulate changesets/action output"
+    runs-on: ubuntu-latest
+    outputs:
+      published: ${{ steps.step1.outputs.published }}
+    steps:
+      - id: step1
+        run: echo "::set-output name=published::${{ github.event.inputs.published }}"
+  merge_to_main:
+    name: "Merge `canary` into `main`"
+    runs-on: ubuntu-latest
+    needs: simulate_output
+    if: ${{ needs.simulate_output.outputs.published == 'true' }}
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v2
+        with:
+          # This makes Actions fetch all Git history so that Changesets can generate changelogs with the correct commits
+          fetch-depth: 0
+
+      - name: Merge to main
+        uses: actions/github-script@v5
+        with:
+          script: |
+            const { mergeToMain } = require('.github/actions/post-release/index.js')
+            return await mergeToMain({github, context})


### PR DESCRIPTION
## Description

<!--
Include a summary of the change and some contextual information.
-->

Creates a manually dispatched workflow for testing a job that will automatically merge `canary` into `main` after a Changesets release.

Currently there is no connection between this workflow and the actual Changesets workflow. I've simulated the outputs we get from Changesets for now. If everything works as expected in this simulation, the next step would be to move the `merge_to_main` job into the `release-packages.yml` workflow and hook up the outputs/inputs there.

## Testing

I've run as much of this as I can locally with `act`, but it needs to be in GitHub to fully test the merge behavior. More specifically, it needs to be on `canary` since the `workflow_dispatch` event I'm using to test can only be triggered from the default branch. The job is currently configured to merge a temporary `TEST_canary` branch into a temporary `TEST_main` branch, so there's no risk of it messing with real history. Once this is merged we should see the following:

1. Manually dispatch the "Post-release jobs" workflow with `published=true` as an input.
2. Confirm that `TEST_canary` is successfully merged into `TEST_main`.
3. Manually dispatch the "Post-release jobs" workflow with `published=false` as an input.
4. Confirm that no merge occurs.