### PR TITLE
Remove multisite subdirectory from path

### DIFF
--- a/.changeset/kind-radios-cough.md
+++ b/.changeset/kind-radios-cough.md
@@ -1,0 +1,5 @@
+---
+'faustwp': patch
+---
+
+Fix menu paths when activated within a multisite using subdirectories.

--- a/plugins/faustwp/includes/replacement/graphql-callbacks.php
+++ b/plugins/faustwp/includes/replacement/graphql-callbacks.php
@@ -56,14 +56,12 @@ function url_replace_recursive( &$data ) {
 		if ( ( 'url' === $key || 'href' === $key ) && is_string( $value ) ) {
 			$replacement = faustwp_get_setting( 'frontend_uri', '/' );
 			$value       = str_replace( site_url(), $replacement, $value );
-		} elseif ( is_array( $value ) ) {
-			url_replace_recursive( $value );
-		}
-
-		if ( 'path' === $key && is_multisite() ) {
+		} elseif ( ( 'path' === $key && is_multisite() ) && is_string( $value ) ) {
 			$site         = get_site();
 			$subdirectory = untrailingslashit( $site->path );
 			$value        = str_replace( $subdirectory, '', $value );
+		} elseif ( is_array( $value ) ) {
+			url_replace_recursive( $value );
 		}
 	}
 }

--- a/plugins/faustwp/includes/replacement/graphql-callbacks.php
+++ b/plugins/faustwp/includes/replacement/graphql-callbacks.php
@@ -59,5 +59,11 @@ function url_replace_recursive( &$data ) {
 		} elseif ( is_array( $value ) ) {
 			url_replace_recursive( $value );
 		}
+
+		if ( 'path' === $key && is_multisite() ) {
+			$site         = get_site();
+			$subdirectory = untrailingslashit( $site->path );
+			$value        = str_replace( $subdirectory, '', $value );
+		}
 	}
 }


### PR DESCRIPTION
## Description

This fixes an issue with using wp-graphql in a WordPress multisite using subdirectories where the individual site subdirectory is included with the menu path.

## Testing

1. Create a local subdirectory multisite.
2. Add a second site in the network under `site-2`.
3. Install & network activate faustwp & wp-graphql.
4. Under site-2's headless settings, enter `http://localhost:3000` for the `frontend_uri`.
5. Run the following inside of site-2's GraphiQL.
    ```graphql
    query MyQuery {
      generalSettings {
        url
      }
      menuItems(where: {location: PRIMARY}) {
        nodes {
          label
          url
          path
        }
      }
      menus(where: {location: PRIMARY}) {
        nodes {
          menuItems {
            nodes {
              label
              url
              path
            }
          }
        }
      }
    }
    ```
6. `site-2` should no longer present within `url` or `path`. 

## Screenshots

**Before**
<img width="1385" alt="Screen Shot 2022-05-04 at 3 24 03 PM" src="https://user-images.githubusercontent.com/6676674/166811382-bdc52551-3d6e-463b-aa7f-58cc4a288bee.png">

**After**
<img width="1385" alt="Screen Shot 2022-05-04 at 3 23 49 PM" src="https://user-images.githubusercontent.com/6676674/166811406-e39af925-6619-4c6d-b7a9-9aca2509649f.png">
