### PR TITLE
Deprecate template conditionals

### DIFF
--- a/.changeset/funny-cycles-cry.md
+++ b/.changeset/funny-cycles-cry.md
@@ -1,0 +1,5 @@
+---
+'faustwp': minor
+---
+
+ConditionalTags has been deprecated as it was introduced in an older version of the framework when routing was done from the NextTemplateLoader. Now that we are using Next.js pages for routing, conditionalTags are no longer needed.

--- a/.changeset/funny-cycles-cry.md
+++ b/.changeset/funny-cycles-cry.md
@@ -1,5 +1,5 @@
 ---
-'faustwp': minor
+'faustwp': patch
 ---
 
 ConditionalTags has been deprecated as it was introduced in an older version of the framework when routing was done from the NextTemplateLoader. Now that we are using Next.js pages for routing, conditionalTags are no longer needed.

--- a/plugins/faustwp/includes/graphql/callbacks.php
+++ b/plugins/faustwp/includes/graphql/callbacks.php
@@ -133,6 +133,8 @@ add_action( 'graphql_register_types', __NAMESPACE__ . '\\register_conditional_ta
  * @uses WPE\FaustWP\GraphQL\get_conditional_tags
  *
  * @uses register_graphql_object_type
+ *
+ * @deprecated
  */
 function register_conditional_tags_field() {
 	register_graphql_object_type(
@@ -142,8 +144,9 @@ function register_conditional_tags_field() {
 			'fields'      => array_map(
 				function ( $tag ) {
 					return array(
-						'type'        => 'Boolean',
-						'description' => $tag['description'],
+						'type'              => 'Boolean',
+						'deprecationReason' => __( 'Deprecated in favor of using Next.js pages', 'faustwp' ),
+						'description'       => $tag['description'],
 					);
 				},
 				array_combine(
@@ -161,8 +164,9 @@ function register_conditional_tags_field() {
 		'UniformResourceIdentifiable',
 		'conditionalTags',
 		array(
-			'type'    => 'ConditionalTags',
-			'resolve' => __NAMESPACE__ . '\\conditional_tags_resolver',
+			'type'              => 'ConditionalTags',
+			'deprecationReason' => __( 'Deprecated in favor of using Next.js pages', 'faustwp' ),
+			'resolve'           => __NAMESPACE__ . '\\conditional_tags_resolver',
 		)
 	);
 }


### PR DESCRIPTION
## Description

Now that we are using Next.js pages for routing, conditionalTags are no longer needed.

## Screenshots

<img width="347" alt="Screen Shot 2022-01-31 at 9 52 05 AM" src="https://user-images.githubusercontent.com/6676674/151815464-feb55697-9d2a-4c9e-b0ab-6e4ed3081959.png">

<img width="345" alt="Screen Shot 2022-01-31 at 9 40 22 AM" src="https://user-images.githubusercontent.com/6676674/151815319-6ef69bb6-c0b5-4647-8749-0237f033c49d.png">
