### PR TITLE
fix: loading full site editor when public route redirects enabled

### DIFF
--- a/.changeset/proud-coats-hang.md
+++ b/.changeset/proud-coats-hang.md
@@ -1,0 +1,5 @@
+---
+'faustwp': patch
+---
+
+Fixes a conflict between public route redirects and the full site editor

--- a/plugins/faustwp/includes/deny-public-access/callbacks.php
+++ b/plugins/faustwp/includes/deny-public-access/callbacks.php
@@ -23,7 +23,13 @@ add_action( 'template_redirect', __NAMESPACE__ . '\\deny_public_access', 99 );
  * @return void
  */
 function deny_public_access() {
-	if ( ! is_redirects_enabled() || is_customize_preview() ) {
+	if (
+		! is_redirects_enabled() ||
+		is_customize_preview() ||
+		doing_file_editor_save() ||
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		isset( $_GET['_wp-find-template'] ) // Allow loading full site editor.
+	) {
 		return;
 	}
 
@@ -37,11 +43,6 @@ function deny_public_access() {
 
 	// Get the request uri with query params.
 	$request_uri = home_url( add_query_arg( null, null ) );
-
-	// Allow saving from file editor.
-	if ( doing_file_editor_save() ) {
-		return;
-	}
 
 	$response_code = 302;
 	$redirect_url  = str_replace( trailingslashit( get_home_url() ), $frontend_uri, $request_uri );


### PR DESCRIPTION
## Description

<!--
Include a summary of the change and some contextual information.
-->

When loading the full site editor, it makes a request to the site's frontend to determine what template to load. The request fails when public route redirects are enabled and causes White Screen of Death. This PR allows that request to skip redirection which allows the site editor to load successfully.

## Testing

<!--
Describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Also list any relevant details for your test configuration such as how to test the changes locally or in staging.
-->

On WP 5.9.3:

1. Go to Settings -> Headless
2. Uncheck "Disable WordPress theme admin pages" and make sure "Enable public route redirects" is checked. Save.
3. Go to Appearance -> Editor (if you don't see Editor, go activate the TwentyTwentyTwo theme and try again)
4. See that the editor fails to load
5. Return to the dashboard
6. Checkout this PR
7. Go to Appearance -> Editor
8. See that the editor loads

