### PR TITLE
Add algolia search

### DIFF
--- a/internal/website/docusaurus.config.js
+++ b/internal/website/docusaurus.config.js
@@ -17,6 +17,15 @@ module.exports = {
   organizationName: 'wpengine', // Usually your GitHub org/user name.
   projectName: 'faustjs', // Usually your repo name.
   themeConfig: {
+    algolia: {
+      // If Algolia did not provide you any appId, use 'BH4D9OD16A'
+      appId: 'KUERGG39MB',
+
+      // Public API key: it is safe to commit it
+      apiKey: '1f3b1850f5442cf1d15033644ff5b1d3',
+
+      indexName: 'faustjs',
+    },
     navbar: {
       title: 'Faust.js™',
       // logo: {

--- a/internal/website/src/pages/index.js
+++ b/internal/website/src/pages/index.js
@@ -18,7 +18,8 @@ function HomepageHeader() {
         <div className={styles.buttons}>
           <Link
             className="button button--info button--lg"
-            to="/docs/next/getting-started">
+            to="/docs/next/getting-started"
+          >
             Get Started
           </Link>
         </div>
@@ -38,12 +39,13 @@ export default function Home() {
       <Head>
         <meta
           httpEquiv="Content-Security-Policy"
-          content="default-src 'self' data: 'unsafe-inline' 'unsafe-eval'"
+          content="default-src 'self' http://kuergg39mb-dsn.algolia.net data: 'unsafe-inline' 'unsafe-eval'"
         />
       </Head>
       <Layout
         title={siteConfig.tagline}
-        description={siteConfig.customFields.description}>
+        description={siteConfig.customFields.description}
+      >
         <HomepageHeader />
         <main>
           <HomepageFeatures />


### PR DESCRIPTION
## Description

Add [Algolia DocSearch](https://docsearch.algolia.com/) to the docs site.

## Staging URL

https://hcixzyt38dn5ak04xxcqc36lf.js.wpenginepowered.com/

## Screenshots
<img width="1920" alt="Screen Shot 2022-01-26 at 8 48 05 AM" src="https://user-images.githubusercontent.com/5946219/151185269-d9124683-c616-46b7-985b-34495c6b819f.png">

<img width="1920" alt="Screen Shot 2022-01-26 at 8 48 12 AM" src="https://user-images.githubusercontent.com/5946219/151185309-34ab71f8-94c5-43db-b75a-3bcefe255b33.png">


