### PR TITLE
Filter page_link in addition to post_link

### DIFF
--- a/.changeset/odd-buses-mate.md
+++ b/.changeset/odd-buses-mate.md
@@ -1,0 +1,5 @@
+---
+'faustwp': patch
+---
+
+Fix page preview links

--- a/plugins/faustwp/includes/replacement/callbacks.php
+++ b/plugins/faustwp/includes/replacement/callbacks.php
@@ -173,10 +173,10 @@ function post_preview_link( $link, $post ) {
 	return $link;
 }
 
-
 add_filter( 'post_link', __NAMESPACE__ . '\\post_link', 1000 );
+add_filter( 'page_link', __NAMESPACE__ . '\\post_link', 1000 );
 /**
- * Callback for WordPress 'post_link' filter.
+ * Callback for WordPress 'post_link' & 'page_link' filter.
  *
  * Swap post links in admin for headless front-end.
  *

--- a/plugins/faustwp/tests/integration/replacement/test-replacement-callbacks.php
+++ b/plugins/faustwp/tests/integration/replacement/test-replacement-callbacks.php
@@ -40,6 +40,10 @@ class ReplacementCallbacksTestCases extends \WP_UnitTestCase {
 		$this->assertSame( 1000, has_action( 'post_link', 'WPE\FaustWP\Replacement\post_link' ) );
 	}
 
+	public function test_page_link_filter() {
+		$this->assertSame( 1000, has_action( 'page_link', 'WPE\FaustWP\Replacement\post_link' ) );
+	}
+
 	public function test_term_link_filter() {
 		$this->assertSame( 1000, has_action( 'term_link', 'WPE\FaustWP\Replacement\term_link' ) );
 	}


### PR DESCRIPTION
## Description

When using Faust within a multisite setup with subdirectories, the preview links for pages still contain the subdirectory of the site. We will need to filter on [page_link](https://developer.wordpress.org/reference/hooks/page_link/) in addition to [post_link](https://developer.wordpress.org/reference/hooks/post_link/) within FaustWP.

