### PR TITLE
🔨 refactor(examples): Enforce Node Engine

### DIFF
--- a/examples/next/getting-started/package.json
+++ b/examples/next/getting-started/package.json
@@ -2,6 +2,9 @@
   "name": "next-headless-getting-started",
   "version": "0.1.0",
   "private": true,
+  "engines": {
+    "node": ">=14.0.0"
+  },
   "scripts": {
     "dev": "next dev",
     "build": "next build",

--- a/examples/next/getting-started/package.json
+++ b/examples/next/getting-started/package.json
@@ -3,7 +3,8 @@
   "version": "0.1.0",
   "private": true,
   "engines": {
-    "node": ">=14.0.0"
+    "node": ">=14.0.0",
+    "npm": ">=6.0.0"
   },
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## Description

Since Faust.js uses ES Modules, Node 12 will not work as intended. Specifying a Node version greater than 14 should help fix this.
