### PR TITLE
Document WPGraphQL CPT Previews bugfix 

### DIFF
--- a/internal/website/docs/next/guides/post-page-previews.mdx
+++ b/internal/website/docs/next/guides/post-page-previews.mdx
@@ -155,3 +155,8 @@ Clicking on **Preview in new tab** should take you to your post preview page wit
   src="/docs/img/post-preview-frontend.png"
   alt="Post preview on the frontend in Next.js"
 />
+
+
+> **NOTE**: If you are having problems viewing Custom Post Type (CPT) previews using the above example,
+you need to make sure you have installed the latest version of the WPGraphQL plugin (> v1.6.11).
+It especially contains a bug fix when the draft previews query returns null for CPTs without revisions.


### PR DESCRIPTION
Signed-off-by: theodesp <theo.despoudis@wpengine.com>

## Description

Adds note in docs for Custom Post Type (CPT) previews bugfix in latest WPGraphQL.

## Related Issue(s):

<!--
Provide the GitHub issue(s) number for issue tracking purposes, use the following syntax:

- #1234
-->

## Testing

<!--
Describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Also list any relevant details for your test configuration such as how to test the changes locally or in staging.
-->

Manually verified that CPTs without revision previews using the latest WPGraphQL plugin works correctly. I added a note in docs to reflect that.

## Screenshots

<!--
If this is a visual change include relevant screenshots about the behavior of the application before and after this change.
-->

## Documentation Changes

<!--
List corresponding changes to the documentation.
-->

Added note in `post-page-previews.mdx`

## Dependant PRs

<!--
List any dependent PR's that are awaiting review. Use the following syntax:

- #1234
-->
