### PR TITLE
Fix PHP 8 warning on non WP GraphQL post types

### DIFF
--- a/plugins/faustwp/includes/replacement/callbacks.php
+++ b/plugins/faustwp/includes/replacement/callbacks.php
@@ -147,7 +147,11 @@ function post_preview_link( $link, $post ) {
 		 * the data.
 		 */
 		$post_type_object = get_post_type_object( $post->post_type );
-		if ( ! isset( $args['typeName'] ) && isset( $post_type_object ) ) {
+		if (
+			! isset( $args['typeName'] ) &&
+			isset( $post_type_object ) &&
+			! empty( $post_type_object->graphql_single_name )
+		) {
 			$gql_type_name    = ucfirst( $post_type_object->graphql_single_name );
 			$args['typeName'] = $gql_type_name;
 		}

--- a/plugins/faustwp/tests/integration/replacement/test-replacement-callbacks.php
+++ b/plugins/faustwp/tests/integration/replacement/test-replacement-callbacks.php
@@ -168,6 +168,24 @@ class ReplacementCallbacksTestCases extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests get_preview_post_link() filters link for post types that are not registered with WP GraphQL.
+	 */
+	public function test_post_preview_link_filters_link_for_posts_not_registered_with_wpgraphql() {
+		faustwp_update_setting( 'frontend_uri', 'http://moo' );
+
+		register_post_type('notgraphql', ['public' => true]);
+
+		$post_id = wp_insert_post( [
+			'title'        => 'Hello world',
+			'post_content' => 'Hi',
+			'post_status'  => 'publish',
+			'post_type'    => 'notgraphql'
+		] );
+
+		$this->assertSame( 'http://moo/?notgraphql=' . $post_id . '&preview=true&p=' . $post_id, get_preview_post_link( $post_id ) );
+	}
+
+	/**
 	 * Tests get_term_link() returns original value when term link rewrites are not enabled.
 	 *
 	 * @covers ::term_link(), which runs on term_link filter inside get_term_link().


### PR DESCRIPTION
## Description

<!--
Include a summary of the change and some contextual information.
-->

Post types that aren't registered with WP GraphQL (like ACF field groups) don't have a `graphql_single_name` property. As of PHP 8, accessing undefined properties on objects results in a warning rather than a notice.

This fix checks that the `graphql_single_name` property exists and is not empty before adding a `typeName` to the preview link.

## Related Issue(s):

<!--
Provide the GitHub issue(s) number for issue tracking purposes, use the following syntax:

- #1234
-->

Fixes #752
Related: #809 

## Testing

<!--
Describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Also list any relevant details for your test configuration such as how to test the changes locally or in staging.
-->

Unit test case has been added. The test case should fail in the absence of this patch regardless of what PHP version the tests are running on because our [test config](https://github.com/wpengine/faustjs/blob/9a24e06d4c932afb5a7c96fc1214064e1a7c30b0/plugins/faustwp/phpunit.xml.dist#L7-L8) converts both PHP warnings _and_ notices to exceptions. 🥳 