### PR TITLE
Allow saving from WP's file editor

### DIFF
--- a/plugins/faustwp/includes/deny-public-access/callbacks.php
+++ b/plugins/faustwp/includes/deny-public-access/callbacks.php
@@ -38,6 +38,11 @@ function deny_public_access() {
 	// Get the request uri with query params.
 	$request_uri = home_url( add_query_arg( null, null ) );
 
+	// Allow saving from file editor.
+	if ( false !== strpos( $request_uri, 'wp_scrape_key' ) ) {
+		return;
+	}
+
 	$response_code = 302;
 	$redirect_url  = str_replace( trailingslashit( get_home_url() ), $frontend_uri, $request_uri );
 


### PR DESCRIPTION
## Description

Although the core hook [template_redirect](https://developer.wordpress.org/reference/hooks/template_redirect/) does not directly fire for wp-admin pages, it does fire for some admin facing actions like when attempting to save changes in WordPress' file editor.

The file editor attempts to perform a 'scrape' of the file by making a request to the front-end of the site with some query args.

```
http://wp.local/?wp_scrape_key=XXXXXXXXXX&wp_scrape_nonce=XXXXX
```

## Testing

1. Ensure “Disable WordPress theme admin pages” is disabled in FaustWP
2. Go to “functions.php” in active WordPress theme
3. Add a new function at the bottom of “functions.php”:
    ```php
    function test_save_file() {
      // Do nothing
    }
    add_action( 'wp_head', 'test_save_file' );
    ```
4. Save file.
5. Notice the following message. 
>File edited successfully.


