### PR TITLE
[MERL-235] Deprecate `applyRequestContext`

### DIFF
--- a/.changeset/selfish-shrimps-care.md
+++ b/.changeset/selfish-shrimps-care.md
@@ -1,0 +1,5 @@
+---
+'@faustjs/core': patch
+---
+
+Adds @deprecated flag in core/config `applyRequestContext`

--- a/internal/website/docs/core/reference/config.mdx
+++ b/internal/website/docs/core/reference/config.mdx
@@ -27,6 +27,7 @@ export default coreConfig({
 ```
 
 ## Config
+
 The Config object has the following properties:
 
 ### `wpUrl`
@@ -96,21 +97,6 @@ type: `(url: string, init: RequestInit): Promise<RequestContext> | RequestContex
 
 Required: `false`
 
-This is a callback function that is called before every request . Use this to apply any headers you might need to for your requests or adjust the request to suite your needs:
+Deprecated: `true`
 
-```tsx
-export default coreConfig({
-  wpUrl: process.env.NEXT_PUBLIC_WORDPRESS_URL,
-  apiClientSecret: process.env.FAUSTWP_SECRET_KEY,
-  applyRequestContext: (url, init) => {
-    const reqInit = {
-      ...init,
-      headers: {
-        ...init.headers,
-        'X-Powered-By': 'WP Engine'
-      }
-    }
-    return {url, init: reqInit};
-  }
-});
-```
+This property is not used anymore and has no effect. You should use this function in [getClient](/docs/next/guides/modifying-the-graphql-request) instead. This will be removed in subsequent versions of Faust.js.

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -93,7 +93,7 @@ export interface Config extends Record<string, unknown> {
    * Called before every request, use this to apply any headers you might
    * need to for your requests or adjust the request to suite your needs.
    *
-   * @deprecated This property is not used anymore and has no effect. You should use this function in [getClient](/docs/next/guides/modifying-the-graphql-request) instead. This will be removed in subsequent versions of Faust.js.
+   * @deprecated This property is not used anymore and has no effect. You should use this function in [getClient](https://faustjs.org/docs/next/guides/modifying-the-graphql-request) instead. This will be removed in subsequent versions of Faust.js.
    * @param {string} url
    * @param {RequestInit} init
    * @returns {RequestContext}

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -93,6 +93,7 @@ export interface Config extends Record<string, unknown> {
    * Called before every request, use this to apply any headers you might
    * need to for your requests or adjust the request to suite your needs.
    *
+   * @deprecated This property is not used anymore and has no effect. You should use this function in [getClient](/docs/next/guides/modifying-the-graphql-request) instead. This will be removed in subsequent versions of Faust.js.
    * @param {string} url
    * @param {RequestInit} init
    * @returns {RequestContext}


### PR DESCRIPTION
## Description

This PR adds a @deprecated flag on the core config `applyRequestContext` referencing the correct way to use this function in the [getClient](http://localhost:3000/docs/next/guides/modifying-the-graphql-request) guide.

## Related Issue(s):

<!--
Provide the GitHub issue(s) number for issue tracking purposes, use the following syntax:

- #1234
-->

## Testing
1. Run the docs site
2. Navigate to the `/docs/core/reference/config` page
3. Read through the docs

## Screenshots

<!--
If this is a visual change include relevant screenshots about the behavior of the application before and after this change.
-->
<img width="1316" alt="Screenshot 2022-04-26 at 10 23 49" src="https://user-images.githubusercontent.com/328805/165269147-11490f88-4d8c-4b6e-85b2-9ef4cb0624a3.png">

## Documentation Changes

<!--
List corresponding changes to the documentation.
-->

The following pages we modified:
* `/docs/core/reference/config`

## Dependant PRs

<!--
List any dependent PR's that are awaiting review. Use the following syntax:

- #1234
-->
