### PR TITLE
Remove trailing slash

### DIFF
--- a/.changeset/cyan-apples-work.md
+++ b/.changeset/cyan-apples-work.md
@@ -1,0 +1,5 @@
+---
+'faustwp': patch
+---
+
+Remove trailing slash from frontend uri.

--- a/plugins/faustwp/includes/settings/callbacks.php
+++ b/plugins/faustwp/includes/settings/callbacks.php
@@ -446,3 +446,20 @@ function add_action_link_settings( $links ) {
 		$links
 	);
 }
+
+add_filter( 'faustwp_get_setting', __NAMESPACE__ . '\\trim_frontend_uri_trailing_slash', 10, 2 );
+/**
+ * Ensure that this plugin's frontend_uri setting does not have a trailing slash.
+ *
+ * @param mixed  $value   The setting value.
+ * @param string $name    The setting name.
+ *
+ * @return string
+ */
+function trim_frontend_uri_trailing_slash( $value, $name ) {
+	if ( 'frontend_uri' !== $name ) {
+		return $value;
+	}
+
+	return untrailingslashit( $value );
+}

--- a/plugins/faustwp/tests/acceptance/SettingsCest.php
+++ b/plugins/faustwp/tests/acceptance/SettingsCest.php
@@ -73,7 +73,7 @@ class SettingsCest
         $I->click("Save Changes");
 
         $I->see("Settings saved.");
-        $I->seeInField('faustwp_settings[frontend_uri]', untrailingslashit($new_frontend_uri));
+        $I->seeInField('faustwp_settings[frontend_uri]', rtrim( $new_frontend_uri, '/\\' ));
     }
 
     /**

--- a/plugins/faustwp/tests/acceptance/SettingsCest.php
+++ b/plugins/faustwp/tests/acceptance/SettingsCest.php
@@ -59,6 +59,24 @@ class SettingsCest
     }
 
     /**
+     * Ensure the frontend_uri is updated when the user saves a valid value.
+     */
+    public function i_see_no_trailing_slash_when_saving_frontend_uri_with_a_trailing_slash(AcceptanceTester $I) {
+        $I->loginAsAdmin();
+        $I->amOnFaustWPSettingsPage();
+
+        $new_frontend_uri = 'http://headless.example.com/';
+
+        $I->dontSeeInField('faustwp_settings[frontend_uri]', $new_frontend_uri);
+        $I->fillField('faustwp_settings[frontend_uri]', $new_frontend_uri);
+
+        $I->click("Save Changes");
+
+        $I->see("Settings saved.");
+        $I->seeInField('faustwp_settings[frontend_uri]', untrailingslashit($new_frontend_uri));
+    }
+
+    /**
      * Ensure the frontend_uri is not updated and an error message is shown when
      * the user saves an invalid value.
      */

--- a/plugins/faustwp/tests/integration/settings/test-callbacks.php
+++ b/plugins/faustwp/tests/integration/settings/test-callbacks.php
@@ -33,6 +33,10 @@ class SettingsCallbacksTestCases extends \WP_UnitTestCase {
 		$this->assertSame( 10, has_action( 'sanitize_option_faustwp_settings', 'WPE\FaustWP\Settings\sanitize_faustwp_settings' ) );
 	}
 
+	public function test_faustwp_get_setting_filter_is_registered() {
+		$this->assertSame( 10, has_action( 'faustwp_get_setting', 'WPE\FaustWP\Settings\trim_frontend_uri_trailing_slash' ) );
+	}
+
 	public function test_sanitize_faustwp_settings_does_not_change_existing_settings() {
 		$this->assertSame( $this->init_settings, sanitize_faustwp_settings( $this->init_settings, $this->option ) );
 	}


### PR DESCRIPTION
## Description

This change sanitizes the `frontend_uri` setting from having a trailing slash `/` .

A user can attempt to save a valid URL with a trailing slash however it will be removed before the value is saved to the database. This change also accounts for those sites that already have a trailing slash in their database.

## Testing

1. Attempt to save a valid URL containing a trailing slash as the `frontend_uri`. _e.g._ `http://example.org/`
2. Save Settings
3. Verify trailing slash did not save to DB
    WP-CLI: `wp option get faustwp_settings`

<img width="447" alt="Screen Shot 2022-03-01 at 5 35 48 PM" src="https://user-images.githubusercontent.com/6676674/156260637-77851838-1373-4956-a53e-8e7fbf763434.png">