### PR TITLE
fix: handling generate endpoint

### DIFF
--- a/plugins/faustwp/includes/auth/callbacks.php
+++ b/plugins/faustwp/includes/auth/callbacks.php
@@ -22,7 +22,9 @@ add_action( 'parse_request', __NAMESPACE__ . '\\handle_generate_endpoint' );
  * @return void
  */
 function handle_generate_endpoint() {
-	if ( ! preg_match( '/^\/generate/', $_SERVER['REQUEST_URI'] ) ) { // phpcs:ignore WordPress.Security
+	$search_pattern = ':^' . site_url('/generate', 'relative') . ':';
+
+	if ( ! preg_match( $search_pattern, $_SERVER['REQUEST_URI'] ) ) { // phpcs:ignore WordPress.Security
 		return;
 	}
 

--- a/plugins/faustwp/includes/auth/callbacks.php
+++ b/plugins/faustwp/includes/auth/callbacks.php
@@ -22,7 +22,7 @@ add_action( 'parse_request', __NAMESPACE__ . '\\handle_generate_endpoint' );
  * @return void
  */
 function handle_generate_endpoint() {
-	$search_pattern = ':^' . site_url('/generate', 'relative') . ':';
+	$search_pattern = ':^' . site_url( '/generate', 'relative' ) . ':';
 
 	if ( ! preg_match( $search_pattern, $_SERVER['REQUEST_URI'] ) ) { // phpcs:ignore WordPress.Security
 		return;


### PR DESCRIPTION
## Description

The hardcoded search pattern does not work if WP is installed in a sub-directory

## Related Issue(s):

#850

## Change/Solution

Use `site_url` with a relative scheme to prepend the install path
