### PR TITLE
Add support for iOS 12 & 13

### DIFF
--- a/.changeset/sixty-fans-cough.md
+++ b/.changeset/sixty-fans-cough.md
@@ -1,0 +1,7 @@
+---
+'@faustjs/core': patch
+'@faustjs/next': patch
+'@faustjs/react': patch
+---
+
+Added support for older versions of iOS

--- a/packages/core/tsconfig-cjs.json
+++ b/packages/core/tsconfig-cjs.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "module": "commonjs",
     "outDir": "dist/cjs",
-    "target": "es2019",
+    "target": "es2017",
     "rootDir": "src"
   }
 }

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "module": "esnext",
     "outDir": "dist/mjs",
-    "target": "esnext",
+    "target": "es2017",
     "rootDir": "src"
   },
   "exclude": ["node_modules", "dist"],

--- a/packages/next/tsconfig-cjs.json
+++ b/packages/next/tsconfig-cjs.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "module": "commonjs",
     "outDir": "dist/cjs",
-    "target": "es2019",
+    "target": "es2017",
     "rootDir": "src"
   }
 }

--- a/packages/next/tsconfig.json
+++ b/packages/next/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "module": "esnext",
     "outDir": "dist/mjs",
-    "target": "esnext",
+    "target": "es2017",
     "rootDir": "src",
     "jsx": "react"
   },

--- a/packages/react/tsconfig-cjs.json
+++ b/packages/react/tsconfig-cjs.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "module": "commonjs",
     "outDir": "dist/cjs",
-    "target": "es2019",
+    "target": "es2017",
     "rootDir": "src"
   }
 }

--- a/packages/react/tsconfig.json
+++ b/packages/react/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "module": "esnext",
     "outDir": "dist/mjs",
-    "target": "esnext",
+    "target": "es2017",
     "rootDir": "src",
     "jsx": "react"
   },


### PR DESCRIPTION
## Description

This change adds support for iOS 12 & 13 and fixes https://github.com/wpengine/faustjs/issues/903 by lowering the [target value](https://www.typescriptlang.org/tsconfig#target) in each package's TSConfig.

>The special ESNext value refers to the highest version your version of TypeScript supports. This setting should be used with caution, since it doesn’t mean the same thing between different TypeScript versions and can make upgrades less predictable.

## Testing

In order to test this on macOS, XCode should be installed with iOS 13.0 downloaded for the simulator. This likely will need to be downloaded which could take some time. https://developer.apple.com/forums/thread/110911

## Screenshots
**Before**
<img width="1735" alt="Screen Shot 2022-06-29 at 10 27 22 AM" src="https://user-images.githubusercontent.com/6676674/176461664-92917ded-b5eb-4f1a-bb9f-b687eab96745.png">

**After**
<img width="1433" alt="Screen Shot 2022-06-29 at 10 22 02 AM" src="https://user-images.githubusercontent.com/6676674/176460920-c18a6d7d-8b4f-49fe-be1d-961b6b71ea2a.png">
