### PR TITLE
Explicitly refresh access token

### DIFF
--- a/packages/core/src/auth/client/accessToken.ts
+++ b/packages/core/src/auth/client/accessToken.ts
@@ -31,9 +31,7 @@ export const TIME_UNTIL_REFRESH_BEFORE_TOKEN_EXPIRES = 60;
 /**
  * The setTimeout instance that refreshes the access token.
  */
-export let __REFRESH_TIMER: RefreshTimer = undefined;
-
-let accessToken: AccessToken | undefined;
+let __REFRESH_TIMER: RefreshTimer = undefined;
 
 export function getRefreshTimer(): RefreshTimer {
   return __REFRESH_TIMER;
@@ -42,6 +40,11 @@ export function getRefreshTimer(): RefreshTimer {
 export function setRefreshTimer(timer: RefreshTimer): void {
   __REFRESH_TIMER = timer;
 }
+
+/**
+ * The access token object
+ */
+let accessToken: AccessToken | undefined;
 
 /**
  * Get an access token from memory if one exists
@@ -125,7 +128,6 @@ export function clearAccessTokenRefreshTimer(): void {
  * @param {string} code An authorization code to fetch an access token
  */
 export async function fetchAccessToken(code?: string): Promise<string | null> {
-  console.log('running fetchAccessToken()');
   const { apiBasePath } = config();
 
   if (isNil(apiBasePath)) {

--- a/packages/core/src/auth/client/accessToken.ts
+++ b/packages/core/src/auth/client/accessToken.ts
@@ -3,8 +3,32 @@ import { isServerSide } from '../../utils/index.js';
 import isNil from 'lodash/isNil.js';
 import isString from 'lodash/isString.js';
 
+/**
+ * The amount of time in seconds until the access token is fetched
+ * before it expires.
+ *
+ * For example, if the access token expires in 5 minutes (300 seconds), and
+ * this value is 60, then the access token will be refreshed at 240 seconds.
+ *
+ * This allows for enough time to fetch a new access token before it expires.
+ *
+ */
+export const TIME_UNTIL_REFRESH_BEFORE_TOKEN_EXPIRES = 60;
+
+/**
+ * The setTimeout instance that refreshes the access token.
+ */
+export let __REFRESH_TIMER: ReturnType<typeof setTimeout> | undefined =
+  undefined;
+
 export interface AccessToken {
+  /**
+   * Base 64 encoded access token
+   */
   token: string | undefined;
+  /**
+   * The time in seconds until the access token expires.
+   */
   expiration: number | undefined;
 }
 
@@ -51,6 +75,41 @@ export function setAccessToken(
 }
 
 /**
+ * Creates the access token refresh timer that will fetch a new access token
+ * before the current one expires.
+ *
+ * @returns {void}
+ */
+export function setAccessTokenRefreshTimer(): void {
+  const currentTimeInSeconds = Math.floor(Date.now() / 1000);
+  const accessTokenExpirationInSeconds = getAccessTokenExpiration();
+
+  // If there is no access token/expiration, don't create a timer.
+  if (accessTokenExpirationInSeconds === undefined) {
+    return;
+  }
+
+  const secondsUntilExpiration =
+    accessTokenExpirationInSeconds - currentTimeInSeconds;
+  const secondsUntilRefresh =
+    secondsUntilExpiration - TIME_UNTIL_REFRESH_BEFORE_TOKEN_EXPIRES;
+
+  __REFRESH_TIMER = setTimeout(
+    () => void fetchAccessToken(),
+    secondsUntilRefresh * 1000,
+  );
+}
+
+/**
+ * Clears the current access token refresh timer if one exists.
+ */
+export function clearAccessTokenRefreshTimer(): void {
+  if (__REFRESH_TIMER !== undefined) {
+    clearTimeout(__REFRESH_TIMER);
+  }
+}
+
+/**
  * Fetch an access token from the authorizeHandler middleware
  *
  * @export
@@ -93,6 +152,15 @@ export async function fetchAccessToken(code?: string): Promise<string | null> {
 
     setAccessToken(result.accessToken, result.accessTokenExpiration);
 
+    // If there is an existing refresh timer, clear it.
+    clearAccessTokenRefreshTimer();
+
+    /**
+     * Set a refresh timer to fetch a new access token before
+     * the current one expires.
+     */
+    setAccessTokenRefreshTimer();
+
     return result.accessToken;
   } catch (error) {
     setAccessToken(undefined, undefined);
@@ -100,34 +168,3 @@ export async function fetchAccessToken(code?: string): Promise<string | null> {
     return null;
   }
 }
-
-/**
- * The interval (in ms) in which the access token is check if a new one
- * needs to be fetched
- */
-export const ACCESS_TOKEN_EXP_CHECK_INTERVAL_MS = 15000;
-
-/**
- * The difference in seconds between the current time and the expiration
- * which the access token should be re-fetched
- */
-export const TIME_DIFF_TO_FETCH_TOKEN = 60;
-
-/**
- * Continuously check if the access token is close to
- * expiration and fetch a new one if needed.
- */
-setInterval(() => {
-  if (!accessToken?.token || !accessToken?.expiration) {
-    return;
-  }
-
-  const currentTime = Math.floor(Date.now() / 1000);
-
-  // Only refetch the token if it's 60 seconds before its expiration
-  if (currentTime + TIME_DIFF_TO_FETCH_TOKEN < accessToken.expiration) {
-    return;
-  }
-
-  void fetchAccessToken();
-}, ACCESS_TOKEN_EXP_CHECK_INTERVAL_MS);


### PR DESCRIPTION
## Description

Currently, the access token is refreshed on a `setInterval`, globally polluting the module scope. This PR explicitly refreshes the access token by setting a timer to be invoked 60 seconds before the existing token expires.

Not only will this be more efficient, but will improve the testing experience as well as a timer is not being invoked globally when importing the `@faustjs` packages.

## Testing

Tests have been provided.

Manual testing:

1. Add the following before the `setRefreshTimer` statement of `setAccessTokenRefreshTimer()`:
   ```ts
   const expiresDate = new Date(
     new Date().getTime() + secondsUntilExpiration * 1000,
   ).toString();
   const refreshDate = new Date(
     new Date().getTime() + secondsUntilRefresh * 1000,
   ).toString();

   console.log(
     `Access token expires at ${expiresDate}, access token will be re-fetched at ${refreshDate}`,
   );
   ```
2. Go to an authenticated endpoint (previews for example).
3. Notice the console message and watch for the access token to be properly fetched at the specified time:
   <img width="1600" alt="Screen Shot 2022-02-21 at 9 08 15 AM" src="https://user-images.githubusercontent.com/5946219/154981663-f2fe6737-24c5-46f4-833a-00afb27c000b.png">
