### PR TITLE
Add missing type dependencies

### DIFF
--- a/examples/next/getting-started/package.json
+++ b/examples/next/getting-started/package.json
@@ -27,7 +27,9 @@
   },
   "devDependencies": {
     "@gqty/cli": "^2.3.1",
+    "@types/node": "^17.0.14",
     "@types/react": "^17.0.37",
+    "@types/react-dom": "^17.0.11",
     "dotenv-flow": "3.2.0",
     "eslint": "^8.4.1",
     "eslint-config-next": "^12.0.7",


### PR DESCRIPTION
## Description

Added missing type dependencies as noted in https://github.com/vercel/next.js/blob/canary/examples/with-typescript/package.json

## Related Issue(s):

None

## Testing

N/A

## Screenshots

N/A

## Documentation Changes

N/A

## Dependent PRs

N/A
