### PR TITLE
Standardize the import path in the docs

### DIFF
--- a/internal/website/docs/next/guides/authentication.mdx
+++ b/internal/website/docs/next/guides/authentication.mdx
@@ -4,11 +4,9 @@ title: Authentication
 description: Use Faust.js' built-in authentication strategies to authenticate users from your WordPress backend
 ---
 
-:::note
+import BaseUrlNotice from '@site/src/mdx/base-url-notice.mdx';
 
-This guide assumes you're storing your pages/styles/etc. in a directory called `src`, and you have the `baseUrl` option set to `src` in your `tsconfig.json` for import modules from the root.
-
-:::
+<BaseUrlNotice />
 
 Authentication can be a cumbersome process when building headless WordPress sites. Thankfully, Faust.js takes care of all your authentication needs in your Next.js application.
 

--- a/internal/website/docs/next/guides/authentication.mdx
+++ b/internal/website/docs/next/guides/authentication.mdx
@@ -4,6 +4,12 @@ title: Authentication
 description: Use Faust.js' built-in authentication strategies to authenticate users from your WordPress backend
 ---
 
+:::note
+
+This guide assumes you're storing your pages/styles/etc. in a directory called `src`, and you have the `baseUrl` option set to `src` in your `tsconfig.json` for import modules from the root.
+
+:::
+
 Authentication can be a cumbersome process when building headless WordPress sites. Thankfully, Faust.js takes care of all your authentication needs in your Next.js application.
 
 ## How It Works
@@ -220,7 +226,7 @@ export default function Page() {
 
 Requests using the above methodology will be un-authenticated.
 
-To make authenticated requests, use the `auth` property exported from the `client`. This  property is essentially a replica of the `client`, except every request gets called with an access token:
+To make authenticated requests, use the `auth` property exported from the `client`. This property is essentially a replica of the `client`, except every request gets called with an access token:
 
 ```TSX {1,4,5}
 import { client } from 'client';

--- a/internal/website/docs/next/guides/custom-post-types.mdx
+++ b/internal/website/docs/next/guides/custom-post-types.mdx
@@ -14,15 +14,21 @@ Before we start, if you haven't already, [setup your WordPress site for headless
 
 We'll be using the [Atlas Content Modeler](https://github.com/wpengine/atlas-content-modeler) plugin to create custom post types for this guide, but you can choose to create custom post types in any way you'd like.
 
-Atlas Content Modeler is a WordPress plugin to create custom post types and fields for headless WordPress sites. Start by downloading the plugin and activating it on your WordPress site [(Download)](https://wp-product-info.wpesvc.net/v1/plugins/atlas-content-modeler?download)
+Atlas Content Modeler is a WordPress plugin to create custom post types and fields for headless WordPress sites. Start by downloading the plugin and activating it on your WordPress site [(Download)](https://wordpress.org/plugins/atlas-content-modeler/).
 
 Now, navigate to WP Admin -> Content Modeler.
 
-<img src="/docs/img/empty-content-modeler.png" alt="The Atlas Content Modeler admin interface" />
+<img
+  src="/docs/img/empty-content-modeler.png"
+  alt="The Atlas Content Modeler admin interface"
+/>
 
 Let's create a custom post type for team members. Click the "Get Started" button, and fill out the fields to create a new Content Model. Be sure to mark "API Visibility" to "Public" so we can query the data.
 
-<img src="/docs/img/team-members-content-modeler.png" alt="The Atlas Content Modeler admin interface with fields for a team member content type" />
+<img
+  src="/docs/img/team-members-content-modeler.png"
+  alt="The Atlas Content Modeler admin interface with fields for a team member content type"
+/>
 
 ## Create Fields for the Custom Post Type
 
@@ -34,7 +40,10 @@ We'll add three fields:
 2. A Text field type. The name will be "Full Name" and the API identifier "fullName". We'll also select "Use this field as the entry title".
 3. A Rich Text field type. The name will be "Bio" and the API identifier "bio".
 
-<img src="/docs/img/team-members-content-modeler-fields.png" alt="The Atlas Content Modeler admin interface with filled custom fields" />
+<img
+  src="/docs/img/team-members-content-modeler-fields.png"
+  alt="The Atlas Content Modeler admin interface with filled custom fields"
+/>
 
 ## Add Some Team Members
 
@@ -42,7 +51,10 @@ Now that you have created a custom post type and fields, you can start entering 
 
 For this example, I've created two team members, Jane and John Doe, with bios and profile pics:
 
-<img src="/docs/img/content-modeler-add-team-member.png" alt="Atlas Content Modeler Custom Post Type interface for adding a new item" />
+<img
+  src="/docs/img/content-modeler-add-team-member.png"
+  alt="Atlas Content Modeler Custom Post Type interface for adding a new item"
+/>
 
 ## Clone the Starter Headless Project
 
@@ -116,8 +128,8 @@ We'll create a team page in `src/pages/team.tsx` to display the team members:
 
 ```tsx title=src/pages/team.tsx
 import Head from 'next/head';
-import { Header, Footer } from '../components';
-import { client } from '../client';
+import { Header, Footer } from 'components';
+import { client } from 'client';
 
 export default function Team() {
   const { generalSettings } = client.useQuery();
@@ -147,20 +159,26 @@ export default function Team() {
 
 This will look something like:
 
-<img src="/docs/img/nextjs-empty-team-members-page.png" alt="An empty web page with a large title for team members" />
+<img
+  src="/docs/img/nextjs-empty-team-members-page.png"
+  alt="An empty web page with a large title for team members"
+/>
 
 ### Query for Team Members
 
 When querying custom post types in Faust.js, you can leverage the `useQuery` hook exported from the client. `useQuery` allows you to access all of WordPress' data. You'll also notice it's typed from your schema, making things super easy to find.
 
-<img src="/docs/img/useQuery-typed.png" alt="A screenshot of the useQuery hook and its typings" />
+<img
+  src="/docs/img/useQuery-typed.png"
+  alt="A screenshot of the useQuery hook and its typings"
+/>
 
 Let's get the team members using the `useQuery` hook:
 
 ```tsx title=src/pages/team.tsx {6,8}
 import Head from 'next/head';
-import { Header, Footer } from '../components';
-import { client } from '../client';
+import { Header, Footer } from 'components';
+import { client } from 'client';
 
 export default function Team() {
   const { useQuery } = client;
@@ -224,9 +242,9 @@ Finally, let's hook up the `TeamMember` component to the team page.
 
 ```tsx title=src/pages/team.tsx {4,27-29}
 import Head from 'next/head';
-import { Header, Footer } from '../components';
-import { client } from '../client';
-import TeamMember from '../components/teamMember';
+import { Header, Footer } from 'components';
+import { client } from 'client';
+import TeamMember from 'components/teamMember';
 
 export default function Team() {
   const { useQuery } = client;
@@ -263,13 +281,16 @@ export default function Team() {
 
 Now, head back to [http://localhost:3000/team](http://localhost:3000/team) to see your WordPress data come to life!
 
-<img src="/docs/img/nextjs-team-page.png" alt="A web page with a list of team members" />
+<img
+  src="/docs/img/nextjs-team-page.png"
+  alt="A web page with a list of team members"
+/>
 
 ## Learnings
 
 In this guide, we demonstrated:
 
-* How to create custom post types/fields using [Atlas Content Modeler](https://github.com/wpengine/atlas-content-modeler)
-* Creating data for your custom post types
-* Creating a starter frontend project to consume your WordPress data
-* Using the `useQuery` custom React hook in the framework to query your custom post type data in GraphQL
+- How to create custom post types/fields using [Atlas Content Modeler](https://github.com/wpengine/atlas-content-modeler)
+- Creating data for your custom post types
+- Creating a starter frontend project to consume your WordPress data
+- Using the `useQuery` custom React hook in the framework to query your custom post type data in GraphQL

--- a/internal/website/docs/next/guides/custom-post-types.mdx
+++ b/internal/website/docs/next/guides/custom-post-types.mdx
@@ -4,6 +4,12 @@ title: Interacting with Custom Post Types
 description: Querying data in custom post types is just as easy as querying for posts or pages in Faust.js.
 ---
 
+:::note
+
+This guide assumes you're storing your pages/styles/etc. in a directory called `src`, and you have the `baseUrl` option set to `src` in your `tsconfig.json` for import modules from the root.
+
+:::
+
 # Interacting with Custom Post Types
 
 Querying data in custom post types is just as easy as querying for posts or pages in Faust.js.

--- a/internal/website/docs/next/guides/custom-post-types.mdx
+++ b/internal/website/docs/next/guides/custom-post-types.mdx
@@ -4,11 +4,9 @@ title: Interacting with Custom Post Types
 description: Querying data in custom post types is just as easy as querying for posts or pages in Faust.js.
 ---
 
-:::note
+import BaseUrlNotice from '@site/src/mdx/base-url-notice.mdx';
 
-This guide assumes you're storing your pages/styles/etc. in a directory called `src`, and you have the `baseUrl` option set to `src` in your `tsconfig.json` for import modules from the root.
-
-:::
+<BaseUrlNotice />
 
 # Interacting with Custom Post Types
 

--- a/internal/website/docs/next/guides/fetching-data.mdx
+++ b/internal/website/docs/next/guides/fetching-data.mdx
@@ -4,11 +4,9 @@ title: Fetching data from Headless WordPress with Faust.js
 description: Faust.js makes fetching data from Headless WordPress incredibly easy with GQty.
 ---
 
-:::note
+import BaseUrlNotice from '@site/src/mdx/base-url-notice.mdx';
 
-This guide assumes you're storing your pages/styles/etc. in a directory called `src`, and you have the `baseUrl` option set to `src` in your `tsconfig.json` for import modules from the root.
-
-:::
+<BaseUrlNotice />
 
 > **NOTE**: If you followed the instructions in the [Getting Started with Next.js](../getting-started.mdx) guide, you already have a working instance of the client. The following guide assumes you are setting up a client on an already existing application.
 

--- a/internal/website/docs/next/guides/fetching-data.mdx
+++ b/internal/website/docs/next/guides/fetching-data.mdx
@@ -4,6 +4,12 @@ title: Fetching data from Headless WordPress with Faust.js
 description: Faust.js makes fetching data from Headless WordPress incredibly easy with GQty.
 ---
 
+:::note
+
+This guide assumes you're storing your pages/styles/etc. in a directory called `src`, and you have the `baseUrl` option set to `src` in your `tsconfig.json` for import modules from the root.
+
+:::
+
 > **NOTE**: If you followed the instructions in the [Getting Started with Next.js](../getting-started.mdx) guide, you already have a working instance of the client. The following guide assumes you are setting up a client on an already existing application.
 
 Faust.js uses [GQty](https://gqty.dev/docs/react/fetching-data) as the primary way to fetch data from Headless WordPress. GQty is a [proxy-based](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy) GraphQL client. GQty [preforms an invisible or skeleton render](https://gqty.dev/docs/intro/how-it-works) to identify what data is needed.

--- a/internal/website/docs/next/guides/handle-404s.mdx
+++ b/internal/website/docs/next/guides/handle-404s.mdx
@@ -4,11 +4,9 @@ title: Handling 404s with is404
 description: Use a built-in Faust.js function to automatically determine if a page is a 404
 ---
 
-:::note
+import BaseUrlNotice from '@site/src/mdx/base-url-notice.mdx';
 
-This guide assumes you're storing your pages/styles/etc. in a directory called `src`, and you have the `baseUrl` option set to `src` in your `tsconfig.json` for import modules from the root.
-
-:::
+<BaseUrlNotice />
 
 # Handling 404s with is404
 

--- a/internal/website/docs/next/guides/handle-404s.mdx
+++ b/internal/website/docs/next/guides/handle-404s.mdx
@@ -4,6 +4,12 @@ title: Handling 404s with is404
 description: Use a built-in Faust.js function to automatically determine if a page is a 404
 ---
 
+:::note
+
+This guide assumes you're storing your pages/styles/etc. in a directory called `src`, and you have the `baseUrl` option set to `src` in your `tsconfig.json` for import modules from the root.
+
+:::
+
 # Handling 404s with is404
 
 With Next.js, you can return `{ notFound: true }` from `getServerSideProps` or `getStaticProps`, which will signal to Next.js that you want to send a `404 Not Found` response. When building a Headless WordPress site, you want to send a 404 in the following conditions:
@@ -41,7 +47,7 @@ import { getNextStaticProps, is404 } from '@faust/next';
 import { client } from 'client';
 
 export default function Page() {
-    return <></>;
+  return <></>;
 }
 
 export async function getStaticProps(context: GetStaticPropsContext) {

--- a/internal/website/docs/next/guides/post-page-previews.mdx
+++ b/internal/website/docs/next/guides/post-page-previews.mdx
@@ -4,11 +4,9 @@ title: Setting Up Post and Page Previews
 description: View WordPress preview post/page content on your headless frontend with Faust.js
 ---
 
-:::note
+import BaseUrlNotice from '@site/src/mdx/base-url-notice.mdx';
 
-This guide assumes you're storing your pages/styles/etc. in a directory called `src`, and you have the `baseUrl` option set to `src` in your `tsconfig.json` for import modules from the root.
-
-:::
+<BaseUrlNotice />
 
 Faust.js supports page and post previews, allowing you to view your WordPress content on the headless frontend as drafts or even before publishing.
 
@@ -38,12 +36,6 @@ FAUSTWP_SECRET_KEY=xxxx
 ```
 
 ### Ensure you've created your `faust.config.js` file and are importing it in your `_app.tsx`
-
-:::note
-
-This guide assumes you're storing your pages/styles/etc. in a directory called `src`, and you have the `baseUrl` option set to `src` in your `tsconfig.json` for import modules from the root.
-
-:::
 
 Like the [`next/getting-started`](https://github.com/wpengine/faustjs/tree/main/examples/next/getting-started) Faust.js example, your [`faust.config.js`](https://github.com/wpengine/faustjs/blob/main/examples/next/getting-started/src/faust.config.js) file will live in the `src` directory.
 

--- a/internal/website/docs/next/guides/post-page-previews.mdx
+++ b/internal/website/docs/next/guides/post-page-previews.mdx
@@ -33,11 +33,17 @@ FAUSTWP_SECRET_KEY=xxxx
 
 ### Ensure you've created your `faust.config.js` file and are importing it in your `_app.tsx`
 
+:::note
+
+This guide assumes you're storing your pages/styles/etc. in a directory called `src`, and you have the `baseUrl` option set to `src` in your `tsconfig.json` for import paths.
+
+:::
+
 Like the [`next/getting-started`](https://github.com/wpengine/faustjs/tree/main/examples/next/getting-started) Faust.js example, your [`faust.config.js`](https://github.com/wpengine/faustjs/blob/main/examples/next/getting-started/src/faust.config.js) file will live in the `src` directory.
 
 You'll need to import it at the top of your `_app.tsx` file to ensure the `config` is set, and your Faust.js app initializes appropriately.
 
-```tsx title=_app.tsx {1}
+```tsx title=src/pages/_app.tsx {1}
 import 'faust.config';
 import { FaustProvider } from '@faustjs/next';
 import { client } from 'client';
@@ -70,12 +76,11 @@ export default apiRouter;
 With your headless secret set and the `authorizeHandler` ready to handle requests, you can now create a Next.js [page](https://nextjs.org/docs/basic-features/pages) for previews. Create a file at `/src/pages/preview.tsx` with the following:
 
 > **NOTE**: The `usePreviewNode` was introduced in `v0.15.1` and replaces the `usePreview` hook.
-From now on you should be using this hook for showing preview content.
-
+> From now on you should be using this hook for showing preview content.
 
 ```tsx title=src/pages/preview.tsx
-import { PageComponent } from './[...pageUri]';
-import { PostComponent } from './posts/[postSlug]';
+import { PageComponent } from 'pages/[...pageUri]';
+import { PostComponent } from 'pages/posts/[postSlug]';
 import type { Page, Post } from 'client';
 import { client } from 'client';
 
@@ -122,10 +127,10 @@ From there, we can make a determination if the result is a page or post, and ren
 ```tsx
 switch (typeName) {
   case 'Page': {
-    return <PageComponent page={node as Page} />
+    return <PageComponent page={node as Page} />;
   }
   case 'Post': {
-    return <PostComponent post={node as Post} />
+    return <PostComponent post={node as Post} />;
   }
   // Add custom post types here as needed
   default: {
@@ -156,7 +161,6 @@ Clicking on **Preview in new tab** should take you to your post preview page wit
   alt="Post preview on the frontend in Next.js"
 />
 
-
 > **NOTE**: If you are having problems viewing Custom Post Type (CPT) previews using the above example,
-you need to make sure you have installed the latest version of the WPGraphQL plugin (> v1.6.11).
-It especially contains a bug fix when the draft previews query returns null for CPTs without revisions.
+> you need to make sure you have installed the latest version of the WPGraphQL plugin (> v1.6.11).
+> It especially contains a bug fix when the draft previews query returns null for CPTs without revisions.

--- a/internal/website/docs/next/guides/post-page-previews.mdx
+++ b/internal/website/docs/next/guides/post-page-previews.mdx
@@ -35,7 +35,7 @@ FAUSTWP_SECRET_KEY=xxxx
 
 :::note
 
-This guide assumes you're storing your pages/styles/etc. in a directory called `src`, and you have the `baseUrl` option set to `src` in your `tsconfig.json` for import paths.
+This guide assumes you're storing your pages/styles/etc. in a directory called `src`, and you have the `baseUrl` option set to `src` in your `tsconfig.json` for import modules from the root.
 
 :::
 

--- a/internal/website/docs/next/guides/post-page-previews.mdx
+++ b/internal/website/docs/next/guides/post-page-previews.mdx
@@ -4,6 +4,12 @@ title: Setting Up Post and Page Previews
 description: View WordPress preview post/page content on your headless frontend with Faust.js
 ---
 
+:::note
+
+This guide assumes you're storing your pages/styles/etc. in a directory called `src`, and you have the `baseUrl` option set to `src` in your `tsconfig.json` for import modules from the root.
+
+:::
+
 Faust.js supports page and post previews, allowing you to view your WordPress content on the headless frontend as drafts or even before publishing.
 
 ## Set Your Headless Secret

--- a/internal/website/docs/next/guides/ssr-ssg.mdx
+++ b/internal/website/docs/next/guides/ssr-ssg.mdx
@@ -4,11 +4,9 @@ title: Server-side Rendering & Static Generation
 description: Use Faust.js and Next.js to statically generate your Headless WordPress site
 ---
 
-:::note
+import BaseUrlNotice from '@site/src/mdx/base-url-notice.mdx';
 
-This guide assumes you're storing your pages/styles/etc. in a directory called `src`, and you have the `baseUrl` option set to `src` in your `tsconfig.json` for import modules from the root.
-
-:::
+<BaseUrlNotice />
 
 Next.js supports Server-side Rendering (SSR) and Static Site Generation (SSG) out of the box for [pages](https://nextjs.org/docs/basic-features/pages). However, with Next.js you are responsible for defining `getStaticProps` or `getServersideProps`, fetching the necessary data, and providing it on `props`. Faust.js provides two functions that can be used for SSG and SSR respectively called `getNextStaticProps` and `getNextServerSideProps`.
 

--- a/internal/website/docs/next/guides/ssr-ssg.mdx
+++ b/internal/website/docs/next/guides/ssr-ssg.mdx
@@ -4,6 +4,12 @@ title: Server-side Rendering & Static Generation
 description: Use Faust.js and Next.js to statically generate your Headless WordPress site
 ---
 
+:::note
+
+This guide assumes you're storing your pages/styles/etc. in a directory called `src`, and you have the `baseUrl` option set to `src` in your `tsconfig.json` for import modules from the root.
+
+:::
+
 Next.js supports Server-side Rendering (SSR) and Static Site Generation (SSG) out of the box for [pages](https://nextjs.org/docs/basic-features/pages). However, with Next.js you are responsible for defining `getStaticProps` or `getServersideProps`, fetching the necessary data, and providing it on `props`. Faust.js provides two functions that can be used for SSG and SSR respectively called `getNextStaticProps` and `getNextServerSideProps`.
 
 ## SSG Using `getNextStaticProps`
@@ -111,9 +117,7 @@ export async function getStaticPaths() {
 
 The code above will perform an inline query to WordPress in order to get the 5 most recent posts. Then it will create a list of paths based on the post URIs. In this case we are not rendering all the post pages up front, so some will be dynamically generated on-the-fly using the `fallback: 'blocking'` feature in Next.js.
 
-
 The above scenarios are most common, but there are other options for [`getStaticPaths`](https://nextjs.org/docs/basic-features/data-fetching#getstaticpaths-static-generation) that might be useful depending upon your needs.
-
 
 ## SSR Using `getNextServerSideProps`
 

--- a/internal/website/docs/next/reference/api-router.mdx
+++ b/internal/website/docs/next/reference/api-router.mdx
@@ -4,11 +4,9 @@ title: Using the API Router
 description: The API Router sets up the API routes for Faust.js.
 ---
 
-:::note
+import BaseUrlNotice from '@site/src/mdx/base-url-notice.mdx';
 
-This guide assumes you're storing your pages/styles/etc. in a directory called `src`, and you have the `baseUrl` option set to `src` in your `tsconfig.json` for import modules from the root.
-
-:::
+<BaseUrlNotice />
 
 The API Router is a node middleware that handles all of the Faust.js related API routes for you.
 

--- a/internal/website/docs/next/reference/api-router.mdx
+++ b/internal/website/docs/next/reference/api-router.mdx
@@ -4,6 +4,12 @@ title: Using the API Router
 description: The API Router sets up the API routes for Faust.js.
 ---
 
+:::note
+
+This guide assumes you're storing your pages/styles/etc. in a directory called `src`, and you have the `baseUrl` option set to `src` in your `tsconfig.json` for import modules from the root.
+
+:::
+
 The API Router is a node middleware that handles all of the Faust.js related API routes for you.
 
 Currently, there are two API routes that are handled by the API Router:

--- a/internal/website/docs/next/reference/expected-url-params.mdx
+++ b/internal/website/docs/next/reference/expected-url-params.mdx
@@ -48,7 +48,7 @@ export default function Page() {
 The same can be done for `[postId]` only this time it will make a request using the `postId` param to get a post by ID.
 
 ```tsx title=/src/pages/posts/[postId].tsx {6}
-import { client, getNextStaticProps } from '@faust/next';
+import { client, getNextStaticProps } from '@faustjs/next';
 import { GetStaticPropsContext } from 'next';
 
 export default function Page() {

--- a/internal/website/docs/next/reference/expected-url-params.mdx
+++ b/internal/website/docs/next/reference/expected-url-params.mdx
@@ -29,7 +29,7 @@ For example, say you have a page:
 Since `[postSlug]` is one of the params we look for, you can use the `usePost()` hook without any arguments and it will understand that it needs to get a post using the value stored in the `postSlug` param!
 
 ```tsx title=/src/pages/posts/[postSlug].tsx {6}
-import { client, getNextStaticProps } from '@faust/next';
+import { client, getNextStaticProps } from '@faustjs/next';
 import { GetStaticPropsContext } from 'next';
 
 export default function Page() {

--- a/internal/website/docs/next/reference/expected-url-params.mdx
+++ b/internal/website/docs/next/reference/expected-url-params.mdx
@@ -29,7 +29,7 @@ For example, say you have a page:
 Since `[postSlug]` is one of the params we look for, you can use the `usePost()` hook without any arguments and it will understand that it needs to get a post using the value stored in the `postSlug` param!
 
 ```tsx title=/src/pages/posts/[postSlug].tsx {6}
-import { client, getNextStaticProps } from '@wpengine/headless-next';
+import { client, getNextStaticProps } from '@faust/next';
 import { GetStaticPropsContext } from 'next';
 
 export default function Page() {
@@ -48,7 +48,7 @@ export default function Page() {
 The same can be done for `[postId]` only this time it will make a request using the `postId` param to get a post by ID.
 
 ```tsx title=/src/pages/posts/[postId].tsx {6}
-import { client, getNextStaticProps } from '@wpengine/headless-next';
+import { client, getNextStaticProps } from '@faust/next';
 import { GetStaticPropsContext } from 'next';
 
 export default function Page() {

--- a/internal/website/docs/next/reference/faust-provider.mdx
+++ b/internal/website/docs/next/reference/faust-provider.mdx
@@ -4,11 +4,9 @@ title: Using FaustProvider
 description: The FaustProvider React component wraps your app to provide context to Faust.js
 ---
 
-:::note
+import BaseUrlNotice from '@site/src/mdx/base-url-notice.mdx';
 
-This guide assumes you're storing your pages/styles/etc. in a directory called `src`, and you have the `baseUrl` option set to `src` in your `tsconfig.json` for import modules from the root.
-
-:::
+<BaseUrlNotice />
 
 The `<FaustProvider>` component is a React component that follows the [provider pattern](https://www.patterns.dev/posts/provider-pattern/), wrapping your Next.js app to provide the necessary context to Faust.js. This includes:
 

--- a/internal/website/docs/next/reference/faust-provider.mdx
+++ b/internal/website/docs/next/reference/faust-provider.mdx
@@ -4,6 +4,12 @@ title: Using FaustProvider
 description: The FaustProvider React component wraps your app to provide context to Faust.js
 ---
 
+:::note
+
+This guide assumes you're storing your pages/styles/etc. in a directory called `src`, and you have the `baseUrl` option set to `src` in your `tsconfig.json` for import modules from the root.
+
+:::
+
 The `<FaustProvider>` component is a React component that follows the [provider pattern](https://www.patterns.dev/posts/provider-pattern/), wrapping your Next.js app to provide the necessary context to Faust.js. This includes:
 
 - React Context for state management

--- a/internal/website/docs/next/reference/hooks/useAuth.mdx
+++ b/internal/website/docs/next/reference/hooks/useAuth.mdx
@@ -4,11 +4,9 @@ title: useAuth
 description: The useAuth hook provides a way to ensure that the user is authenticated.
 ---
 
-:::note
+import BaseUrlNotice from '@site/src/mdx/base-url-notice.mdx';
 
-This guide assumes you're storing your pages/styles/etc. in a directory called `src`, and you have the `baseUrl` option set to `src` in your `tsconfig.json` for import modules from the root.
-
-:::
+<BaseUrlNotice />
 
 The `useAuth` hook provides a way to guarantee a users' authentication state, thus allowing you to control how a page's content is rendered.
 

--- a/internal/website/docs/next/reference/hooks/useAuth.mdx
+++ b/internal/website/docs/next/reference/hooks/useAuth.mdx
@@ -4,6 +4,12 @@ title: useAuth
 description: The useAuth hook provides a way to ensure that the user is authenticated.
 ---
 
+:::note
+
+This guide assumes you're storing your pages/styles/etc. in a directory called `src`, and you have the `baseUrl` option set to `src` in your `tsconfig.json` for import modules from the root.
+
+:::
+
 The `useAuth` hook provides a way to guarantee a users' authentication state, thus allowing you to control how a page's content is rendered.
 
 The `useAuth` hook accepts 1 argument of `UseAuthOptions`, which is an object that contains the following properties:

--- a/internal/website/docs/next/reference/hooks/useLogin.mdx
+++ b/internal/website/docs/next/reference/hooks/useLogin.mdx
@@ -4,11 +4,9 @@ title: useLogin
 description: The useLogin hook provides a way to log in a user
 ---
 
-:::note
+import BaseUrlNotice from '@site/src/mdx/base-url-notice.mdx';
 
-This guide assumes you're storing your pages/styles/etc. in a directory called `src`, and you have the `baseUrl` option set to `src` in your `tsconfig.json` for import modules from the root.
-
-:::
+<BaseUrlNotice />
 
 The `useLogin` hook provides an abstraction around obtaining an authorization code and fetching refresh/access tokens from WordPress, thus logging in a user to your Headless frontend.
 

--- a/internal/website/docs/next/reference/hooks/useLogin.mdx
+++ b/internal/website/docs/next/reference/hooks/useLogin.mdx
@@ -4,6 +4,12 @@ title: useLogin
 description: The useLogin hook provides a way to log in a user
 ---
 
+:::note
+
+This guide assumes you're storing your pages/styles/etc. in a directory called `src`, and you have the `baseUrl` option set to `src` in your `tsconfig.json` for import modules from the root.
+
+:::
+
 The `useLogin` hook provides an abstraction around obtaining an authorization code and fetching refresh/access tokens from WordPress, thus logging in a user to your Headless frontend.
 
 The following example shows how to use the `useLogin` hook to login a user:

--- a/internal/website/docs/next/reference/hooks/useLogout.mdx
+++ b/internal/website/docs/next/reference/hooks/useLogout.mdx
@@ -4,6 +4,12 @@ title: useLogout Hook
 description: The useLogout hook provides a way to logout a user
 ---
 
+:::note
+
+This guide assumes you're storing your pages/styles/etc. in a directory called `src`, and you have the `baseUrl` option set to `src` in your `tsconfig.json` for import modules from the root.
+
+:::
+
 The `useLogout` hook provides a way to logout a user from your headless frontend.
 
 The following example shows how you could use the `useLogout` hook in a `logout.tsx` page:

--- a/internal/website/docs/next/reference/hooks/useLogout.mdx
+++ b/internal/website/docs/next/reference/hooks/useLogout.mdx
@@ -4,11 +4,9 @@ title: useLogout Hook
 description: The useLogout hook provides a way to logout a user
 ---
 
-:::note
+import BaseUrlNotice from '@site/src/mdx/base-url-notice.mdx';
 
-This guide assumes you're storing your pages/styles/etc. in a directory called `src`, and you have the `baseUrl` option set to `src` in your `tsconfig.json` for import modules from the root.
-
-:::
+<BaseUrlNotice />
 
 The `useLogout` hook provides a way to logout a user from your headless frontend.
 

--- a/internal/website/docs/next/reference/hooks/usePage.mdx
+++ b/internal/website/docs/next/reference/hooks/usePage.mdx
@@ -4,11 +4,9 @@ title: usePage Hook
 description: The usePage hook provides a standard way to get a wordpress page
 ---
 
-:::note
+import BaseUrlNotice from '@site/src/mdx/base-url-notice.mdx';
 
-This guide assumes you're storing your pages/styles/etc. in a directory called `src`, and you have the `baseUrl` option set to `src` in your `tsconfig.json` for import modules from the root.
-
-:::
+<BaseUrlNotice />
 
 The `usePage` hook provides the standard interface for getting a page from your Headless WordPress API. It also allows you to pass-in no arguments. When you do not pass arguments into `usePage` it will attempt to look at the URL params in order to determine how to get a page from your Headless WordPress API. In Next.js this means you will need to name your page file in a particular way in order to get the proper URL params. Below are the possible names that will work automatically with Faust.js:
 

--- a/internal/website/docs/next/reference/hooks/usePage.mdx
+++ b/internal/website/docs/next/reference/hooks/usePage.mdx
@@ -4,6 +4,12 @@ title: usePage Hook
 description: The usePage hook provides a standard way to get a wordpress page
 ---
 
+:::note
+
+This guide assumes you're storing your pages/styles/etc. in a directory called `src`, and you have the `baseUrl` option set to `src` in your `tsconfig.json` for import modules from the root.
+
+:::
+
 The `usePage` hook provides the standard interface for getting a page from your Headless WordPress API. It also allows you to pass-in no arguments. When you do not pass arguments into `usePage` it will attempt to look at the URL params in order to determine how to get a page from your Headless WordPress API. In Next.js this means you will need to name your page file in a particular way in order to get the proper URL params. Below are the possible names that will work automatically with Faust.js:
 
 - `[pageId].tsx`

--- a/internal/website/docs/next/reference/hooks/usePost.mdx
+++ b/internal/website/docs/next/reference/hooks/usePost.mdx
@@ -4,6 +4,12 @@ title: usePost Hook
 description: The usePost hook provides a standard way to get a WordPress post
 ---
 
+:::note
+
+This guide assumes you're storing your pages/styles/etc. in a directory called `src`, and you have the `baseUrl` option set to `src` in your `tsconfig.json` for import modules from the root.
+
+:::
+
 The `usePost` hook provides the standard interface for getting a post from your Headless WordPress API. It also allows you to pass-in no arguments. When you do not pass arguments into `usePost` it will attempt to look at the URL params in order to determine how to get a post from your Headless WordPress API. In Next.js this means you will need to name your post page file in a particular way in order to get the proper URL params. Below are the possible names that will work automatically with Faust.js:
 
 - `[postId].tsx`

--- a/internal/website/docs/next/reference/hooks/usePost.mdx
+++ b/internal/website/docs/next/reference/hooks/usePost.mdx
@@ -4,11 +4,9 @@ title: usePost Hook
 description: The usePost hook provides a standard way to get a WordPress post
 ---
 
-:::note
+import BaseUrlNotice from '@site/src/mdx/base-url-notice.mdx';
 
-This guide assumes you're storing your pages/styles/etc. in a directory called `src`, and you have the `baseUrl` option set to `src` in your `tsconfig.json` for import modules from the root.
-
-:::
+<BaseUrlNotice />
 
 The `usePost` hook provides the standard interface for getting a post from your Headless WordPress API. It also allows you to pass-in no arguments. When you do not pass arguments into `usePost` it will attempt to look at the URL params in order to determine how to get a post from your Headless WordPress API. In Next.js this means you will need to name your post page file in a particular way in order to get the proper URL params. Below are the possible names that will work automatically with Faust.js:
 

--- a/internal/website/docs/next/reference/hooks/usePosts.mdx
+++ b/internal/website/docs/next/reference/hooks/usePosts.mdx
@@ -4,6 +4,12 @@ title: usePosts Hook
 description: The usePosts hook provides a standard way to get multiple WordPress posts
 ---
 
+:::note
+
+This guide assumes you're storing your pages/styles/etc. in a directory called `src`, and you have the `baseUrl` option set to `src` in your `tsconfig.json` for import modules from the root.
+
+:::
+
 The `usePosts` hook provides the standard interface for getting a list of posts from your Headless WordPress API. It also allows you to pass-in no arguments. When you do not pass arguments into `usePosts` it will attempt to look at the URL params in order to determine how to get a list of posts from your Headless WordPress API. In Next.js this means you will need to name your post page file in a particular way in order to get the proper URL params. Below are the possible names that will work automatically with Faust.js:
 
 1. If `categoryId` is found in the URL params, a request is made to retrieve a list of posts for a `category` by `ID`

--- a/internal/website/docs/next/reference/hooks/usePosts.mdx
+++ b/internal/website/docs/next/reference/hooks/usePosts.mdx
@@ -4,11 +4,9 @@ title: usePosts Hook
 description: The usePosts hook provides a standard way to get multiple WordPress posts
 ---
 
-:::note
+import BaseUrlNotice from '@site/src/mdx/base-url-notice.mdx';
 
-This guide assumes you're storing your pages/styles/etc. in a directory called `src`, and you have the `baseUrl` option set to `src` in your `tsconfig.json` for import modules from the root.
-
-:::
+<BaseUrlNotice />
 
 The `usePosts` hook provides the standard interface for getting a list of posts from your Headless WordPress API. It also allows you to pass-in no arguments. When you do not pass arguments into `usePosts` it will attempt to look at the URL params in order to determine how to get a list of posts from your Headless WordPress API. In Next.js this means you will need to name your post page file in a particular way in order to get the proper URL params. Below are the possible names that will work automatically with Faust.js:
 

--- a/internal/website/docs/next/reference/hooks/usePreview.mdx
+++ b/internal/website/docs/next/reference/hooks/usePreview.mdx
@@ -14,9 +14,15 @@ The `usePreview` hook provides an abstraction around getting a preview `page` or
 
 The following example shows how to use the `usePreview` hook to render either a `post` or `page` from WordPress:
 
+:::note
+
+This guide assumes you're storing your pages/styles/etc. in a directory called `src`, and you have the `baseUrl` option set to `src` in your `tsconfig.json` for import modules from the root.
+
+:::
+
 ```tsx title=src/pages/preview.tsx {14-17}
-import { PageComponent } from './[...pageUri]';
-import { PostComponent } from './posts/[postSlug]';
+import { PageComponent } from 'pages/[...pageUri]';
+import { PostComponent } from 'pages/posts/[postSlug]';
 import { client } from 'client';
 
 export default function Preview() {

--- a/internal/website/docs/next/reference/hooks/usePreview.mdx
+++ b/internal/website/docs/next/reference/hooks/usePreview.mdx
@@ -4,6 +4,8 @@ title: usePreview Hook
 description: The usePreview hook provides a way to get post preview data from WordPress
 ---
 
+import BaseUrlNotice from '@site/src/mdx/base-url-notice.mdx';
+
 :::caution Deprecation Notice
 
 `usePreview` has been deprecated in favor of [`usePreviewNode`](/docs/next/reference/hooks/usePreviewNode)
@@ -14,11 +16,7 @@ The `usePreview` hook provides an abstraction around getting a preview `page` or
 
 The following example shows how to use the `usePreview` hook to render either a `post` or `page` from WordPress:
 
-:::note
-
-This guide assumes you're storing your pages/styles/etc. in a directory called `src`, and you have the `baseUrl` option set to `src` in your `tsconfig.json` for import modules from the root.
-
-:::
+<BaseUrlNotice />
 
 ```tsx title=src/pages/preview.tsx {14-17}
 import { PageComponent } from 'pages/[...pageUri]';

--- a/internal/website/docs/next/reference/hooks/usePreviewNode.mdx
+++ b/internal/website/docs/next/reference/hooks/usePreviewNode.mdx
@@ -4,6 +4,12 @@ title: usePreviewNode Hook
 description: The usePreviewNode hook provides a way to get post preview data from WordPress for any post type
 ---
 
+:::note
+
+This guide assumes you're storing your pages/styles/etc. in a directory called `src`, and you have the `baseUrl` option set to `src` in your `tsconfig.json` for import modules from the root.
+
+:::
+
 The `usePreviewNode` hook provides an abstraction around getting preview data for any post type. When calling the `usePreviewNode` hook on an appropriate preview page, the hook will ensure authorization, make a request to determine the post type, then make a subsequent request to retrieve the proper preview data. When using 0.7.2 of FaustWP or later, preview data will be retrieved with one request.
 
 The `usePreviewNode` hook will return an object with the following properties:
@@ -78,7 +84,7 @@ export default function Preview() {
           <h1>{event.title()}</h1>
           <p>{event.content()}</p>
         </>
-      )
+      );
     }
     // Add additional custom post types here as needed
     default: {

--- a/internal/website/docs/next/reference/hooks/usePreviewNode.mdx
+++ b/internal/website/docs/next/reference/hooks/usePreviewNode.mdx
@@ -4,11 +4,9 @@ title: usePreviewNode Hook
 description: The usePreviewNode hook provides a way to get post preview data from WordPress for any post type
 ---
 
-:::note
+import BaseUrlNotice from '@site/src/mdx/base-url-notice.mdx';
 
-This guide assumes you're storing your pages/styles/etc. in a directory called `src`, and you have the `baseUrl` option set to `src` in your `tsconfig.json` for import modules from the root.
-
-:::
+<BaseUrlNotice />
 
 The `usePreviewNode` hook provides an abstraction around getting preview data for any post type. When calling the `usePreviewNode` hook on an appropriate preview page, the hook will ensure authorization, make a request to determine the post type, then make a subsequent request to retrieve the proper preview data. When using 0.7.2 of FaustWP or later, preview data will be retrieved with one request.
 

--- a/internal/website/docs/tutorial/basic-headless-site.mdx
+++ b/internal/website/docs/tutorial/basic-headless-site.mdx
@@ -18,25 +18,34 @@ To get started, run the following command:
 npx create-next-app my-app
 ```
 
-If prompted to `create-next-app`, enter `y' to continue.
+If prompted to `create-next-app`, enter `y` to continue.
 
 Great! You've deployed your app! However, it's not quite ready for TypeScript yet. Let's do that now.
 
 ### Setup TypeScript
 
-Start by `cd'ing into your app directory:
+Start by `cd`ing into your app directory:
 
 ```bash
 cd my-app
 ```
 
-Now, run:
+Now, create a `tsconfig.json` file in the root directory of your app with the following:
 
-```bash
-touch tsconfig.json
+```json
+{
+  "compilerOptions": {
+    "baseUrl": "."
+  }
+}
 ```
 
-This command creates your [TypeScript config file.](https://www.typescriptlang.org/docs/handbook/tsconfig-json.html)
+:::note
+
+We're setting the `baseUrl` to `.` so we can import files relative to the root of our app. For example: <br />
+`import 'styles/globals.css'` instead of `import '../styles/globals.css'`
+
+:::
 
 Now, let's install TypeScript and our dependencies.
 
@@ -44,9 +53,15 @@ Now, let's install TypeScript and our dependencies.
 npm install --save-dev typescript @types/react
 ```
 
-Once the dependencies are installed, run `npm run dev` to start the development server. Doing this will automatically generate the settings needed for `tsconfig.json`.
+Once the dependencies are installed, run:
 
-Now, convert your existing pages to TypeScript:
+```bash
+npm run dev
+```
+
+This will automatically generate the rest of the settings needed for `tsconfig.json`, and start the development server.
+
+Congrats! You've setup TypeScript within your project. Let's now convert your existing JavaScript pages to TypeScript pages:
 
 Rename `pages/_app.js` to `pages/_app.tsx`, and replace the contents with the following:
 

--- a/internal/website/docs/tutorial/basic-headless-site.mdx
+++ b/internal/website/docs/tutorial/basic-headless-site.mdx
@@ -51,7 +51,7 @@ Now, convert your existing pages to TypeScript:
 Rename `pages/_app.js` to `pages/_app.tsx`, and replace the contents with the following:
 
 ```jsx title=_app.tsx
-import '../styles/globals.css';
+import 'styles/globals.css';
 
 import type { AppProps /*, AppContext */ } from 'next/app';
 
@@ -72,23 +72,30 @@ Now that we have created a Next.js app, we can create a WordPress site. We use [
 
 Download and install Local from https://localwp.com. Once installed, click the `+` button in the bottom left corner of the screen.
 
-<img src="/docs/img/localwp-create-site.png"
+<img
+  src="/docs/img/localwp-create-site.png"
   alt="Red arrow pointing to the create site button in Local"
 />
 
 Follow the onboarding process to create a new WordPress site.
 
-<img src="/docs/img/localwp-site-created.png" alt="Created site settings in Local" />
+<img
+  src="/docs/img/localwp-site-created.png"
+  alt="Created site settings in Local"
+/>
 
 You can then copy the "Site Domain" and visit your new WordPress site directly.
 
-<img src="/docs/img/localwp-site-created-preview.png" alt="WordPress site created using Local" />
+<img
+  src="/docs/img/localwp-site-created-preview.png"
+  alt="WordPress site created using Local"
+/>
 
 ### Key Takeaways
 
-  - We used `create-next-app` to create a Next.js app
-  - We installed and setup TypeScript on a basic Next.js app
-  - We created a WordPress site using Local
+- We used `create-next-app` to create a Next.js app
+- We installed and setup TypeScript on a basic Next.js app
+- We created a WordPress site using Local
 
 ### What's Next?
 

--- a/internal/website/docs/tutorial/basic-headless-site.mdx
+++ b/internal/website/docs/tutorial/basic-headless-site.mdx
@@ -50,7 +50,7 @@ We're setting the `baseUrl` to `.` so we can import files relative to the root o
 Now, let's install TypeScript and our dependencies.
 
 ```bash
-npm install --save-dev typescript @types/react
+npm install --save-dev typescript @types/react @types/react-dom @types/node
 ```
 
 Once the dependencies are installed, run:

--- a/internal/website/docs/tutorial/first-react-component.mdx
+++ b/internal/website/docs/tutorial/first-react-component.mdx
@@ -99,7 +99,7 @@ Head back over to the `pages/posts.tsx` file we created earlier. Let's use our n
 First, we import our `Post` component:
 
 ```tsx title=pages/posts.tsx {1}
-import Post from '../components/post';
+import Post from 'components/post';
 
 export default function PostsPage() {
   return <h1>My posts page</h1>;
@@ -109,7 +109,7 @@ export default function PostsPage() {
 Let's also create some fake data to use in our example:
 
 ```tsx title=pages/posts.tsx {3-17}
-import Post from '../components/post';
+import Post from 'components/post';
 
 const posts = [
   {
@@ -135,7 +135,7 @@ export default function PostsPage() {
 Finally, we'll create a list of posts by looping through the `posts` array and rendering a `Post` component for each post:
 
 ```tsx title=pages/posts.tsx {23-25}
-import Post from '../components/post';
+import Post from 'components/post';
 
 const posts = [
   {
@@ -174,11 +174,11 @@ Your final result will look something like:
 
 ### Key Takeaways
 
-  - React is a framework for building user interfaces with components.
-  - React components are JavaScript functions that return React elements.
-  - React elements are written in a special JavaScript syntax called JSX. JSX allows you to write JavaScript code that looks like HTML.
-  - React components can receive data from the parent component in the form of `props`.
-  - React components are used to build pages in Next.js by placing the component in a `pages` directory.
+- React is a framework for building user interfaces with components.
+- React components are JavaScript functions that return React elements.
+- React elements are written in a special JavaScript syntax called JSX. JSX allows you to write JavaScript code that looks like HTML.
+- React components can receive data from the parent component in the form of `props`.
+- React components are used to build pages in Next.js by placing the component in a `pages` directory.
 
 ### What's Next?
 

--- a/internal/website/docs/tutorial/querying-data.mdx
+++ b/internal/website/docs/tutorial/querying-data.mdx
@@ -19,8 +19,8 @@ The client we created in the previous tutorial gives us access to helpful [React
 Let's use the [`usePosts`](../next/reference/hooks/usePosts) hook to get the latest posts from your headless WordPress site.
 
 ```tsx title=pages/posts.tsx {1,5-6}
-import { client } from '../client';
-import Post from '../components/post';
+import { client } from 'client';
+import Post from 'components/post';
 
 export default function PostsPage() {
   const { usePosts } = client;
@@ -40,7 +40,7 @@ export default function PostsPage() {
 Let's also update the `Post` component to accept a `post` prop:
 
 ```tsx title=components/post.tsx {1,4,8}
-import { Post as PostType } from '../client';
+import { Post as PostType } from 'client';
 
 export interface PostProps {
   post: PostType;
@@ -69,8 +69,8 @@ post.title({ format: PostObjectFieldFormatEnum.RAW });
 Let's go back to the `pages/posts.tsx` component and hook up the data we're fetching to the `Post` component:
 
 ```tsx title=pages/posts.tsx {12}
-import { client } from '../client';
-import Post from '../components/post';
+import { client } from 'client';
+import Post from 'components/post';
 
 export default function PostsPage() {
   const { usePosts } = client;
@@ -103,8 +103,8 @@ That is where the [`useQuery`](../next/reference/hooks/gqty-hooks) hook comes in
 Let's display the site title and description using the `useQuery` hook.
 
 ```tsx title=pages/posts.tsx {5,10,11}
-import { client } from '../client';
-import Post from '../components/post';
+import { client } from 'client';
+import Post from 'components/post';
 
 export default function PostsPage() {
   const { usePosts, useQuery } = client;

--- a/internal/website/docs/tutorial/setup-faustjs.mdx
+++ b/internal/website/docs/tutorial/setup-faustjs.mdx
@@ -218,12 +218,12 @@ The `<FaustProvider>` is a [Higher-Order Component](https://reactjs.org/docs/hig
 Replace the existing `pages/_app.tsx` file contents with the following:
 
 ```tsx title=pages/_app.tsx
-import '../faust.config';
-import '../styles/globals.css';
+import 'faust.config';
+import 'styles/globals.css';
 
 import type { AppProps /*, AppContext */ } from 'next/app';
 import { FaustProvider } from '@faustjs/next';
-import { client } from '../client';
+import { client } from 'client';
 
 function MyApp({ Component, pageProps }: AppProps) {
   return (

--- a/internal/website/src/mdx/base-url-notice.mdx
+++ b/internal/website/src/mdx/base-url-notice.mdx
@@ -1,5 +1,5 @@
 :::tip
 
-This doc assumes you're storing your pages/styles/etc. in a directory called `src`, and you have the `baseUrl` option set to `src` in your `tsconfig.json` for import modules from the root.
+This doc assumes you're storing your pages/styles/etc. in a directory called `src`, and you have the `baseUrl` option set to `src` in your `tsconfig.json` for importing modules from the root.
 
 :::

--- a/internal/website/src/mdx/base-url-notice.mdx
+++ b/internal/website/src/mdx/base-url-notice.mdx
@@ -1,0 +1,5 @@
+:::tip
+
+This doc assumes you're storing your pages/styles/etc. in a directory called `src`, and you have the `baseUrl` option set to `src` in your `tsconfig.json` for import modules from the root.
+
+:::


### PR DESCRIPTION
## Description

This PR standardizes the import path in the docs to use the project root, and explains that this should be configured in `tsconfig.json`. Guides and ref docs also now display a notice saying:

> This doc assumes you're storing your pages/styles/etc. in a directory called `src`, and you have the `baseUrl` option set to `src` in your `tsconfig.json` for import modules from the root.

To be more clear on how imports are handled.

## Documentation Changes
1. Added Base Url notice to all docs that use imports from the root
2. Standardized the import paths to use no relative import paths and instead import from the root. e.g. `import 'styles/globals.css'` instead of `import '../styles/globals.css'`
3. Added a [section](https://hcixzyt38dn5ak04xxcqc36lf.js.wpenginepowered.com/docs/tutorial/basic-headless-site#setup-typescript) to the tutorial for PHP developers to configure this option in `tsconfig.json`

## Staging URL
https://hcixzyt38dn5ak04xxcqc36lf.js.wpenginepowered.com/