### PR TITLE
Have Next handle sitemap URL replacement

### DIFF
--- a/.changeset/wet-dots-pretend.md
+++ b/.changeset/wet-dots-pretend.md
@@ -2,4 +2,4 @@
 'faustwp': patch
 ---
 
-Normalize sitemap URLs in order to support 'partially headless' sites.
+Ensure sitemap URLs use the WordPress domain and not the headless frontend domain. Fixes a conflict with Yoast SEO that prevented post links from being added to the posts sitemap.

--- a/.changeset/wet-dots-pretend.md
+++ b/.changeset/wet-dots-pretend.md
@@ -1,0 +1,5 @@
+---
+'faustwp': patch
+---
+
+Normalize sitemap URLs in order to support 'partially headless' sites.

--- a/plugins/faustwp/composer.json
+++ b/plugins/faustwp/composer.json
@@ -31,7 +31,7 @@
       "@phpcs",
       "@test"
     ],
-    "test": "phpunit"
+    "test": "phpunit --testdox"
   },
   "config": {
     "preferred-install": "dist",

--- a/plugins/faustwp/includes/replacement/callbacks.php
+++ b/plugins/faustwp/includes/replacement/callbacks.php
@@ -183,13 +183,7 @@ function post_link( $link ) {
 		return $link;
 	}
 
-	$frontend_uri = faustwp_get_setting( 'frontend_uri' );
-
-	if ( $frontend_uri ) {
-		return str_replace( trailingslashit( get_home_url() ), trailingslashit( $frontend_uri ), $link );
-	}
-
-	return $link;
+	return equivalent_frontend_url( $link );
 }
 
 add_filter( 'term_link', __NAMESPACE__ . '\\term_link', 1000 );
@@ -205,16 +199,7 @@ function term_link( $term_link ) {
 		return $term_link;
 	}
 
-	$frontend_uri = faustwp_get_setting( 'frontend_uri' );
-
-	if ( empty( $frontend_uri ) ) {
-		return $term_link;
-	}
-
-	$frontend_uri = trailingslashit( $frontend_uri );
-	$site_url     = trailingslashit( site_url() );
-
-	return str_replace( $site_url, $frontend_uri, $term_link );
+	return equivalent_frontend_url( $term_link );
 }
 
 
@@ -258,5 +243,5 @@ add_filter( 'wpseo_xml_sitemap_post_url', __NAMESPACE__ . '\\yoast_sitemap_post_
  * @param string $url URL to use in the XML sitemap.
  */
 function yoast_sitemap_post_url( $url ) {
-	return normalize_sitemap_url( $url );
+	return equivalent_wp_url( $url );
 }

--- a/plugins/faustwp/includes/replacement/callbacks.php
+++ b/plugins/faustwp/includes/replacement/callbacks.php
@@ -260,13 +260,3 @@ add_filter( 'wpseo_xml_sitemap_post_url', __NAMESPACE__ . '\\yoast_sitemap_post_
 function yoast_sitemap_post_url( $url ) {
 	return normalize_sitemap_url( $url );
 }
-
-add_filter( 'wpseo_sitemap_entry', __NAMESPACE__ . '\\yoast_sitemap_entry' );
-/**
- * Filter URL entry before it gets added to the sitemap.
- *
- * @param array $sitemap_entry Array of URL parts.
- */
-function yoast_sitemap_entry( $sitemap_entry ) {
-	return normalize_sitemap_entry( $sitemap_entry );
-}

--- a/plugins/faustwp/includes/replacement/callbacks.php
+++ b/plugins/faustwp/includes/replacement/callbacks.php
@@ -228,3 +228,45 @@ function enqueue_preview_scripts() {
 	wp_enqueue_script( 'faustwp-gutenberg-filters', plugins_url( '/previewlinks.js', __FILE__ ), array(), '1.0.0', true );
 	wp_localize_script( 'faustwp-gutenberg-filters', '_faustwp_preview_link', array( '_preview_link' => get_preview_post_link() ) );
 }
+
+add_filter( 'wp_sitemaps_posts_entry', __NAMESPACE__ . '\\sitemaps_posts_entry' );
+/**
+ * Filters the sitemap entry for an individual post.
+ *
+ * @param array $sitemap_entry Sitemap entry for the post.
+ */
+function sitemaps_posts_entry( $sitemap_entry ) {
+	return normalize_sitemap_entry( $sitemap_entry );
+}
+
+add_filter( 'wp_sitemaps_taxonomies_entry', __NAMESPACE__ . '\\sitemaps_taxonomies_entry' );
+/**
+ * Filters the sitemap entry for an individual term.
+ *
+ * @param array  $sitemap_entry  Sitemap entry for the term.
+ */
+function sitemaps_taxonomies_entry( $sitemap_entry ) {
+	return normalize_sitemap_entry( $sitemap_entry );
+}
+
+add_filter( 'wpseo_xml_sitemap_post_url', __NAMESPACE__ . '\\yoast_sitemap_post_url' );
+/**
+ * Filter the URL Yoast SEO uses in the XML sitemap.
+ *
+ * Note that only absolute local URLs are allowed as the check after this removes external URLs.
+ *
+ * @param string  $url  URL to use in the XML sitemap
+ */
+function yoast_sitemap_post_url( $url ) {
+	return normalize_sitemap_url( $url );
+}
+
+add_filter( 'wpseo_sitemap_entry', __NAMESPACE__ . '\\wpseo_sitemap_entry' );
+/**
+ * Filter URL entry before it gets added to the sitemap.
+ *
+ * @param array  $sitemap_entry  Array of URL parts.
+ */
+function wpseo_sitemap_entry( $sitemap_entry ) {
+	return normalize_sitemap_entry( $sitemap_entry );
+}

--- a/plugins/faustwp/includes/replacement/callbacks.php
+++ b/plugins/faustwp/includes/replacement/callbacks.php
@@ -167,9 +167,7 @@ function post_preview_link( $link, $post ) {
 
 add_filter( 'post_link', __NAMESPACE__ . '\\post_link', 1000 );
 /**
- * Callback for WordPress 'preview_post_link' filter and 'post_link' filter.
- *
- * Callback for WordPress  'post_link' filter.
+ * Callback for WordPress 'post_link' filter.
  *
  * Swap post links in admin for headless front-end.
  *

--- a/plugins/faustwp/includes/replacement/callbacks.php
+++ b/plugins/faustwp/includes/replacement/callbacks.php
@@ -243,7 +243,7 @@ add_filter( 'wp_sitemaps_taxonomies_entry', __NAMESPACE__ . '\\sitemaps_taxonomi
 /**
  * Filters the sitemap entry for an individual term.
  *
- * @param array  $sitemap_entry  Sitemap entry for the term.
+ * @param array $sitemap_entry Sitemap entry for the term.
  */
 function sitemaps_taxonomies_entry( $sitemap_entry ) {
 	return normalize_sitemap_entry( $sitemap_entry );
@@ -255,7 +255,7 @@ add_filter( 'wpseo_xml_sitemap_post_url', __NAMESPACE__ . '\\yoast_sitemap_post_
  *
  * Note that only absolute local URLs are allowed as the check after this removes external URLs.
  *
- * @param string  $url  URL to use in the XML sitemap
+ * @param string $url URL to use in the XML sitemap.
  */
 function yoast_sitemap_post_url( $url ) {
 	return normalize_sitemap_url( $url );
@@ -265,7 +265,7 @@ add_filter( 'wpseo_sitemap_entry', __NAMESPACE__ . '\\yoast_sitemap_entry' );
 /**
  * Filter URL entry before it gets added to the sitemap.
  *
- * @param array  $sitemap_entry  Array of URL parts.
+ * @param array $sitemap_entry Array of URL parts.
  */
 function yoast_sitemap_entry( $sitemap_entry ) {
 	return normalize_sitemap_entry( $sitemap_entry );

--- a/plugins/faustwp/includes/replacement/callbacks.php
+++ b/plugins/faustwp/includes/replacement/callbacks.php
@@ -261,12 +261,12 @@ function yoast_sitemap_post_url( $url ) {
 	return normalize_sitemap_url( $url );
 }
 
-add_filter( 'wpseo_sitemap_entry', __NAMESPACE__ . '\\wpseo_sitemap_entry' );
+add_filter( 'wpseo_sitemap_entry', __NAMESPACE__ . '\\yoast_sitemap_entry' );
 /**
  * Filter URL entry before it gets added to the sitemap.
  *
  * @param array  $sitemap_entry  Array of URL parts.
  */
-function wpseo_sitemap_entry( $sitemap_entry ) {
+function yoast_sitemap_entry( $sitemap_entry ) {
 	return normalize_sitemap_entry( $sitemap_entry );
 }

--- a/plugins/faustwp/includes/replacement/functions.php
+++ b/plugins/faustwp/includes/replacement/functions.php
@@ -35,12 +35,13 @@ function domain_replacement_enabled() {
 }
 
 /**
- * Normalizes a sitemap URL to be the original WordPress URL.
+ * Returns the equivalent WordPress URL given a frontend URL.
  *
- * @param string $url The sitemap URL to normalize.
- * @return string
+ * @param string $url      The URL to normalize.
+ * @param bool   $frontend Returns an equivalent frontend URL given a WordPress URL if true.
+ * @return string The WordPress URL.
  */
-function normalize_sitemap_url( $url ) {
+function normalize_url( $url, $frontend = false ) {
 	$frontend_uri = faustwp_get_setting( 'frontend_uri' );
 
 	// Return the URL as is if frontend uri is empty.
@@ -51,9 +52,31 @@ function normalize_sitemap_url( $url ) {
 	$frontend_uri = trailingslashit( $frontend_uri );
 	$home_url     = trailingslashit( get_home_url() );
 
-	$normalized_url = str_replace( $frontend_uri, $home_url, $url );
+	$normalized_url = $frontend
+		? str_replace( $home_url, $frontend_uri, $url )
+		: str_replace( $frontend_uri, $home_url, $url );
 
 	return $normalized_url;
+}
+
+/**
+ * Returns the equivalent WordPress URL given a frontend URL.
+ *
+ * @param string $url The frontend URL.
+ * @return string The WordPress URL.
+ */
+function equivalent_wp_url( $url ) {
+	return normalize_url( $url, false );
+}
+
+/**
+ * Returns the equivalent frontend URL given a WordPress URL.
+ *
+ * @param string $url The WordPress URL.
+ * @return string The frontend URL.
+ */
+function equivalent_frontend_url( $url ) {
+	return normalize_url( $url, true );
 }
 
 /**
@@ -67,7 +90,7 @@ function normalize_sitemap_entry( $sitemap_entry ) {
 		return $sitemap_entry;
 	}
 
-	$sitemap_entry['loc'] = normalize_sitemap_url( $sitemap_entry['loc'] );
+	$sitemap_entry['loc'] = equivalent_wp_url( $sitemap_entry['loc'] );
 
 	return $sitemap_entry;
 }

--- a/plugins/faustwp/includes/replacement/functions.php
+++ b/plugins/faustwp/includes/replacement/functions.php
@@ -7,7 +7,10 @@
 
 namespace WPE\FaustWP\Replacement;
 
-use function WPE\FaustWP\Settings\is_rewrites_enabled;
+use function WPE\FaustWP\Settings\{
+	faustwp_get_setting,
+	is_rewrites_enabled
+};
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -29,4 +32,42 @@ function domain_replacement_enabled() {
 	 * @param bool $enabled True if domain replacement is enabled, false if else.
 	 */
 	return apply_filters( 'faustwp_domain_replacement_enabled', is_rewrites_enabled() );
+}
+
+/**
+ * Normalizes a sitemap URL to be the original WordPress URL.
+ *
+ * @param string $url The sitemap URL to normalize.
+ * @return string
+ */
+function normalize_sitemap_url( $url ) {
+	$frontend_uri = faustwp_get_setting( 'frontend_uri' );
+
+	// Return the URL as is if frontend uri is empty.
+	if ( ! $frontend_uri ) {
+		return $url;
+	}
+
+	$frontend_uri = trailingslashit( $frontend_uri );
+	$home_url     = trailingslashit( get_home_url() );
+
+	$normalized_url = str_replace( $frontend_uri, $home_url, $url );
+
+	return $normalized_url;
+}
+
+/**
+ * Normalizes a sitemap URL to be the original WordPress URL.
+ *
+ * @param array $sitemap_entry The sitemap entry containing the URL to normalize.
+ * @return array
+ */
+function normalize_sitemap_entry( $sitemap_entry ) {
+	if ( ! isset( $sitemap_entry['loc'] ) ) {
+		return $sitemap_entry;
+	}
+
+	$sitemap_entry['loc'] = normalize_sitemap_url( $sitemap_entry['loc'] );
+
+	return $sitemap_entry;
 }

--- a/plugins/faustwp/tests/integration/replacement/test-replacement-callbacks.php
+++ b/plugins/faustwp/tests/integration/replacement/test-replacement-callbacks.php
@@ -51,6 +51,22 @@ class ReplacementCallbacksTestCases extends \WP_UnitTestCase {
 		$this->assertSame( 10, has_action( 'enqueue_block_editor_assets', 'WPE\FaustWP\Replacement\enqueue_preview_scripts' ) );
 	}
 
+	public function test_wp_sitemaps_posts_entry_filter() {
+		$this->assertSame( 10, has_action( 'wp_sitemaps_posts_entry', 'WPE\FaustWP\Replacement\sitemaps_posts_entry' ) );
+	}
+
+	public function test_wp_sitemaps_taxonomies_entry_filter() {
+		$this->assertSame( 10, has_action( 'wp_sitemaps_taxonomies_entry', 'WPE\FaustWP\Replacement\sitemaps_taxonomies_entry' ) );
+	}
+
+	public function test_wpseo_xml_sitemap_post_url_filter() {
+		$this->assertSame( 10, has_action( 'wpseo_xml_sitemap_post_url', 'WPE\FaustWP\Replacement\yoast_sitemap_post_url' ) );
+	}
+
+	public function test_wpseo_sitemap_entry_filter() {
+		$this->assertSame( 10, has_action( 'wpseo_sitemap_entry', 'WPE\FaustWP\Replacement\yoast_sitemap_entry' ) );
+	}
+
 	/**
 	 * Tests content_replacement() returns original value when content replacement is not enabled.
 	 */

--- a/plugins/faustwp/tests/integration/replacement/test-replacement-callbacks.php
+++ b/plugins/faustwp/tests/integration/replacement/test-replacement-callbacks.php
@@ -63,10 +63,6 @@ class ReplacementCallbacksTestCases extends \WP_UnitTestCase {
 		$this->assertSame( 10, has_action( 'wpseo_xml_sitemap_post_url', 'WPE\FaustWP\Replacement\yoast_sitemap_post_url' ) );
 	}
 
-	public function test_wpseo_sitemap_entry_filter() {
-		$this->assertSame( 10, has_action( 'wpseo_sitemap_entry', 'WPE\FaustWP\Replacement\yoast_sitemap_entry' ) );
-	}
-
 	/**
 	 * Tests content_replacement() returns original value when content replacement is not enabled.
 	 */

--- a/plugins/faustwp/tests/integration/replacement/test-replacement-functions.php
+++ b/plugins/faustwp/tests/integration/replacement/test-replacement-functions.php
@@ -9,7 +9,9 @@ namespace WPE\FaustWP\Tests\Replacement;
 
 use function WPE\FaustWP\Replacement\{
 	domain_replacement_enabled,
-	normalize_sitemap_url,
+	normalize_url,
+	equivalent_wp_url,
+	equivalent_frontend_url,
 	normalize_sitemap_entry
 };
 
@@ -18,6 +20,10 @@ class ReplacementFunctionsTestCases extends \WP_UnitTestCase {
 
 	protected $init_settings = [
 		'frontend_uri' => 'http://localhost:3000',
+	];
+
+	protected $empty_settings = [
+		'frontend_uri' => '',
 	];
 
 	public function setUp() {
@@ -35,14 +41,44 @@ class ReplacementFunctionsTestCases extends \WP_UnitTestCase {
 		remove_filter( 'faustwp_domain_replacement_enabled', '__return_true' );
 	}
 
-	public function test_normalize_sitemap_url_replaces_frontend_uri_with_home_url() {
-		$frontend_post_url      = $this->init_settings['frontend_uri'] . '/posts/hello-world/';
-		$normalized_sitemap_url = normalize_sitemap_url( $frontend_post_url );
+	public function test_normalize_url_defaults_to_replacing_frontend_uri_with_home_url() {
+		$frontend_url = $this->init_settings['frontend_uri'] . '/posts/hello-world/';
+		$wp_url       = normalize_url( $frontend_url );
 
-		$this->assertContains( get_home_url(), $normalized_sitemap_url );
+		$this->assertContains( get_home_url(), $wp_url );
 	}
 
-	public function test_normalize_sitemap_entry() {
+	public function test_normalize_url_replaces_wp_url_with_frontend_uri_when_frontend_arg_is_true() {
+		$wp_url       = get_home_url() . '/posts/hello-world/';
+		$frontend_url = normalize_url( $wp_url, true );
+
+		$this->assertContains( $this->init_settings['frontend_uri'], $frontend_url );
+	}
+
+	public function test_equivalent_wp_url_replaces_frontend_uri_with_home_url() {
+		$frontend_url = $this->init_settings['frontend_uri'] . '/posts/hello-world/';
+		$wp_url       = equivalent_wp_url( $frontend_url );
+
+		$this->assertContains( get_home_url(), $wp_url );
+	}
+
+	public function test_equivalent_frontend_url_replaces_home_url_with_frontend_uri() {
+		$wp_url       = get_home_url() . '/posts/hello-world/';
+		$frontend_url = equivalent_frontend_url( $wp_url );
+
+		$this->assertContains( $this->init_settings['frontend_uri'], $frontend_url );
+	}
+
+	public function test_equivalent_frontend_url_does_not_replace_when_frontend_uri_not_set() {
+		update_option( $this->option, $this->empty_settings );
+
+		$wp_url       = get_home_url() . '/posts/hello-world/';
+		$frontend_url = equivalent_frontend_url( $wp_url );
+
+		$this->assertContains( $wp_url, $frontend_url );
+	}
+
+	public function test_normalize_sitemap_entry_replaces_frontend_uri_with_home_url() {
 		$frontend_post_url = $this->init_settings['frontend_uri'] . '/posts/hello-world/';
 
 		// https://github.com/WordPress/wordpress-develop/blob/ce3d66c7c9d94671268d5ce51de47cdd3bd9d6c8/src/wp-includes/sitemaps/providers/class-wp-sitemaps-posts.php#L127-L129

--- a/plugins/faustwp/tests/integration/replacement/test-replacement-functions.php
+++ b/plugins/faustwp/tests/integration/replacement/test-replacement-functions.php
@@ -23,8 +23,6 @@ class ReplacementFunctionsTestCases extends \WP_UnitTestCase {
 	public function setUp() {
 		parent::setUp();
 		update_option( $this->option, $this->init_settings );
-		// We have to clear this manually since all tests execute in a single "request"
-		$GLOBALS['wp_settings_errors'] = [];
 	}
 
 	public function test_domain_replacement_enabled_returns_false() {

--- a/plugins/faustwp/tests/integration/replacement/test-replacement-functions.php
+++ b/plugins/faustwp/tests/integration/replacement/test-replacement-functions.php
@@ -7,9 +7,26 @@
 
 namespace WPE\FaustWP\Tests\Replacement;
 
-use function WPE\FaustWP\Replacement\domain_replacement_enabled;
+use function WPE\FaustWP\Replacement\{
+	domain_replacement_enabled,
+	normalize_sitemap_url,
+	normalize_sitemap_entry
+};
 
 class ReplacementFunctionsTestCases extends \WP_UnitTestCase {
+	protected $option = 'faustwp_settings';
+
+	protected $init_settings = [
+		'frontend_uri' => 'http://localhost:3000',
+	];
+
+	public function setUp() {
+		parent::setUp();
+		update_option( $this->option, $this->init_settings );
+		// We have to clear this manually since all tests execute in a single "request"
+		$GLOBALS['wp_settings_errors'] = [];
+	}
+
 	public function test_domain_replacement_enabled_returns_false() {
 		$this->assertFalse( domain_replacement_enabled() );
 	}
@@ -18,5 +35,25 @@ class ReplacementFunctionsTestCases extends \WP_UnitTestCase {
 		add_filter( 'faustwp_domain_replacement_enabled', '__return_true' );
 		$this->assertTrue( domain_replacement_enabled() );
 		remove_filter( 'faustwp_domain_replacement_enabled', '__return_true' );
+	}
+
+	public function test_normalize_sitemap_url() {
+		$frontend_post_url      = $this->init_settings['frontend_uri'] . '/posts/hello-world/';
+		$normalized_sitemap_url = normalize_sitemap_url( $frontend_post_url );
+
+		$this->assertContains( get_home_url(), $normalized_sitemap_url );
+	}
+
+	public function test_normalize_sitemap_entry() {
+		$frontend_post_url = $this->init_settings['frontend_uri'] . '/posts/hello-world/';
+
+		// https://github.com/WordPress/wordpress-develop/blob/ce3d66c7c9d94671268d5ce51de47cdd3bd9d6c8/src/wp-includes/sitemaps/providers/class-wp-sitemaps-posts.php#L127-L129
+		$sitemap_entry = array(
+			'loc' => $frontend_post_url,
+		);
+
+		$normalized_sitemap_entry = normalize_sitemap_entry( $sitemap_entry );
+
+		$this->assertContains( get_home_url(), $normalized_sitemap_entry['loc'] );
 	}
 }

--- a/plugins/faustwp/tests/integration/replacement/test-replacement-functions.php
+++ b/plugins/faustwp/tests/integration/replacement/test-replacement-functions.php
@@ -35,7 +35,7 @@ class ReplacementFunctionsTestCases extends \WP_UnitTestCase {
 		remove_filter( 'faustwp_domain_replacement_enabled', '__return_true' );
 	}
 
-	public function test_normalize_sitemap_url() {
+	public function test_normalize_sitemap_url_replaces_frontend_uri_with_home_url() {
 		$frontend_post_url      = $this->init_settings['frontend_uri'] . '/posts/hello-world/';
 		$normalized_sitemap_url = normalize_sitemap_url( $frontend_post_url );
 


### PR DESCRIPTION
## Description

These changes normalize the sitemap URLs to always have the WordPress Home URL as the base, regardless of any FaustWP setting.

Since this is essentially a reversal of the plugin filtering `post_link`, this normalization is only needed in the following sitemap providers
- posts
- taxonomies

This also fixes the issue where posts & taxonomies were not showing up in the sitemap Yoast generates due to Yoast intentionally filtering out external sitemap entries.

## Testing

1. Setup a local WordPress install with both FaustWP & Yoast (wordpress-seo) activated.
2. Visit settings -> permalinks & save changes in order to flush WordPress rewrite rules.
3. Create a few test posts.
4. Visit /sitemap.xml to view the sitemap index & go to the post sitemap.
5. You should now see all posts with the current WordPress site's URL as the base.

Repeat process for taxonomies 🔁

## Screenshots

### Before

🟡 WordPress Core Sitemap
<img width="1033" alt="WordPress Core Sitemap" src="https://user-images.githubusercontent.com/6676674/155752514-cb73023d-2475-4459-a044-857ea33c3ef1.png">

🟡 Yoast Sitemap
<img width="1037" alt="Yoast Sitemap" src="https://user-images.githubusercontent.com/6676674/155751884-5daa93a1-dd1e-4e08-9113-eacb51b6f7c5.png">

### After

🟢 WordPress Core Sitemap
<img width="1038" alt="WordPress Core Sitemap" src="https://user-images.githubusercontent.com/6676674/155752539-8c80fe99-d71d-4e74-b00b-7d230fd10226.png">

🟢 Yoast Sitemap
<img width="1041" alt="Yoast Sitemap" src="https://user-images.githubusercontent.com/6676674/155751892-47d828f8-d1ad-4bad-9778-11f1a5d0f041.png">


## Documentation Changes

Should we add a new documentation section for this plugin's custom filters?