### PR TITLE
Explicitly set `preview=true` in preview links

### DIFF
--- a/.changeset/light-ligers-join.md
+++ b/.changeset/light-ligers-join.md
@@ -1,0 +1,5 @@
+---
+'faustwp': patch
+---
+
+Fix conflict with PublishPress that caused preview links to fail

--- a/plugins/faustwp/includes/replacement/callbacks.php
+++ b/plugins/faustwp/includes/replacement/callbacks.php
@@ -135,6 +135,11 @@ function post_preview_link( $link, $post ) {
 			$args['p'] = $preview_id;
 		}
 
+		// Add preview=true in case other plugins have stripped it.
+		if ( ! isset( $args['preview'] ) ) {
+			$args['preview'] = 'true';
+		}
+
 		// Add page_id=xx if it's missing, which is the case for published pages.
 		if ( ! isset( $args['page_id'] ) && 'page' === $post->post_type ) {
 			$args['page_id'] = $preview_id;

--- a/plugins/faustwp/tests/integration/replacement/test-replacement-callbacks.php
+++ b/plugins/faustwp/tests/integration/replacement/test-replacement-callbacks.php
@@ -9,6 +9,7 @@ namespace WPE\FaustWP\Tests\Replacement;
 
 use function WPE\FaustWP\Replacement\{
 	content_replacement,
+	post_preview_link,
 	image_source_replacement,
 	image_source_srcset_replacement
 };
@@ -165,6 +166,17 @@ class ReplacementCallbacksTestCases extends \WP_UnitTestCase {
 		faustwp_update_setting( 'frontend_uri', 'http://moo' );
 
 		$this->assertSame( 'http://moo/?p=' . $this->post_id . '&preview=true&typeName=Post', get_preview_post_link( $this->post_id ) );
+	}
+
+	/**
+	 * Tests post_preview_link() adds preview=true when it doesn't already exist.
+	 */
+	public function test_post_preview_link_adds_preview_true_query_param() {
+		faustwp_update_setting( 'frontend_uri', 'http://moo' );
+
+		$link = post_preview_link( 'http://moo/', get_post( $this->post_id ) );
+
+		$this->assertSame( 'http://moo/?p=' . $this->post_id . '&preview=true&typeName=Post', $link );
 	}
 
 	/**


### PR DESCRIPTION
## Description

<!--
Include a summary of the change and some contextual information.
-->

WordPress preview links include the `preview=true` query param by default. We rely on this query param to identify and handle preview requests on Faust.js frontends. Any WP plugin ([PublishPress](https://wordpress.org/plugins/publishpress/) is a known example) could potentially remove `preview=true`, causing previews to fail.

This PR explicitly adds `preview=true` to all preview links in case it was removed by another plugin.

## Testing

<!--
Describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Also list any relevant details for your test configuration such as how to test the changes locally or in staging.
-->

Integration test is included.