### PR TITLE
FaustWP Anonymous Telemetry

### DIFF
--- a/plugins/faustwp/faustwp.php
+++ b/plugins/faustwp/faustwp.php
@@ -29,6 +29,7 @@ define( 'FAUSTWP_PATH', plugin_basename( FAUSTWP_FILE ) );
 define( 'FAUSTWP_SLUG', dirname( plugin_basename( FAUSTWP_FILE ) ) );
 
 require FAUSTWP_DIR . '/includes/auth/functions.php';
+require FAUSTWP_DIR . '/includes/telemetry/functions.php';
 require FAUSTWP_DIR . '/includes/replacement/functions.php';
 require FAUSTWP_DIR . '/includes/settings/functions.php';
 require FAUSTWP_DIR . '/includes/graphql/functions.php';

--- a/plugins/faustwp/includes/rest/callbacks.php
+++ b/plugins/faustwp/includes/rest/callbacks.php
@@ -84,7 +84,7 @@ function register_rest_routes() {
 		array(
 			'methods'             => 'GET',
 			'callback'            => __NAMESPACE__ . '\\handle_rest_telemetry_callback',
-			'permission_callback' => __NAMESPACE__ . '\\rest_authorize_permission_callback',
+			'permission_callback' => __NAMESPACE__ . '\\rest_telemetry_permission_callback',
 		)
 	);
 
@@ -214,6 +214,19 @@ function rest_authorize_permission_callback( \WP_REST_Request $request ) {
 	}
 
 	return false;
+}
+
+/**
+ * Callback to check permissions for requests to `faustwp/v1/telemetry`.
+ *
+ * Authorized if the 'secret_key' settings value and http header 'x-faustwp-secret' match.
+ *
+ * @param \WP_REST_Request $request The current WP_REST_Request object.
+ *
+ * @return bool True if current user can, false if else.
+ */
+function rest_telemetry_permission_callback( \WP_REST_Request $request ) {
+	return rest_authorize_permission_callback( $request );
 }
 
 /**

--- a/plugins/faustwp/includes/rest/callbacks.php
+++ b/plugins/faustwp/includes/rest/callbacks.php
@@ -15,6 +15,16 @@ use function WPE\FaustWP\Auth\{
 	generate_access_token
 };
 use function WPE\FaustWP\Settings\get_secret_key;
+use function WPE\FaustWP\Telemetry\{
+	get_wp_version,
+	is_wpe,
+	get_active_theme,
+	get_active_theme_version,
+	get_active_plugins,
+	get_active_network_plugins,
+	get_permalink_structure,
+	get_anonymous_faustwp_settings
+};
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -59,6 +69,7 @@ add_action( 'rest_api_init', __NAMESPACE__ . '\\register_rest_routes' );
 /**
  * Callback for WordPress 'rest_api_init' action.
  *
+ * Register the GET /faustwp/v1/telemetry endpoint.
  * Register the POST /faustwp/v1/authorize endpoint.
  *
  * @link https://developer.wordpress.org/reference/functions/register_rest_route/
@@ -67,6 +78,16 @@ add_action( 'rest_api_init', __NAMESPACE__ . '\\register_rest_routes' );
  * @return void
  */
 function register_rest_routes() {
+	register_rest_route(
+		'faustwp/v1',
+		'/telemetry',
+		array(
+			'methods'             => 'GET',
+			'callback'            => __NAMESPACE__ . '\\handle_rest_telemetry_callback',
+			'permission_callback' => __NAMESPACE__ . '\\rest_authorize_permission_callback',
+		)
+	);
+
 	register_rest_route(
 		'faustwp/v1',
 		'/authorize',
@@ -91,6 +112,39 @@ function register_rest_routes() {
 			'permission_callback' => __NAMESPACE__ . '\\wpac_authorize_permission_callback',
 		)
 	);
+}
+
+/**
+ * Callback for WordPress register_rest_route() 'callback' parameter.
+ *
+ * Handle GET /faustwp/v1/telemetry response.
+ *
+ * @link https://developer.wordpress.org/reference/functions/register_rest_route/
+ * @link https://developer.wordpress.org/rest-api/extending-the-rest-api/routes-and-endpoints/#endpoint-callback
+ *
+ * @param \WP_REST_Request $request Current WP_REST_Request object.
+ *
+ * @return mixed A WP_REST_Response, array, or WP_Error.
+ */
+function handle_rest_telemetry_callback( \WP_REST_Request $request ) {
+	$data = array(
+		'php_version'            => PHP_VERSION,
+		'web_server_info'        => $_SERVER['SERVER_SOFTWARE'],
+		'wp_version'             => get_wp_version(),
+		'wp_multisite'           => is_multisite(),
+		'wp_theme'               => get_active_theme(),
+		'wp_theme_version'       => get_active_theme_version(),
+		'wp_plugins'             => get_active_plugins(),
+		'wp_permalink_structure' => get_permalink_structure(),
+		'faustwp_settings'       => get_anonymous_faustwp_settings(),
+		'is_wpe'                 => is_wpe(),
+	);
+
+	if ( is_multisite() ) {
+		$data['wp_network_plugins'] = get_active_network_plugins();
+	}
+
+	return new \WP_REST_Response( $data );
 }
 
 /**

--- a/plugins/faustwp/includes/rest/callbacks.php
+++ b/plugins/faustwp/includes/rest/callbacks.php
@@ -129,7 +129,6 @@ function register_rest_routes() {
 function handle_rest_telemetry_callback( \WP_REST_Request $request ) {
 	$data = array(
 		'php_version'            => PHP_VERSION,
-		'web_server_info'        => $_SERVER['SERVER_SOFTWARE'],
 		'wp_version'             => get_wp_version(),
 		'wp_multisite'           => is_multisite(),
 		'wp_theme'               => get_active_theme(),

--- a/plugins/faustwp/includes/telemetry/functions.php
+++ b/plugins/faustwp/includes/telemetry/functions.php
@@ -76,7 +76,7 @@ function get_active_plugins() {
 	$active_plugins         = \get_option( 'active_plugins', array() );
 
 	foreach ( $plugins as $plugin_path => $plugin ) {
-		if ( ! in_array( $plugin_path, $active_plugins ) ) {
+		if ( ! in_array( $plugin_path, $active_plugins, true ) ) {
 			continue;
 		}
 

--- a/plugins/faustwp/includes/telemetry/functions.php
+++ b/plugins/faustwp/includes/telemetry/functions.php
@@ -1,0 +1,112 @@
+<?php
+/**
+ * Telemetry functions.
+ *
+ * @package FaustWP
+ */
+
+namespace WPE\FaustWP\Telemetry;
+
+use function WPE\FaustWP\Settings\{
+	is_redirects_enabled,
+	is_rewrites_enabled,
+	is_themes_disabled,
+	is_image_source_replacement_enabled,
+	faustwp_get_setting,
+};
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+function get_wp_version() {
+	return get_bloginfo( 'version' );
+}
+
+function is_wpe() {
+	return defined( 'WPE_APIKEY' );
+}
+
+function get_active_theme() {
+	$theme       = wp_get_theme();
+	$text_domain = $theme->get( 'TextDomain' );
+
+	return $text_domain;
+}
+
+function get_active_theme_version() {
+	$theme   = wp_get_theme();
+	$version = $theme->get( 'Version' );
+
+	return $version;
+}
+
+function get_active_plugins() {
+	if ( ! function_exists( 'get_plugins' ) ) {
+		require_once ABSPATH . 'wp-admin/includes/plugin.php';
+	}
+
+	$active_plugin_versions = array();
+	$plugins                = \get_plugins();
+	$active_plugins         = \get_option( 'active_plugins', array() );
+
+	foreach ( $plugins as $plugin_path => $plugin ) {
+		if ( ! in_array( $plugin_path, $active_plugins ) ) {
+			continue;
+		}
+
+		$active_plugin_versions[ $plugin['TextDomain'] ] = $plugin['Version'];
+	}
+
+	return $active_plugin_versions;
+}
+
+function get_active_network_plugins() {
+	if ( ! is_multisite() ) {
+		return false;
+	}
+
+	$active_network_plugins = array();
+	$plugins                = wp_get_active_network_plugins();
+	$active_plugins         = get_site_option( 'active_sitewide_plugins', array() );
+
+	foreach ( $plugins as $plugin_path ) {
+		$plugin_base = plugin_basename( $plugin_path );
+
+		if ( ! array_key_exists( $plugin_base, $active_plugins ) ) {
+			continue;
+		}
+
+		$plugin = get_plugin_data( $plugin_path );
+
+		$active_network_plugins[ $plugin['TextDomain'] ] = $plugin['Version'];
+	}
+
+	return $active_network_plugins;
+}
+
+function get_permalink_structure() {
+	return get_option( 'permalink_structure' );
+}
+
+function get_anonymous_faustwp_settings() {
+	$anonymous_settings = array(
+		'has_frontend_uri'                 => has_frontend_uri(),
+		'redirects_enabled'                => is_redirects_enabled(),
+		'rewrites_enabled'                 => is_rewrites_enabled(),
+		'themes_disabled'                  => is_themes_disabled(),
+		'image_source_replacement_enabled' => is_image_source_replacement_enabled(),
+	);
+
+	return $anonymous_settings;
+}
+
+function has_frontend_uri() {
+	$frontend_uri = faustwp_get_setting( 'frontend_uri' );
+
+	if ( empty( $frontend_uri ) ) {
+		return false;
+	}
+
+	return true;
+}

--- a/plugins/faustwp/includes/telemetry/functions.php
+++ b/plugins/faustwp/includes/telemetry/functions.php
@@ -19,14 +19,29 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+/**
+ * Returns the current WordPress version.
+ *
+ * @return string
+ */
 function get_wp_version() {
 	return get_bloginfo( 'version' );
 }
 
+/**
+ * Checks if the current hosting environment is WP Engine.
+ *
+ * @return boolean
+ */
 function is_wpe() {
 	return defined( 'WPE_APIKEY' );
 }
 
+/**
+ * Returns the active theme text domain.
+ *
+ * @return string
+ */
 function get_active_theme() {
 	$theme       = wp_get_theme();
 	$text_domain = $theme->get( 'TextDomain' );
@@ -34,6 +49,11 @@ function get_active_theme() {
 	return $text_domain;
 }
 
+/**
+ * Returns the active theme's version.
+ *
+ * @return string
+ */
 function get_active_theme_version() {
 	$theme   = wp_get_theme();
 	$version = $theme->get( 'Version' );
@@ -41,6 +61,11 @@ function get_active_theme_version() {
 	return $version;
 }
 
+/**
+ * Returns an array of active plugin text domains with their versions.
+ *
+ * @return array
+ */
 function get_active_plugins() {
 	if ( ! function_exists( 'get_plugins' ) ) {
 		require_once ABSPATH . 'wp-admin/includes/plugin.php';
@@ -61,6 +86,11 @@ function get_active_plugins() {
 	return $active_plugin_versions;
 }
 
+/**
+ * Returns an array of active network plugin text domains with their versions.
+ *
+ * @return array
+ */
 function get_active_network_plugins() {
 	if ( ! is_multisite() ) {
 		return false;
@@ -85,10 +115,20 @@ function get_active_network_plugins() {
 	return $active_network_plugins;
 }
 
+/**
+ * Returns the current permalink structure as set in WP settings.
+ *
+ * @return string
+ */
 function get_permalink_structure() {
 	return get_option( 'permalink_structure' );
 }
 
+/**
+ * Returns the current FaustWP settings while keeping identifiable information private.
+ *
+ * @return array
+ */
 function get_anonymous_faustwp_settings() {
 	$anonymous_settings = array(
 		'has_frontend_uri'                 => has_frontend_uri(),
@@ -101,6 +141,11 @@ function get_anonymous_faustwp_settings() {
 	return $anonymous_settings;
 }
 
+/**
+ * Checks if the frontend_uri FaustWP setting has been set.
+ *
+ * @return boolean
+ */
 function has_frontend_uri() {
 	$frontend_uri = faustwp_get_setting( 'frontend_uri' );
 


### PR DESCRIPTION
## Description

Proof of concept for collecting anonymous FaustWP info in order to support our telemetry effort.

## Testing

1. Copy your FaustWP secret key
2. Make a **GET** request to `/wp-json/faustwp/v1/telemetry` with the faustwp-secret header.
    ```sh
    curl --header "x-faustwp-secret: f8e70441-44c4-474f-a2f8-b54876d7b3d1" faustjs.local/wp-json/faustwp/v1/telemetry | python -m json.tool
    ```
3. Response with **valid** secret key
      ```json
    {
        "faustwp": {
          "version": "0.7.9",
          "has_frontend_uri": true,
          "redirects_enabled": false,
          "rewrites_enabled": false,
          "themes_disabled": false,
          "image_source_replacement_enabled": false
        },
          "is_wpe": false,
          "multisite": false,
          "php_version": "8.0.0",
          "wp_version": "6.0"
    }
     ```

    Response with **Enable usage tracking** option off, or **invalid** secret key
    ```json
    {
        "code": "rest_forbidden",
        "data": {
            "status": 401
        },
        "message": "Sorry, you are not allowed to do that."
    }
    ```
