### PR TITLE
Add private flag so faustnx packages are not published

### DIFF
--- a/examples/next/faust-nx/package.json
+++ b/examples/next/faust-nx/package.json
@@ -1,5 +1,6 @@
 {
   "name": "faust-nx-getting-started",
+  "private": true,
   "version": "0.1.0",
   "scripts": {
     "dev": "next dev",

--- a/packages/faust-nx/package.json
+++ b/packages/faust-nx/package.json
@@ -1,6 +1,7 @@
 {
   "name": "faust-nx",
   "version": "0.0.1",
+  "private": true,
   "description": "Experimental next version of Faust.js",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Description

Add the `private` property to respective `package.json` files so FaustNX packages are not published.