### PR TITLE
Filter GQL keys to exclude for domain replacement

### DIFF
--- a/plugins/faustwp/includes/replacement/graphql-callbacks.php
+++ b/plugins/faustwp/includes/replacement/graphql-callbacks.php
@@ -49,7 +49,7 @@ function url_replacement( $response ) {
  */
 function url_replace_recursive( &$data ) {
 	foreach ( $data as $key => &$value ) {
-		if ( 'generalSettings' === $key ) {
+		if ( in_array( $key, apply_filters( 'faustwp_domain_replacement_blacklist', array( 'generalSettings' ) ) ) ) {
 			continue;
 		}
 


### PR DESCRIPTION
## Description

Instead of hardcoding in `generalSettings` as the only excluded key for which we skip domain filtering, I applied filters instead to allow developers to extend this as needed.

## Testing

I implemented a filter to also not replace domains for admin menu bar items for a custom WPGQL field. It worked great.
