### PR TITLE
Bump WP tested up to 6.0

### DIFF
--- a/plugins/faustwp/readme.txt
+++ b/plugins/faustwp/readme.txt
@@ -2,7 +2,7 @@
 Contributors: antpb, apmatthe, blakewpe, chriswiegman, claygriffiths, jasonkonen, joefusco, markkelnar, mindctrl, modernnerd, rfmeier, wpengine
 Tags: faustjs, faust, headless, decoupled
 Requires at least: 5.7
-Tested up to: 5.9
+Tested up to: 6.0
 Stable tag: 0.7.8
 Requires PHP: 7.2
 License: GPLv2 or later


### PR DESCRIPTION
Integration and acceptance tests are all passing on 6.0-RC3 🟢 

Two issues found in manual testing: #874, #873 