### PR TITLE
🐞 fix(ci): Properly sync dot files for Atlas template

### DIFF
--- a/.github/workflows/sync-example-to-template.yml
+++ b/.github/workflows/sync-example-to-template.yml
@@ -30,15 +30,17 @@ jobs:
           cd ../
           mkdir source
 
-          # Move all files in SYNC_DIR to the "source" dir
+          # Rsync all files in SYNC_DIR to the "source" dir
+          # Using -a, the archive flag, to preserve ownership and permissions
+          # Using --no-compress as the sync is between local devices
           cd $CHECKOUT_DIR_NAME
-          mv $SYNC_DIR/* ../source/
+          rsync -a --no-compress $SYNC_DIR/ ../source/
           cd ../
 
-          # Clone the target repo, and move it's .git dir to the "source" dir
+          # Clone the target repo, and rsync it's .git dir to the "source" dir
           git clone git@github.com:$TARGET_REPO.git target
           cd target
-          mv .git ../source
+          rsync -a --no-compress .git ../source
           cd ../
 
           cd source


### PR DESCRIPTION
## Description

The Atlas template sync workflow has a bug where it will not properly sync dot files, since the `mv` command with wildcard glob doesn't recognize hidden files. This PR addresses this by using `rsync` instead.

## Screenshots
<img width="814" alt="Screen Shot 2022-02-07 at 8 46 37 AM" src="https://user-images.githubusercontent.com/5946219/152810652-6e3e3c3e-2739-4537-a9ad-fd87ed07f534.png">

