### PR TITLE
MERL-247 multisite default settings

### DIFF
--- a/.changeset/old-rice-speak.md
+++ b/.changeset/old-rice-speak.md
@@ -1,0 +1,5 @@
+---
+'faustwp': patch
+---
+
+The plugin's default settings are now working when activated within a multisite installation.

--- a/plugins/faustwp/composer.json
+++ b/plugins/faustwp/composer.json
@@ -31,7 +31,7 @@
       "@phpcs",
       "@test"
     ],
-    "test": "phpunit --testdox && phpunit --testdox -c phpunit-multisite.xml"
+    "test": "phpunit --testdox && phpunit --testdox -c phpunit-multisite.xml.dist"
   },
   "config": {
     "preferred-install": "dist",

--- a/plugins/faustwp/composer.json
+++ b/plugins/faustwp/composer.json
@@ -31,7 +31,7 @@
       "@phpcs",
       "@test"
     ],
-    "test": "phpunit --testdox"
+    "test": "phpunit --testdox && phpunit --testdox -c phpunit-multisite.xml"
   },
   "config": {
     "preferred-install": "dist",

--- a/plugins/faustwp/includes/settings/functions.php
+++ b/plugins/faustwp/includes/settings/functions.php
@@ -129,6 +129,13 @@ function maybe_set_default_settings() {
 		faustwp_update_setting( 'disable_theme', '1' );
 		faustwp_update_setting( 'enable_rewrites', '1' );
 		faustwp_update_setting( 'enable_redirects', '1' );
+
+		// Force WP to regenerate rewrite rules without calling flush_rewrite_rules which breaks
+		// things when used inside of `switch_to_blog()`.
+		// https://iandunn.name/2015/04/23/flushing-rewrite-rules-on-all-sites-in-a-multisite-network/
+		if ( is_multisite() ) {
+			delete_option( 'rewrite_rules' );
+		}
 	}
 
 	if ( ! $secret_key ) {

--- a/plugins/faustwp/includes/settings/functions.php
+++ b/plugins/faustwp/includes/settings/functions.php
@@ -132,7 +132,6 @@ function maybe_set_default_settings() {
 
 		// Force WP to regenerate rewrite rules without calling flush_rewrite_rules which breaks
 		// things when used inside of `switch_to_blog()`.
-		// https://iandunn.name/2015/04/23/flushing-rewrite-rules-on-all-sites-in-a-multisite-network/
 		if ( is_multisite() ) {
 			delete_option( 'rewrite_rules' );
 		}

--- a/plugins/faustwp/includes/settings/functions.php
+++ b/plugins/faustwp/includes/settings/functions.php
@@ -115,3 +115,23 @@ function faustwp_get_settings() {
 	 */
 	return apply_filters( 'faustwp_get_settings', $settings );
 }
+
+/**
+ * Applies the default settings to a site if settings don't already exist.
+ *
+ * @return void
+ */
+function maybe_set_default_settings() {
+	$secret_key = get_secret_key();
+	$settings   = faustwp_get_settings();
+
+	if ( empty( $settings ) ) {
+		faustwp_update_setting( 'disable_theme', '1' );
+		faustwp_update_setting( 'enable_rewrites', '1' );
+		faustwp_update_setting( 'enable_redirects', '1' );
+	}
+
+	if ( ! $secret_key ) {
+		faustwp_update_setting( 'secret_key', wp_generate_uuid4() );
+	}
+}

--- a/plugins/faustwp/includes/utilities/callbacks.php
+++ b/plugins/faustwp/includes/utilities/callbacks.php
@@ -11,7 +11,8 @@ use function WPE\FaustWP\Detect_Conflicts\delete_conflicts_dismissed;
 use function WPE\FaustWP\Settings\{
 	get_secret_key,
 	faustwp_get_settings,
-	faustwp_update_setting
+	faustwp_update_setting,
+	maybe_set_default_settings
 };
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -31,27 +32,29 @@ register_activation_hook( FAUSTWP_FILE, __NAMESPACE__ . '\\handle_activation' );
  *
  * @link https://developer.wordpress.org/reference/functions/register_activation_hook/
  *
+ * @param bool $network_active True if plugin is network activated.
+ *
  * @return void
  */
-function handle_activation() {
+function handle_activation( $network_active ) {
 	if ( is_plugin_active( 'wpe-headless/wpe-headless.php' ) ) {
 		deactivate_plugins( 'wpe-headless/wpe-headless.php', true );
 	}
 
-	$secret_key = get_secret_key();
-	$settings   = faustwp_get_settings();
+	// Handle network activation of plugin within multisite.
+	if ( $network_active ) {
+		$sites = get_sites();
 
-	if ( empty( $settings ) ) {
-		faustwp_update_setting( 'disable_theme', '1' );
-		faustwp_update_setting( 'enable_rewrites', '1' );
-		faustwp_update_setting( 'enable_redirects', '1' );
+		foreach ( $sites as $site ) {
+			switch_to_blog( $site->blog_id );
+			maybe_set_default_settings();
+			restore_current_blog();
+		}
+
+		return;
 	}
 
-	if ( ! $secret_key ) {
-		faustwp_update_setting( 'secret_key', wp_generate_uuid4() );
-	}
-
-	flush_rewrite_rules();
+	maybe_set_default_settings();
 }
 
 register_deactivation_hook( FAUSTWP_FILE, __NAMESPACE__ . '\\handle_deactivation' );
@@ -69,4 +72,20 @@ register_deactivation_hook( FAUSTWP_FILE, __NAMESPACE__ . '\\handle_deactivation
 function handle_deactivation() {
 	delete_conflicts_dismissed();
 	flush_rewrite_rules();
+}
+
+add_action( 'wp_initialize_site', __NAMESPACE__ . '\\handle_new_site_creation' );
+/**
+ * Fires when a site's initialization routine should be executed.
+ *
+ * @link https://developer.wordpress.org/reference/hooks/wp_initialize_site/
+ *
+ * @param WP_Site $new_site New site object.
+ *
+ * @return void
+ */
+function handle_new_site_creation( $new_site ) {
+	switch_to_blog( $new_site->blog_id );
+	maybe_set_default_settings();
+	restore_current_blog();
 }

--- a/plugins/faustwp/includes/utilities/callbacks.php
+++ b/plugins/faustwp/includes/utilities/callbacks.php
@@ -43,10 +43,13 @@ function handle_activation( $network_active ) {
 
 	// Handle network activation of plugin within multisite.
 	if ( $network_active ) {
-		$sites = get_sites();
+		$args  = array(
+			'fields' => 'ids',
+		);
+		$sites = get_sites( $args );
 
 		foreach ( $sites as $site ) {
-			switch_to_blog( $site->blog_id );
+			switch_to_blog( $site );
 			maybe_set_default_settings();
 			restore_current_blog();
 		}

--- a/plugins/faustwp/phpunit-multisite.xml.dist
+++ b/plugins/faustwp/phpunit-multisite.xml.dist
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<phpunit
+	bootstrap="tests/bootstrap.php"
+	backupGlobals="false"
+	colors="true"
+	convertErrorsToExceptions="true"
+	convertNoticesToExceptions="true"
+	convertWarningsToExceptions="true"
+	>
+	<php>
+		<const name="WP_TESTS_MULTISITE" value="1" />
+	</php>
+	<testsuites>
+		<testsuite name="integration">
+			<directory prefix="test-" suffix=".php">./tests/integration/</directory>
+		</testsuite>
+	</testsuites>
+</phpunit>

--- a/plugins/faustwp/tests/integration/settings/test-functions.php
+++ b/plugins/faustwp/tests/integration/settings/test-functions.php
@@ -15,7 +15,8 @@ use function WPE\FaustWP\Settings\{
 	faustwp_get_settings,
 	faustwp_get_setting,
 	faustwp_update_setting,
-	get_secret_key
+	get_secret_key,
+	maybe_set_default_settings
 };
 
 class FunctionsTest extends \WP_UnitTestCase {
@@ -110,11 +111,30 @@ class FunctionsTest extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * Used to filter return value of faustwp_get_setting() via faustwp_get_setting filter.
-	 * @return string
+	 * Test maybe_set_default_settings() does not override a preexisting secret key.
 	 */
-	public function faustwp_get_setting_test_filtered_value() {
-		return 'filtered value';
+	public function test_maybe_set_default_settings_does_not_override_preexisting_api_key() {
+		$preexisting_key = wp_generate_uuid4();
+
+		faustwp_update_setting( 'secret_key', $preexisting_key );
+
+		maybe_set_default_settings();
+
+		$this->assertSame( $preexisting_key, faustwp_get_setting( 'secret_key' ) );
+	}
+
+	/**
+	 * Test maybe_set_default_settings() sets the default settings when .
+	 */
+	public function test_default_settings_are_applied_when_settings_do_not_exist() {
+		delete_option( 'faustwp_settings' );
+
+		maybe_set_default_settings();
+
+		$this->assertSame( faustwp_get_setting( 'disable_theme' ), '1' );
+		$this->assertSame( faustwp_get_setting( 'enable_rewrites' ), '1' );
+		$this->assertSame( faustwp_get_setting( 'enable_redirects' ), '1' );
+		$this->assertNotEmpty( faustwp_get_setting( 'secret_key' ) );
 	}
 
 	/**
@@ -123,4 +143,20 @@ class FunctionsTest extends \WP_UnitTestCase {
 	public function test_plugin_action_links_has_settings_callback_attached() {
 		$this->assertSame( 10, has_action( 'plugin_action_links_faustwp/faustwp.php', 'WPE\FaustWP\Settings\add_action_link_settings' ) );
 	}
+
+	/**
+	 * Tests that wp_initialize_site has callback attached.
+	 */
+	public function test_wp_initialize_site_has_settings_callback_attached() {
+		$this->assertSame( 10, has_action( 'wp_initialize_site', 'WPE\FaustWP\Utilities\handle_new_site_creation' ) );
+	}
+
+	/**
+	 * Used to filter return value of faustwp_get_setting() via faustwp_get_setting filter.
+	 * @return string
+	 */
+	public function faustwp_get_setting_test_filtered_value() {
+		return 'filtered value';
+	}
+
 }


### PR DESCRIPTION
## Description

This change handles the following multisite scenarios

- Default settings are properly applied to all sites when plugin is activated, both individual and network activations.
- Default settings are properly applied to newly created sites within a multisite network.

## Testing

1. Create a new WordPress multisite in Local. (Subdomains/subdirectories does not matter)
2. Create 2 additional sites. Call them whatever you want.
3. Going back to Local, slick "SYNC MULTISITE DOMAINS TO HOSTS FILE".
4. Install FaustWP & network activate.
5. Go to Site 1 -> Settings -> Headless to view FaustWP settings.
6. All default settings should be there.
7. Go to Site 2 -> Settings -> Headless to view FaustWP settings.
9. All default settings should be there.
10. With the plugin still active, create another site (Site 3)
11. Go to Site 3 -> Settings -> Headless to view FaustWP settings.
12. All default settings should be there.