### PR TITLE
feat[core]: (#739) allow plugins to filter out pages from public url redirect

### DIFF
--- a/plugins/faustwp/includes/deny-public-access/callbacks.php
+++ b/plugins/faustwp/includes/deny-public-access/callbacks.php
@@ -32,6 +32,13 @@ function deny_public_access() {
 	if ( ! $frontend_uri ) {
 		return;
 	}
+	
+	// Allow for some URLs not to be redirected
+	$excluded_pages = apply_filters( 'faustwp_exclude_from_public_redirect', [] );
+
+	if( in_array( basename( add_query_arg( null, null ) ), $excluded_pages ) ) {
+		return;
+	}
 
 	$frontend_uri = trailingslashit( $frontend_uri );
 


### PR DESCRIPTION
Offer the option to exclude specific pages from redirect should a developer have a need to do this.

## Description

The WordPress plugin offers the option to redirect all or none of the pages to the headless site URI. There may be cases where a developer would want some exceptions to this all or nothing approach. For instance if someone is using WooCommerce and wants to use the WooCommerce checkout page without having to rewrite all the logic in the headless site.

## Related Issue(s):
- #739 


## Testing

I added the following filter to a custom plugin I built after modifying callbacks.php to include this filter.

```PHP
add_filter( 'faustwp_exclude_from_public_redirect', function( $excluded ) {
  $excluded = array_merge( $excluded, [
    'checkout',
    'cart',
    'shop',
  ]);
  return $excluded;
}, 10, 1 );
```
This successfully prevented redirecting from https://mywordpresssite.com/shop/ to http://localhost:3000/shop. I tested other URLs such as https://mywordpresssite.com/alligator/ and that DID redirect correctly.
