### PR TITLE
Make preview links compatible with i18n config

### DIFF
--- a/packages/next/src/config/withFaust.ts
+++ b/packages/next/src/config/withFaust.ts
@@ -1,18 +1,25 @@
 import { trim } from 'lodash';
 import isFunction from 'lodash/isFunction.js';
 import { NextConfig } from 'next';
-import { Redirect } from 'next/dist/lib/load-custom-routes.js';
+import { Redirect, RouteHas } from 'next/dist/lib/load-custom-routes.js';
 
 export interface WithFaustConfig {
   previewDestination?: string;
 }
 
 export async function createRedirects(
+  nextConfig?: NextConfig,
   redirectFn?: NextConfig['redirects'],
-  trailingSlash = false,
   previewDestination = '/preview',
 ): Promise<Redirect[]> {
   let redirects: Redirect[] = [];
+  const previewQuery: RouteHas[] = [
+    {
+      type: 'query',
+      key: 'preview',
+      value: 'true',
+    },
+  ];
 
   if (isFunction(redirectFn)) {
     redirects = await redirectFn();
@@ -20,22 +27,33 @@ export async function createRedirects(
 
   let previewPath = trim(previewDestination, '/');
 
-  if (trailingSlash) {
+  if (nextConfig?.trailingSlash) {
     previewPath += '/';
   }
 
   redirects.unshift({
     source: `/((?!${previewPath}).*)`,
-    has: [
-      {
-        type: 'query',
-        key: 'preview',
-        value: 'true',
-      },
-    ],
+    has: previewQuery,
     destination: `/${previewPath}`,
     permanent: false,
   });
+
+  if (nextConfig?.i18n) {
+    /**
+     * All redirect sources are automatically prefixed with available locales
+     * when i18n is configured, so our previous rule won't match '/'. We need
+     * an extra rule to catch each locale's root path.
+     *
+     * https://nextjs.org/docs/api-reference/next.config.js/redirects#redirects-with-i18n-support
+     */
+    redirects.unshift({
+      source: nextConfig.trailingSlash ? '/:lang/' : '/:lang',
+      has: previewQuery,
+      destination: `/:lang/${previewPath}`,
+      permanent: false,
+      locale: false,
+    });
+  }
 
   return redirects;
 }
@@ -57,11 +75,7 @@ export function withFaust(
 
   const existingRedirects = nextConfig.redirects;
   nextConfig.redirects = () =>
-    createRedirects(
-      existingRedirects,
-      nextConfig.trailingSlash,
-      previewDestination,
-    );
+    createRedirects(nextConfig, existingRedirects, previewDestination);
 
   return nextConfig;
 }

--- a/packages/next/test/withFaust.test.ts
+++ b/packages/next/test/withFaust.test.ts
@@ -116,4 +116,45 @@ describe('withFaust', () => {
 
     expect(configRedirects).toStrictEqual(expectedRedirects);
   });
+
+  test('preview redirect respects i18n config', async () => {
+    const config = withFaust({
+      i18n: {
+        locales: ['en', 'fr'],
+        defaultLocale: 'en',
+      },
+    });
+
+    const configRedirects = await (config as any).redirects();
+
+    const expectedRedirects = [
+      {
+        source: '/:lang',
+        has: [
+          {
+            type: 'query',
+            key: 'preview',
+            value: 'true',
+          },
+        ],
+        destination: '/:lang/preview',
+        permanent: false,
+        locale: false,
+      },
+      {
+        source: '/((?!preview).*)',
+        has: [
+          {
+            type: 'query',
+            key: 'preview',
+            value: 'true',
+          },
+        ],
+        destination: '/preview',
+        permanent: false,
+      },
+    ];
+
+    expect(configRedirects).toStrictEqual(expectedRedirects);
+  });
 });


### PR DESCRIPTION
## Description

<!--
Include a summary of the change and some contextual information.
-->

Next.js includes support for [internationalized routing through the `i18n` config](https://nextjs.org/docs/advanced-features/i18n-routing). The `i18n` config [affects redirects](https://nextjs.org/docs/api-reference/next.config.js/redirects#redirects-with-i18n-support) in such a way that our existing preview regex doesn't match on any root path (i.e. `/`, `/en`, `/fr`, etc.). This PR adds an extra redirect rule to handle the special cases that `i18n` introduces.

## Testing

<!--
Describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Also list any relevant details for your test configuration such as how to test the changes locally or in staging.
-->

