### PR TITLE
Disable the site editor when themes are disabled

### DIFF
--- a/.changeset/sixty-fishes-nail.md
+++ b/.changeset/sixty-fishes-nail.md
@@ -2,4 +2,4 @@
 'faustwp': patch
 ---
 
-Hide the site editor menu item when themes are disabled
+Disables access to the site editor when themes are disabled

--- a/.changeset/sixty-fishes-nail.md
+++ b/.changeset/sixty-fishes-nail.md
@@ -1,0 +1,5 @@
+---
+'faustwp': patch
+---
+
+Hide the site editor menu item when themes are disabled

--- a/plugins/faustwp/includes/admin-menus/callbacks.php
+++ b/plugins/faustwp/includes/admin-menus/callbacks.php
@@ -39,6 +39,9 @@ function remove_admin_menu_pages() {
 	// Remove Appearance > Theme Editor.
 	remove_submenu_page( 'themes.php', 'theme-editor.php' );
 
+	// Remove Appearance > Editor.
+	remove_submenu_page( 'themes.php', 'site-editor.php' );
+
 	// Remove Appearance > Widgets.
 	remove_submenu_page( 'themes.php', 'widgets.php' );
 

--- a/plugins/faustwp/includes/admin-menus/callbacks.php
+++ b/plugins/faustwp/includes/admin-menus/callbacks.php
@@ -82,6 +82,7 @@ function remove_admin_bar_items() {
 
 	$wp_admin_bar->remove_menu( 'customize' );
 	$wp_admin_bar->remove_node( 'themes' );
+	$wp_admin_bar->remove_node( 'site-editor' );
 	$wp_admin_bar->remove_node( 'widgets' );
 }
 

--- a/plugins/faustwp/includes/admin-menus/callbacks.php
+++ b/plugins/faustwp/includes/admin-menus/callbacks.php
@@ -97,9 +97,14 @@ function prevent_admin_page_access() {
 		return;
 	}
 
+	$disabled_screens = array(
+		'site-editor',
+		'themes',
+	);
+
 	$screen = get_current_screen();
 
-	if ( is_object( $screen ) && 'themes' === $screen->id ) {
+	if ( is_object( $screen ) && in_array( $screen->id, $disabled_screens, true ) ) {
 		wp_safe_redirect( admin_url() );
 		exit;
 	}

--- a/plugins/faustwp/tests/integration/admin-menus/test-callbacks.php
+++ b/plugins/faustwp/tests/integration/admin-menus/test-callbacks.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * Class AdminMenusCallbacksTestCases
+ *
+ * @package FaustWP
+ */
+
+namespace WPE\FaustWP\Tests\Admin_Menus;
+
+class AdminMenusCallbacksTestCases extends \WP_UnitTestCase {
+	public function setUp() {
+		parent::setUp();
+	}
+
+	public function test_the_callbacks_are_registered() {
+		$this->assertSame( 1000, has_action( 'admin_menu', 'WPE\FaustWP\Admin_Menus\remove_admin_menu_pages' ) );
+		$this->assertSame( 10, has_action( 'wp_before_admin_bar_render', 'WPE\FaustWP\Admin_Menus\remove_admin_bar_items' ) );
+		$this->assertSame( 10, has_action( 'current_screen', 'WPE\FaustWP\Admin_Menus\prevent_admin_page_access' ) );
+	}
+}


### PR DESCRIPTION
## Description

<!--
Include a summary of the change and some contextual information.
-->

Disables the site editor from the sidebar, top bar, and direct access when the `Disable WordPress theme admin pages` setting is checked.

## Testing

<!--
Describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Also list any relevant details for your test configuration such as how to test the changes locally or in staging.
-->

Writing good automated tests for this was difficult because the items that show up under Appearance or in the admin bar vary depending on which theme is active. Checking for presence/absence of specific menu items would be unreliable. For example, our test environment currently runs Twenty Twenty-one, which doesn't enable the site editor at all. If I added a test to verify that `site-editor` is not in the Appearance menu, it would pass both before and after these changes; with or without themes enabled. While switching themes during the test could be an option to explore in the future, that level of test expansion seemed out of scope for this ticket.

Running WordPress 5.9 and the default Twenty Twenty-two theme:

1. Uncheck the `Disable WordPress theme admin pages` and `Disable public route redirects` settings.
2. See that "Editor (beta)" is listed under the "Appearance" sidebar menu.
3. Visit the front-end of your WordPress site (note: _not the headless front-end_)
4. See that "Edit site" is in the top admin bar.
5. Click "Edit site" and see that you are taken to the site editor.
6. Visit Settings -> Headless and check the `Disable WordPress theme admin pages` setting. Save.
7. See that "Editor (beta)" is not listed under the "Appearance" sidebar menu.
8. Visit the front-end of your WordPress site (note: _not the headless front-end_)
9. See that "Edit site" is not in the top admin bar.
10. Visit `/wp-admin/site-editor.php` and see that you are redirected to the dashboard.

## Screenshots

<!--
If this is a visual change include relevant screenshots about the behavior of the application before and after this change.
-->
### Before
<img width="918" alt="Screen Shot 2022-02-24 at 5 43 32 PM" src="https://user-images.githubusercontent.com/4661832/155619993-f70f4bef-f715-4615-ad19-e9e46ed37c2c.png">
<img width="1116" alt="Screen Shot 2022-02-25 at 9 39 46 AM" src="https://user-images.githubusercontent.com/4661832/155734237-ab984ea1-5a90-4dc6-be12-5efe9b60a2d2.png">


### After
<img width="874" alt="Screen Shot 2022-02-24 at 5 44 00 PM" src="https://user-images.githubusercontent.com/4661832/155619986-7e50ec8d-b7cf-43b5-92bf-7a6e9216215e.png">
<img width="1130" alt="Screen Shot 2022-02-25 at 9 42 03 AM" src="https://user-images.githubusercontent.com/4661832/155734442-d2655745-2bdb-45d0-a956-4655fd45fd17.png">
