### PR TITLE
System fonts

### DIFF
--- a/examples/next/getting-started/src/pages/_document.tsx
+++ b/examples/next/getting-started/src/pages/_document.tsx
@@ -4,24 +4,7 @@ class MyDocument extends Document {
   render() {
     return (
       <Html>
-        <Head>
-          <link
-            rel="preconnect"
-            href="https://fonts.gstatic.com"
-            crossOrigin="anonymous"
-          />
-          <link
-            rel="preload"
-            as="style"
-            href="https://fonts.googleapis.com/css2?display=swap&amp;family=Public%20Sans%3Aital%2Cwght%400%2C100..900%3B1%2C100..900&amp;subset=latin%2Clatin-ext"
-          />
-          <link
-            rel="stylesheet"
-            href="https://fonts.googleapis.com/css2?display=swap&amp;family=Public%20Sans%3Aital%2Cwght%400%2C100..900%3B1%2C100..900&amp;subset=latin%2Clatin-ext"
-            type="text/css"
-            media="all"
-          />
-        </Head>
+        <Head />
         <body>
           <Main />
           <NextScript />

--- a/examples/next/getting-started/src/scss/_variables.scss
+++ b/examples/next/getting-started/src/scss/_variables.scss
@@ -5,7 +5,7 @@ $color-dark-gray: #1f1f1f;
 $color-light-gray: #f2f2f2;
 $color-mid-gray: #606060;
 
-$font-family: "Public Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
+$font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji';
 $font-weight-normal: 300;
 $font-weight-bold: 600;
 

--- a/internal/website/src/css/custom.css
+++ b/internal/website/src/css/custom.css
@@ -71,7 +71,7 @@
 
 html,
 body {
-  font-family: 'Open Sans', sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji';
 }
 
 .docusaurus-highlight-code-line {


### PR DESCRIPTION
## Description

These changes remove the usage of Google Fonts in favor of system fonts.

## Testing

1. Spin up example site - `npm run dev`
2. Open dev tools and check that computed fonts are showing system fonts
    ```css
    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji";
    ```
    ^ System font-stack taken from GitHub

3. Spin up docs site - `npm run docs`
4. Open dev tools and check that computed fonts are showing system fonts
