### PR TITLE
Properly invalidate refresh token upon expiration

### DIFF
--- a/.changeset/cool-bikes-grab.md
+++ b/.changeset/cool-bikes-grab.md
@@ -1,0 +1,5 @@
+---
+'@faustjs/core': patch
+---
+
+Fixed a bug where expired refresh tokens were not being cleared from the browser cookie, possibly resulting in infinite loops during authentication, or an inability to request authenticated content.

--- a/packages/core/src/server/auth/middleware.ts
+++ b/packages/core/src/server/auth/middleware.ts
@@ -62,10 +62,18 @@ export async function authorizeHandler(
         res.statusCode = result.response.status;
       } else {
         res.statusCode = 401;
-
-        // If the response to the token endpoint is unauthorized, remove the existing refresh token.
-        oauth.setRefreshToken(undefined);
       }
+
+      /**
+       * If the response to the authorization request does not match
+       * isOAuthTokens, remove the refresh token from the cookie in the case
+       * the token is:
+       * - expired
+       * - invalid
+       * - revoked
+       * - from a different WordPress instance when developing on localhost
+       */
+      oauth.setRefreshToken(undefined);
 
       res.setHeader('Content-Type', 'application/json');
       res.end(JSON.stringify(result.result));


### PR DESCRIPTION
## Description

Currently refresh tokens that have been expired are not being properly invalidated and unset due to a bug. The logic is correct, however, it is in a conditional that it should not be in. This PR brings that logic outside of the conditional to properly invalidate the refresh token.

[Video demonstration of the bug](https://www.youtube.com/watch?v=ApqcCDfqaFg) (love this idea @jasonbahl)

## Testing

1. Clone Faust and create a page called `auth-content.tsx` with the following content:
    ```tsx
    import { client } from 'client';
    
    export default function Page() {
      const { isAuthenticated } = client.auth.useAuth();
      
      return <div>My Page</div>;
    }
    ```
2. On line 128 of `plugins/faustwp/includes/rest/callbacks.php`, set `$refresh_token_expiration` to some thing very short, like `5`.
3. Start the dev server running `npm run dev:next:getting-started` from the monorepo root
4. Go to `localhost:3000` and ensure you have no cookies saved for `localhost`
5. Go to `localhost:3000/auth-content`, notice that authorization happens, a refresh token is set, and authenticated content is now showing.
6. Wait 6 seconds for the refresh token to become expired
7. Refresh the page, and notice an infinite loop of authorization requests.
8. Now, checkout the PR
9. Follows steps 4-7, but now notice that the refresh token was properly unset, and a new authorization code was requested.