### PR TITLE
Fix previews when `trailingSlash` is enabled in Next.js config

### DIFF
--- a/.changeset/modern-llamas-shop.md
+++ b/.changeset/modern-llamas-shop.md
@@ -1,0 +1,6 @@
+---
+'@faustjs/core': patch
+'@faustjs/next': patch
+---
+
+Fixed previews when trailingSlash is enabled in Next.js config

--- a/packages/core/src/server/router/index.ts
+++ b/packages/core/src/server/router/index.ts
@@ -1,5 +1,6 @@
 import { IncomingMessage, ServerResponse } from 'http';
 import isUndefined from 'lodash/isUndefined.js';
+import trimEnd from 'lodash/trimEnd.js';
 import { authorizeHandler, logoutHandler } from '../auth/middleware.js';
 import { parseUrl } from '../../utils/index.js';
 import {
@@ -35,7 +36,7 @@ export async function apiRouter(
   }
 
   const parsedUrl = parseUrl(req.url);
-  const pathname = parsedUrl?.pathname;
+  const pathname = trimEnd(parsedUrl?.pathname, '/');
 
   switch (pathname) {
     case `${apiBasePath}/${TOKEN_ENDPOINT_PARTIAL_PATH}`:

--- a/packages/core/test/server/router/router.test.ts
+++ b/packages/core/test/server/router/router.test.ts
@@ -52,6 +52,30 @@ describe('server/router', () => {
     authorizeHandlerSpy.mockRestore();
   });
 
+  test('token route with trailing slash calls the authorizeHandler', async () => {
+    config({
+      wpUrl: '',
+    });
+
+    const req: IncomingMessage = {
+      url: '/api/faust/auth/token/?code=xxxx',
+    } as any;
+
+    const res: ServerResponse = {
+      end() {},
+    } as any;
+
+    const authorizeHandlerSpy = jest
+      .spyOn(middleware, 'authorizeHandler')
+      .mockImplementation(async () => {});
+
+    await apiRouter(req, res);
+
+    expect(authorizeHandlerSpy).toBeCalled();
+
+    authorizeHandlerSpy.mockRestore();
+  });
+
   test('req.url with /api/faust/auth/logout calls the logoutHandler', async () => {
     config({
       wpUrl: '',

--- a/packages/next/src/config/withFaust.ts
+++ b/packages/next/src/config/withFaust.ts
@@ -9,6 +9,7 @@ export interface WithFaustConfig {
 
 export async function createRedirects(
   redirectFn?: NextConfig['redirects'],
+  trailingSlash = false,
   previewDestination = '/preview',
 ): Promise<Redirect[]> {
   let redirects: Redirect[] = [];
@@ -17,8 +18,14 @@ export async function createRedirects(
     redirects = await redirectFn();
   }
 
+  let previewPath = trim(previewDestination, '/');
+
+  if (trailingSlash) {
+    previewPath += '/';
+  }
+
   redirects.unshift({
-    source: `/((?!${trim(previewDestination, '/')}$).*)`,
+    source: `/((?!${previewPath}).*)`,
     has: [
       {
         type: 'query',
@@ -26,7 +33,7 @@ export async function createRedirects(
         value: 'true',
       },
     ],
-    destination: `/${trim(previewDestination, '/')}`,
+    destination: `/${previewPath}`,
     permanent: false,
   });
 
@@ -50,7 +57,11 @@ export function withFaust(
 
   const existingRedirects = nextConfig.redirects;
   nextConfig.redirects = () =>
-    createRedirects(existingRedirects, previewDestination);
+    createRedirects(
+      existingRedirects,
+      nextConfig.trailingSlash,
+      previewDestination,
+    );
 
   return nextConfig;
 }

--- a/packages/next/test/withFaust.test.ts
+++ b/packages/next/test/withFaust.test.ts
@@ -26,7 +26,7 @@ describe('withFaust', () => {
 
     const expectedRedirects = [
       {
-        source: '/((?!preview$).*)',
+        source: '/((?!preview).*)',
         has: [
           {
             type: 'query',
@@ -63,7 +63,7 @@ describe('withFaust', () => {
 
     const expectedRedirects = [
       {
-        source: '/((?!preview-new$).*)',
+        source: '/((?!preview-new).*)',
         has: [
           {
             type: 'query',

--- a/packages/next/test/withFaust.test.ts
+++ b/packages/next/test/withFaust.test.ts
@@ -79,4 +79,41 @@ describe('withFaust', () => {
 
     expect(configRedirects).toStrictEqual(expectedRedirects);
   });
+
+  test('preview redirect respects trailingSlash config', async () => {
+    const config = withFaust(
+      {
+        trailingSlash: true,
+        async redirects() {
+          return [
+            {
+              source: '/about',
+              destination: '/',
+              permanent: true,
+            },
+          ];
+        },
+      }
+    );
+
+    const configRedirects = await (config as any).redirects();
+
+    const expectedRedirects = [
+      {
+        source: '/((?!preview/).*)',
+        has: [
+          {
+            type: 'query',
+            key: 'preview',
+            value: 'true',
+          },
+        ],
+        destination: '/preview/',
+        permanent: false,
+      },
+      { source: '/about', destination: '/', permanent: true },
+    ];
+
+    expect(configRedirects).toStrictEqual(expectedRedirects);
+  });
 });


### PR DESCRIPTION
## Description

<!--
Include a summary of the change and some contextual information.
-->

I wasn't able to find a single regex that works both when `trailingSlash` is enabled and when it's disabled, but we _can_ check the config and modify the regex appropriately. If `trailingSlash` is enabled, we expect the `/` at the end of the `/preview` `source` path. We also add it to the `destination` to avoid triggering another `trailingSlash` redirect.

Once that was corrected, I still had issues previewing. The `apiRouter` was returning a 404 on the `auth/token/` endpoint because of the trailing slash, hence the added `trimEnd()`.

## Testing

<!--
Describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Also list any relevant details for your test configuration such as how to test the changes locally or in staging.
-->

Jest tests were added. I'd like to cover this in an e2e test as well, but booting a totally separate front-end with a different next.config.js just to test for `trailingSlash` seemed excessive. Maybe one day we'll have a way to easily swap configs in our e2e environments, but for now I'd recommend testing this manually:

1. Run the stock example project `npm run dev`
2. Open a preview link from your WordPress instance
3. Verify that you're redirected to `/preview` and the preview is rendered
4. Stop the example project server and add the following to your `next.config.js` in `examples/next/getting-started`:

```js
const { withFaust } = require('@faustjs/next');

/**
 * @type {import('next').NextConfig}
 **/
module.exports = withFaust({
  trailingSlash: true,
});
```
5. Start the example project again `npm run dev`
6. Open a preview link from your WordPress instance
7. Verify that you're redirected to `/preview/` and the preview is rendered
