### PR TITLE
Clean up WP.org zip

### DIFF
--- a/.changeset/long-suits-film.md
+++ b/.changeset/long-suits-film.md
@@ -1,0 +1,5 @@
+---
+'faustwp': patch
+---
+
+Remove unnecessary config from wordpress.org zip.

--- a/plugins/faustwp/.distignore
+++ b/plugins/faustwp/.distignore
@@ -16,6 +16,7 @@ composer.json
 composer.lock
 docker-compose.yml
 phpunit.xml.dist
+phpunit-multisite.xml.dist
 vendor
 package.json
 .wordpress-org


### PR DESCRIPTION
## Description

This change excludes `phpunit-multisite.xml.dist` from the zip for WordPress.org. 

## Related Issue(s):

## Testing

## Screenshots

## Documentation Changes

## Dependant PRs
