### PR TITLE
Sync `examples/next/getting-started` to Atlas Template

### DIFF
--- a/.github/workflows/sync-example-to-template.yml
+++ b/.github/workflows/sync-example-to-template.yml
@@ -11,6 +11,7 @@ jobs:
     env:
       CHECKOUT_DIR_NAME: ${{ github.event.repository.name }}
       SOURCE_REPO: ${{ github.event.repository.full_name }}
+      SOURCE_AFTER_SHA: ${{ github.event.after }}
       TARGET_REPO: wpengine/faust-atlas-hello-world
       TARGET_BRANCH: main
       SYNC_DIR: examples/next/getting-started # No trailing slash
@@ -52,7 +53,7 @@ jobs:
           git status
 
           # If there are changes, commit them
-          git diff-index --quiet HEAD || git commit -m "Automatic sync from $SOURCE_REPO"
+          git diff-index --quiet HEAD || git commit -m "Automatic sync from $SOURCE_REPO@$SOURCE_AFTER_SHA"
           
           # Push to the target branch
           git push origin $TARGET_BRANCH

--- a/.github/workflows/sync-example-to-template.yml
+++ b/.github/workflows/sync-example-to-template.yml
@@ -1,0 +1,58 @@
+name: Sync example project to Atlas template
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'examples/next/getting-started/**'
+jobs:
+  sync_example_project_to_atlas_template:
+    runs-on: ubuntu-latest
+    env:
+      CHECKOUT_DIR_NAME: ${{ github.event.repository.name }}
+      SOURCE_REPO: ${{ github.event.repository.full_name }}
+      TARGET_REPO: wpengine/faust-atlas-hello-world
+      TARGET_BRANCH: main
+      SYNC_DIR: examples/next/getting-started # No trailing slash
+      GIT_EMAIL: bot@wpengine.com
+      GIT_NAME: WP Engine Bot 
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Set SSH Agent
+        uses: webfactory/ssh-agent@v0.5.4
+        with:
+          ssh-private-key: ${{ secrets.SYNC_ATLAS_TEMPLATE_SSH_PRIVATE_KEY }}
+      - name: Sync Atlas Template
+        run: |
+          # Store the code we want to push to the target in "source" dir
+          cd ../
+          mkdir source
+
+          # Move all files in SYNC_DIR to the "source" dir
+          cd $CHECKOUT_DIR_NAME
+          mv $SYNC_DIR/* ../source/
+          cd ../
+
+          # Clone the target repo, and move it's .git dir to the "source" dir
+          git clone git@github.com:$TARGET_REPO.git target
+          cd target
+          mv .git ../source
+          cd ../
+
+          cd source
+
+          # This is the committer who will show up in the target repo
+          git config user.email "$GIT_EMAIL"
+          git config user.name "$GIT_NAME"
+
+          # Add all the recent changes non-existent in the target
+          git add .
+
+          git status
+
+          # If there are changes, commit them
+          git diff-index --quiet HEAD || git commit -m "Automatic sync from $SOURCE_REPO"
+          
+          # Push to the target branch
+          git push origin $TARGET_BRANCH


### PR DESCRIPTION
This PR sets up a workflow to sync the example project (`examples/next/getting-started`) to the Atlas template for User Portal ([wpengine/faust-atlas-hello-world](https://github.com/wpengine/faust-atlas-hello-world)) when there are changes to `examples/next/getting-started` in the `main` branch of the `wpengine/faustjs` repo.

In order to allow the `wpengine/faustjs` repo to make commits in `wpengine/faust-atlas-hello-world`, we would need to either generate a [Personal Access Token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) (PAT), or use [deploy keys](https://docs.github.com/en/developers/overview/managing-deploy-keys), as the `GITHUB_TOKEN` env var that is loaded into GitHub Actions only has permissions for the repo it runs in.

PATs give access to all repos, and are linked to a specific user, so it is not ideal in this scenario. Instead, we'll use deploy keys. Deploy keys will allow us to make commits and pushes via an SSH key.

We'll have to generate an SSH key using the following command:
```bash
ssh-keygen -t ed25519  -C "Atlas Template Sync Key" -f path/to/keyfile
```

The SSH public key lives on the `faust-atlas-hello-world` repo as a deploy key, where the SSH private key will be stored in a secret in this repo, which we can access in our GitHub Actions workflow.

Todos before merging:
- [x] Setup deploy key on `faust-atlas-hello-world`
- [x] Setup SSH private key secret on `faustjs`
