### PR TITLE
[MERL-315] - Code Coverage FaustWP

### DIFF
--- a/.github/workflows/e2e-test-plugin.yml
+++ b/.github/workflows/e2e-test-plugin.yml
@@ -20,6 +20,8 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: '7.4'
+          coverage: pcov
+          ini-values: pcov.directory=includes
       - name: Setup Frontend
         run: |
           NEXT_PUBLIC_WORDPRESS_URL=http://localhost:8080 FAUSTWP_SECRET_KEY=00000000-0000-4000-8000-000000000001 npm run dev:next:getting-started &

--- a/.github/workflows/test-plugin.yml
+++ b/.github/workflows/test-plugin.yml
@@ -13,10 +13,10 @@ jobs:
         run: sleep 15
       - name: Setup testing framework
         working-directory: ./plugins/faustwp
-        run: docker exec $(docker-compose ps -q wordpress) init-testing-environment.sh
+        run: docker exec -e COVERAGE=1 $(docker-compose ps -q wordpress) init-testing-environment.sh
       - name: Install and activate WP GraphQL
         working-directory: ./plugins/faustwp
         run: docker exec --workdir=/var/www/html/wp-content/plugins/faustwp $(docker-compose ps -q wordpress) wp plugin install wp-graphql --activate --allow-root
       - name: Run unit tests
         working-directory: ./plugins/faustwp
-        run: docker exec -w /var/www/html/wp-content/plugins/faustwp $(docker-compose ps -q wordpress) composer test
+        run: docker exec -e COVERAGE=1 -w /var/www/html/wp-content/plugins/faustwp $(docker-compose ps -q wordpress) composer test

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -68,10 +68,10 @@ To run WordPress unit tests, first create the Docker containers from the `plugin
 docker-compose up -d
 ```
 
-Once the containers are up, set up the test framework:
+Once the containers are up, set up the test framework. If you want to enable code coverage reporting, make sure you provide the `COVERAGE=1` environment variable as a parameter:
 
 ```
-docker-compose exec wordpress init-testing-environment.sh
+docker-compose exec -e COVERAGE=1 wordpress init-testing-environment.sh
 ```
 
 Install and activate WP GraphQL:

--- a/plugins/faustwp/.distignore
+++ b/plugins/faustwp/.distignore
@@ -19,3 +19,4 @@ phpunit.xml.dist
 vendor
 package.json
 .wordpress-org
+coverage

--- a/plugins/faustwp/.docker/Dockerfile
+++ b/plugins/faustwp/.docker/Dockerfile
@@ -23,7 +23,8 @@ RUN set -e \
 	-qq --no-install-recommends \
 	; sudo adduser www-data sudo \
 	; rm -rf /var/lib/apt/lists/* \
-	&& pecl install pcov
+	&& pecl install pcov \
+	&& docker-php-ext-enable pcov
 
 # Copy the script to create the testing environment
 COPY scripts/init-testing-environment.sh /usr/local/bin/

--- a/plugins/faustwp/.docker/Dockerfile
+++ b/plugins/faustwp/.docker/Dockerfile
@@ -5,24 +5,25 @@ RUN docker-php-ext-install pdo pdo_mysql
 
 # Install WP cli
 RUN curl -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar \
-    && chmod +x wp-cli.phar \
-    && mv wp-cli.phar /usr/local/bin/wp \
-    && wp --info
+	&& chmod +x wp-cli.phar \
+	&& mv wp-cli.phar /usr/local/bin/wp \
+	&& wp --info
 
 RUN set -e \
-    ; apt-get -qq update \
-    ; apt-get install \
-        default-mysql-client \
-        less \
-        openssh-server \
-        sudo \
-        subversion \
-        default-mysql-client \
-        telnet \
-        vim \
-        -qq --no-install-recommends \
-    ; sudo adduser www-data sudo \
-    ; rm -rf /var/lib/apt/lists/*
+	; apt-get -qq update \
+	; apt-get install \
+	default-mysql-client \
+	less \
+	openssh-server \
+	sudo \
+	subversion \
+	default-mysql-client \
+	telnet \
+	vim \
+	-qq --no-install-recommends \
+	; sudo adduser www-data sudo \
+	; rm -rf /var/lib/apt/lists/* \
+	&& pecl install pcov
 
 # Copy the script to create the testing environment
 COPY scripts/init-testing-environment.sh /usr/local/bin/

--- a/plugins/faustwp/.docker/scripts/init-testing-environment.sh
+++ b/plugins/faustwp/.docker/scripts/init-testing-environment.sh
@@ -1,12 +1,27 @@
 #!/bin/bash
 
+# Exits with a status of 0 (true) if provided version number is higher than proceeding numbers.
+version_gt() {
+    test "$(printf '%s\n' "$@" | sort -V | head -n 1)" != "$1";
+}
+
 cd /var/www/html/wp-content/plugins/$WP_PLUGIN_FOLDER
 
 # Setup WordPress test core files and database
-bash -c "./bin/install-wp-tests.sh $WP_TESTS_DB_NAME $WORDPRESS_DB_USER $WORDPRESS_DB_PASSWORD $WORDPRESS_DB_HOST latest" 
+bash -c "./bin/install-wp-tests.sh $WP_TESTS_DB_NAME $WORDPRESS_DB_USER $WORDPRESS_DB_PASSWORD $WORDPRESS_DB_HOST latest"
 
 # Install composer deps
 composer install
+
+# Install pcov/clobber if PHP7.1+
+if version_gt $PHP_VERSION 7.0 && [[ -n "$COVERAGE" ]]; then
+    echo "Using pcov/clobber for codecoverage"
+    docker-php-ext-enable pcov
+    echo "pcov.enabled=1" >> /usr/local/etc/php/conf.d/docker-php-ext-pcov.ini
+    echo "pcov.directory=/var/www/html/wp-content/plugins/$WP_PLUGIN_FOLDER" >> /usr/local/etc/php/conf.d/docker-php-ext-pcov.ini
+    COMPOSER_MEMORY_LIMIT=-1 composer require pcov/clobber --dev
+    vendor/bin/pcov clobber
+fi
 
 # Back to the root WP folder
 cd /var/www/html/

--- a/plugins/faustwp/.docker/scripts/init-testing-environment.sh
+++ b/plugins/faustwp/.docker/scripts/init-testing-environment.sh
@@ -16,10 +16,8 @@ composer install
 # Install pcov/clobber if PHP7.1+
 if version_gt $PHP_VERSION 7.0 && [[ "$COVERAGE" == '1' ]]; then
     echo "Using pcov/clobber for codecoverage"
-    docker-php-ext-enable pcov
     echo "pcov.enabled=1" >> /usr/local/etc/php/conf.d/docker-php-ext-pcov.ini
     echo "pcov.directory=/var/www/html/wp-content/plugins/$WP_PLUGIN_FOLDER" >> /usr/local/etc/php/conf.d/docker-php-ext-pcov.ini
-    COMPOSER_MEMORY_LIMIT=-1 composer require pcov/clobber --dev
     vendor/bin/pcov clobber
 fi
 

--- a/plugins/faustwp/.docker/scripts/init-testing-environment.sh
+++ b/plugins/faustwp/.docker/scripts/init-testing-environment.sh
@@ -14,7 +14,7 @@ bash -c "./bin/install-wp-tests.sh $WP_TESTS_DB_NAME $WORDPRESS_DB_USER $WORDPRE
 composer install
 
 # Install pcov/clobber if PHP7.1+
-if version_gt $PHP_VERSION 7.0 && [[ -n "$COVERAGE" ]]; then
+if version_gt $PHP_VERSION 7.0 && [[ "$COVERAGE" == '1' ]]; then
     echo "Using pcov/clobber for codecoverage"
     docker-php-ext-enable pcov
     echo "pcov.enabled=1" >> /usr/local/etc/php/conf.d/docker-php-ext-pcov.ini

--- a/plugins/faustwp/.gitignore
+++ b/plugins/faustwp/.gitignore
@@ -4,3 +4,4 @@ Thumbs.db
 
 .env.testing
 !.env.testing.example
+/coverage/

--- a/plugins/faustwp/.zipignore
+++ b/plugins/faustwp/.zipignore
@@ -27,4 +27,5 @@ deploy.sh
 *docker*
 *docker-compose.yml*
 *codeception.dist.yml*
+*coverage*
 .zipignore

--- a/plugins/faustwp/composer.json
+++ b/plugins/faustwp/composer.json
@@ -14,6 +14,7 @@
     "codeception/util-universalframework": "^1.0",
     "dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
     "lucatume/wp-browser": "3.0.11",
+    "pcov/clobber": "^2.0",
     "php-parallel-lint/php-parallel-lint": "^1.2",
     "phpcompatibility/phpcompatibility-wp": "^2.1",
     "phpunit/phpunit": "~7",

--- a/plugins/faustwp/composer.lock
+++ b/plugins/faustwp/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7db073d69c98ae712ace3cc64bb59965",
+    "content-hash": "662897c019eb774fd06156435de5adfc",
     "packages": [],
     "packages-dev": [
         {
@@ -2048,6 +2048,96 @@
                 }
             ],
             "time": "2021-11-01T21:22:20+00:00"
+        },
+        {
+            "name": "nikic/php-parser",
+            "version": "v4.13.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nikic/PHP-Parser.git",
+                "reference": "210577fe3cf7badcc5814d99455df46564f3c077"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/210577fe3cf7badcc5814d99455df46564f3c077",
+                "reference": "210577fe3cf7badcc5814d99455df46564f3c077",
+                "shasum": ""
+            },
+            "require": {
+                "ext-tokenizer": "*",
+                "php": ">=7.0"
+            },
+            "require-dev": {
+                "ircmaxell/php-yacc": "^0.0.7",
+                "phpunit/phpunit": "^6.5 || ^7.0 || ^8.0 || ^9.0"
+            },
+            "bin": [
+                "bin/php-parse"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.9-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PhpParser\\": "lib/PhpParser"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Nikita Popov"
+                }
+            ],
+            "description": "A PHP parser written in PHP",
+            "keywords": [
+                "parser",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/nikic/PHP-Parser/issues",
+                "source": "https://github.com/nikic/PHP-Parser/tree/v4.13.2"
+            },
+            "time": "2021-11-30T19:35:32+00:00"
+        },
+        {
+            "name": "pcov/clobber",
+            "version": "v2.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/krakjoe/pcov-clobber.git",
+                "reference": "4c30759e912e6e5d5bf833fb3d77b5bd51709f05"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/krakjoe/pcov-clobber/zipball/4c30759e912e6e5d5bf833fb3d77b5bd51709f05",
+                "reference": "4c30759e912e6e5d5bf833fb3d77b5bd51709f05",
+                "shasum": ""
+            },
+            "require": {
+                "ext-pcov": "^1.0",
+                "nikic/php-parser": "^4.2"
+            },
+            "bin": [
+                "bin/pcov"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "pcov\\Clobber\\": "src/pcov/clobber"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "support": {
+                "issues": "https://github.com/krakjoe/pcov-clobber/issues",
+                "source": "https://github.com/krakjoe/pcov-clobber/tree/v2.0.3"
+            },
+            "time": "2019-10-29T05:03:37+00:00"
         },
         {
             "name": "phar-io/manifest",

--- a/plugins/faustwp/docker-compose.yml
+++ b/plugins/faustwp/docker-compose.yml
@@ -16,6 +16,7 @@ services:
       WORDPRESS_DB_PASSWORD: wordpress
       WP_TESTS_DB_NAME: wordpress_unit_test
       WP_PLUGIN_FOLDER: faustwp
+      COVERAGE: ${COVERAGE:-}
     volumes:
       - wordpress:/var/www/html
       - ./:/var/www/html/wp-content/plugins/faustwp

--- a/plugins/faustwp/phpunit-multisite.xml.dist
+++ b/plugins/faustwp/phpunit-multisite.xml.dist
@@ -15,4 +15,12 @@
 			<directory prefix="test-" suffix=".php">./tests/integration/</directory>
 		</testsuite>
 	</testsuites>
+	<filter>
+        <whitelist processUncoveredFilesFromWhitelist="true">
+            <directory suffix=".php">./includes</directory>
+        </whitelist>
+    </filter>
+	<logging>
+		<log type="coverage-clover" target="coverage/clover.xml"/>
+	</logging>
 </phpunit>

--- a/plugins/faustwp/phpunit.xml.dist
+++ b/plugins/faustwp/phpunit.xml.dist
@@ -12,4 +12,12 @@
 			<directory prefix="test-" suffix=".php">./tests/integration/</directory>
 		</testsuite>
 	</testsuites>
+	<filter>
+        <whitelist processUncoveredFilesFromWhitelist="true">
+            <directory suffix=".php">./includes</directory>
+        </whitelist>
+    </filter>
+	<logging>
+		<log type="coverage-clover" target="coverage/clover.xml"/>
+	</logging>
 </phpunit>


### PR DESCRIPTION
## Description

This PR adds a flag when running the `init-testing-environment.sh` to enable coverage reporting via PCOV. It also updates the `DEVELOPMENT.md` guide to describe the way for this to happen. Once enabled the report is stored within the docker container folder `/var/www/html/wp-content/plugins/faustwp/coverage`.

**Note**: Currently the coverage report is saved locally and  is not send to a CodeClimate.

## Related Issue(s):
MERL-315

## Testing

<!--
Describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Also list any relevant details for your test configuration such as how to test the changes locally or in staging.
-->

1. Follow the instructions for setting up the environment for running the WP Unit tests.

Once the containers are up, set up the test framework. If you want to enable code coverage reporting, make sure you provide the `COVERAGE=1` environment variable as a parameter:

```
docker-compose exec -e COVERAGE=1 wordpress init-testing-environment.sh
``` 

Then run the tests as usual:

```
docker-compose exec -w /var/www/html/wp-content/plugins/faustwp wordpress composer test

```

## Screenshots

<!--
If this is a visual change include relevant screenshots about the behavior of the application before and after this change.
-->

<img width="1282" alt="Screenshot 2022-05-30 at 15 38 01" src="https://user-images.githubusercontent.com/328805/171014634-f3836dfd-c050-4cc5-912e-7d7e3b60c0a3.png">


## Documentation Changes

<!--
List corresponding changes to the documentation.
-->

## Dependant PRs

<!--
List any dependent PR's that are awaiting review. Use the following syntax:

- #1234
-->
