### PR TITLE
Fix SonarQube scan on canary

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,5 +1,4 @@
 sonar.projectKey=faustjs
-sonar.newCode.referenceBranch=canary
 sonar.tests=./plugins/faustwp,./packages
 sonar.test.inclusions=**/tests/**/*,**/test/**/*
 sonar.exclusions=schema.generated.ts,**/tests/**/*,**/test/**/*


### PR DESCRIPTION
SonarQube scans run on PRs and also on merge to `canary`. The `sonar.newCode.referenceBranch` [setting causes the scan to fail](https://github.com/wpengine/faustjs/runs/6408851207?check_suite_focus=true) on merge to `canary`. This removes the scanner parameter so that the [default Project level settings](https://docs.sonarqube.org/latest/project-administration/new-code-period/) are used instead.