### PR TITLE
[MERL-277] docs(tip): Adds Local Atlas Extension Links to getting started section

### DIFF
--- a/internal/website/docs/tutorial/basic-headless-site.mdx
+++ b/internal/website/docs/tutorial/basic-headless-site.mdx
@@ -8,7 +8,7 @@ description: In this tutorial, we'll walk you through the process of creating a 
 
 You can now save most of the following steps by using the **Local Atlas extension** that enables an effortless experience spinning up a WordPress instance with an accompanying Faust.js frontend.
 Just follow the steps outlined in the [**relevant help docs**](https://localwp.com/help-docs/local-add-ons-help/using-the-atlas-headless-wp-add-on/).
-With this addoned enabled, you will be able to install [**Blueprints**](https://localwp.com/help-docs/local-add-ons-help/what-are-atlas-blueprints/)
+With this add-on enabled, you will be able to install [**Blueprints**](https://localwp.com/help-docs/local-add-ons-help/what-are-atlas-blueprints/)
 which are pre-built headless WordPress sites designed to work seamlessly with WP Engine's Atlas hosting platform and are useful for testing.
 :::
 

--- a/internal/website/docs/tutorial/basic-headless-site.mdx
+++ b/internal/website/docs/tutorial/basic-headless-site.mdx
@@ -4,6 +4,14 @@ title: Create A Basic Headless WordPress Site
 description: In this tutorial, we'll walk you through the process of creating a basic headless WordPress site using Next.js and Local.
 ---
 
+:::tip
+
+You can now save most of the following steps by using the **Local Atlas extension** that enables an effortless experience spinning up a WordPress instance with an accompanying Faust.js frontend.
+Just follow the steps outlined in the [**relevant help docs**](https://localwp.com/help-docs/local-add-ons-help/using-the-atlas-headless-wp-add-on/).
+With this addoned enabled, you will be able to install [**Blueprints**](https://localwp.com/help-docs/local-add-ons-help/what-are-atlas-blueprints/)
+which are pre-built headless WordPress sites designed to work seamlessly with WP Engine's Atlas hosting platform and are useful for testing.
+:::
+
 In the previous tutorial, we set up our development environment to create JavaScript/TypeScript apps efficiently.
 
 Now, we will create our frontend web app using Next.js, and spin up an instance of WordPress.


### PR DESCRIPTION
This PR adds a tip to the Faust.js getting started guide mentioning
how Local Atlas extension can help saving some steps in the process.

## Description

<!--
Include a summary of the change and some contextual information.
-->

## Related Issue(s):

<!--
Provide the GitHub issue(s) number for issue tracking purposes, use the following syntax:

- #1234
-->
MERL-277


## Testing

<!--
Describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Also list any relevant details for your test configuration such as how to test the changes locally or in staging.
-->

1. Navigate to the `/docs/tutorial/basic-headless-site` section of the docs.
2. Observe the tooltip section pertaining information about  Local Atlas Extension
 
## Screenshots
<img width="1777" alt="Screenshot 2022-05-05 at 13 44 29" src="https://user-images.githubusercontent.com/328805/166925568-035715bd-4380-4dac-b0f8-26d0ab134552.png">
<!--
If this is a visual change include relevant screenshots about the behavior of the application before and after this change.
-->

## Documentation Changes

<!--
List corresponding changes to the documentation.
-->

## Dependant PRs

<!--
List any dependent PR's that are awaiting review. Use the following syntax:

- #1234
-->
