### PR TITLE
FaustNX CLI POC

### DIFF
--- a/examples/next/faust-nx/package.json
+++ b/examples/next/faust-nx/package.json
@@ -3,15 +3,16 @@
   "private": true,
   "version": "0.1.0",
   "scripts": {
-    "dev": "next dev",
-    "build": "next build",
-    "start": "next start"
+    "dev": "faustnx dev",
+    "build": "faustnx build",
+    "start": "faustnx start"
   },
   "dependencies": {
     "next": "^12.1.6",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "@apollo/client": "^3.6.6",
-    "faust-nx": "file:../../../packages/faust-nx/dist/index.js"
+    "faust-nx": "file:../../../packages/faust-nx/dist/index.js",
+    "faust-nx-cli": "file:../../../packages/faust-nx-cli/dist/index.js"
   }
 }

--- a/internal/website/blog/2022-07-06-the-future-of-faust.md
+++ b/internal/website/blog/2022-07-06-the-future-of-faust.md
@@ -1,0 +1,38 @@
+---
+title: The Future of Faust.js
+description: An update on Faust.js, where it is and where it is going
+slug: the-future-of-faust
+hide_table_of_contents: true
+---
+
+We launched this blog 7 months ago with a goal of keeping you informed of what is going on in the development of Faust.js as well as to help you get started using the framework in your own projects. To date, we simply have not prioritized keeping up here on the blog and it is time for that to change.
+
+<!--truncate-->
+
+Today we want to talk about where Faust.js is and where we're working on taking it in the future. It will be the first of many regular posts designed to tell the story of Faust.js and how it affects developers of all backgrounds.
+
+## Where Faust.js is Today
+
+First and foremost, the development of Faust.js is alive and well. When the last post was written in December we were a rather unorthodox team of two engineers working on understanding what Faust.js should be.
+
+Today the Faust.js team, known internally as Team Merlin, is made of of five engineers and an engineering manager and [we're still looking for one more staff/lead engineer to join our team](https://wpengine.wd1.myworkdayjobs.com/en-US/WP_Engine/job/Software-Engineer-IV--ATLAS---Themes-_JR100226).
+
+While we've expanded, we've moved much of our development process out of GitHub projects and into company tools that allow us to be more in tune with the needs of the organization and [Atlas](https://wpengine.com/atlas/) as well as allows us to more easily communicate the story of Faust.js to stakeholders throughout the company.
+
+Today we're revisiting this blog primarily as a way to update you on what we're doing now that we're currently not working in public. From this point forward we'll be updating the blog at least once every two weeks with the current accomplishments and next steps on our journey to ensure Faust.js is the leading framework for folks looking to develop headless sites with WordPress.
+
+## Where Faust.js is Going
+
+As [WP Engine](https://wpengine.com) has made a significant investment in the future of Faust.js by increasing the team working on it, it's time to talk to where we're currently spending our time.
+
+When Faust.js was first conceived a decision was made to go with [GQty](https://gqty.dev) as our data library as we thought it would be the simplest way for users to pull data from WordPress using [WPGraphQL](https://www.wpgraphql.com). While we largely were able to prove it was indeed simple, that simplicity came with complications. GQty proved a difficult choice for users to scale with as it over-abstracted enough of the data layer that modifying how a user was getting data from WordPress quickly became a difficult process.
+
+Today we're working on removing the limits imposed by choosing GQty by replacing it with the popular [Apollo library](https://www.apollographql.com). This will allow users to get what they need from WordPress in whatever way they need it. Users won't be constrained on the queries they run and will be able to more easily modify a default query to fit any use case imaginable. You can expect to see our work on this feature available in the 3rd quarter of 2022.
+
+As part of replacing GQty with Apollo, another shift in Faust.js since our last writing is that we've realized our target audience is not so much JavaScript developers forced to use WordPress but is, in fact, WordPress developers pivoting to headless sites. While the difference might sound trivial, the shift comes with a change of expectations that lead to numerous features in development. For instance, in the 3rd quarter of 2022 we also hope to release a template hierarchy feature that utilizes WordPress' core routing system, popularly known as [permalinks](https://wordpress.org/support/article/using-permalinks/), to power a developer experience that better utilizes the existing development skills of WordPress developers and agencies.
+
+While our audience might not be what we originally thought it was, that isn't to say we're not working on cutting edge features for JavaScript developers as well. From the ability to share components between your front end and WordPress' Block Editor to authentication and even advanced ways to handle use cases such as A/B testing and more there is a lot planned in our backlog and we can't wait to start rolling it out to you over the coming months.
+
+## Check Back Often For Updates From Our Latest Sprint
+
+Faust.js has a bright future and we look forward to sharing it with you. Check back here roughly every two weeks for news on where we're at and what we're working on and, as always, you can ask the team questions in our [GitHub issues](https://github.com/wpengine/faustjs) or on [our Discord server](https://developers.wpengine.com). We're looking forward to powering your project.

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
           "examples/next/getting-started",
           "plugins/faustwp",
           "packages/faust-nx",
+          "packages/faust-nx-cli",
           "examples/next/faust-nx"
         ]
       }
@@ -31,6 +32,7 @@
       "dependencies": {
         "@apollo/client": "^3.6.6",
         "faust-nx": "file:../../../packages/faust-nx/dist/index.js",
+        "faust-nx-cli": "file:../../../packages/faust-nx-cli/dist/index.js",
         "next": "^12.1.6",
         "react": "^17.0.2",
         "react-dom": "^17.0.2"
@@ -38,6 +40,10 @@
     },
     "examples/next/faust-nx/node_modules/faust-nx": {
       "resolved": "packages/faust-nx/dist/index.js",
+      "link": true
+    },
+    "examples/next/faust-nx/node_modules/faust-nx-cli": {
+      "resolved": "packages/faust-nx-cli/dist/index.js",
       "link": true
     },
     "examples/next/getting-started": {
@@ -1033,6 +1039,14 @@
         "fs-extra": "^7.0.1",
         "human-id": "^1.0.2",
         "prettier": "^1.19.1"
+      }
+    },
+    "node_modules/@colors/colors": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
+      "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
+      "engines": {
+        "node": ">=0.1.90"
       }
     },
     "node_modules/@eslint/eslintrc": {
@@ -2428,6 +2442,12 @@
       "integrity": "sha512-20R/mDpKSPWdJs5TOpz3e7zqbeCNuMCPhV7Yndk9KU2Rbij2r5W4RzwDPkzC+2lzUqXYu9rFzTktCBnDjHuNQg==",
       "dev": true
     },
+    "node_modules/@types/configstore": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@types/configstore/-/configstore-6.0.0.tgz",
+      "integrity": "sha512-GUvNiia85zTDDIx0iPrtF3pI8dwrQkfuokEqxqPDE55qxH0U5SZz4awVZjiJLWN2ZZRkXCUqgsMUbygXY+kytA==",
+      "dev": true
+    },
     "node_modules/@types/cookie": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.4.1.tgz",
@@ -2585,6 +2605,16 @@
       "integrity": "sha512-XFjFHmaLVifrAKaZ+EKghFHtHSUonyw8P2Qmy2/+osBnrKbH9UYtlK10zg8/kCt47MFilll/DEDKy3DHfJ0URw==",
       "dev": true
     },
+    "node_modules/@types/prompt": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@types/prompt/-/prompt-1.1.2.tgz",
+      "integrity": "sha512-Zc9YzOvjAWxxGY7qo0Q6yINMVVspAa4p68UCzucWMU+GaPujpjwbOwzI38s7Jq01k0GztzLxXlRiFcZf/aeIWA==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*",
+        "@types/revalidator": "*"
+      }
+    },
     "node_modules/@types/prop-types": {
       "version": "15.7.5",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz",
@@ -2620,6 +2650,12 @@
         "@types/react": "*"
       }
     },
+    "node_modules/@types/revalidator": {
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/@types/revalidator/-/revalidator-0.3.8.tgz",
+      "integrity": "sha512-q6KSi3PklLGQ0CesZ/XuLwly4DXXlnJuucYOG9lrBqrP8rKiuPZThav2h2+pFjaheNpnT0qKK3i304QWIePeJw==",
+      "dev": true
+    },
     "node_modules/@types/scheduler": {
       "version": "0.16.2",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
@@ -2646,6 +2682,12 @@
       "dependencies": {
         "@types/jest": "*"
       }
+    },
+    "node_modules/@types/uuid": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
+      "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==",
+      "dev": true
     },
     "node_modules/@types/webpack-env": {
       "version": "1.16.4",
@@ -3423,6 +3465,11 @@
       "integrity": "sha512-eBvWn1lvIApYMhzQMsu9ciLfkBY499mFZlNqG+/9WR7PVlroQw0vG30cOQQbaKz3sCEc44TAOu2ykzqXSNnwag==",
       "dev": true
     },
+    "node_modules/async": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.3.tgz",
+      "integrity": "sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g=="
+    },
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -4022,6 +4069,14 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
+    "node_modules/colors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+      "integrity": "sha512-pFGrxThWcWQ2MsAz6RtgeWe4NK2kUE1WfsrvvlctdII745EW9I0yflqhe7++M5LEc7bV2c/9/5zc8sFcpL0Drw==",
+      "engines": {
+        "node": ">=0.1.90"
+      }
+    },
     "node_modules/combined-stream": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -4054,6 +4109,24 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
+    },
+    "node_modules/configstore": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/configstore/-/configstore-6.0.0.tgz",
+      "integrity": "sha512-cD31W1v3GqUlQvbBCGcXmd2Nj9SvLDOP1oQ0YFuLETufzSPaKp11rYBsSOm7rCsW3OnIRAFM3OxRhceaXNYHkA==",
+      "dependencies": {
+        "dot-prop": "^6.0.1",
+        "graceful-fs": "^4.2.6",
+        "unique-string": "^3.0.0",
+        "write-file-atomic": "^3.0.3",
+        "xdg-basedir": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/yeoman/configstore?sponsor=1"
+      }
     },
     "node_modules/confusing-browser-globals": {
       "version": "1.0.11",
@@ -4119,6 +4192,31 @@
         "lru-cache": "^4.0.1",
         "shebang-command": "^1.2.0",
         "which": "^1.2.9"
+      }
+    },
+    "node_modules/crypto-random-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-4.0.0.tgz",
+      "integrity": "sha512-x8dy3RnvYdlUcPOjkEHqozhiwzKNSq7GcPuXFbnyMOCHxX8V3OgIg/pYuabl2sbUPfIJaeAQB7PMOK8DFIdoRA==",
+      "dependencies": {
+        "type-fest": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/crypto-random-string/node_modules/type-fest": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
+      "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/css": {
@@ -4200,6 +4298,14 @@
       "resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-5.6.5.tgz",
       "integrity": "sha512-PjiQ659aQ+fUTQqSrd1XEDnOr52jh30RBurfzkscaE2tPaFsDH5wOAHJiw8XAHphRknCwMUE9KRayc4K/NbO8A==",
       "dev": true
+    },
+    "node_modules/cycle": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz",
+      "integrity": "sha512-TVF6svNzeQCOpjCqsy0/CSy8VgObG3wXusJ73xW2GbG5rGx7lC8zxDSURicsXI2UsGdi2L0QNRCi745/wUDvsA==",
+      "engines": {
+        "node": ">=0.4.0"
+      }
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
@@ -4542,6 +4648,20 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dot-prop": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-6.0.1.tgz",
+      "integrity": "sha512-tE7ztYzXHIeyvc7N+hR3oi7FIbf/NIjVP9hmAt3yMXzrQ072/fpjGLx2GxNxGxUl5V73MEqYzioOMoVhGMJ5cA==",
+      "dependencies": {
+        "is-obj": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/electron-to-chromium": {
@@ -5625,6 +5745,14 @@
         "node": ">=4"
       }
     },
+    "node_modules/eyes": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
+      "integrity": "sha512-GipyPsXO1anza0AOZdy69Im7hGFCNB7Y/NGjDlZGJ3GJJLtwNSb2vrzYrTYJRrRloVx7pl+bhUaTB8yiccPvFQ==",
+      "engines": {
+        "node": "> 0.1.90"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -5691,6 +5819,10 @@
     },
     "node_modules/faust-nx": {
       "resolved": "packages/faust-nx",
+      "link": true
+    },
+    "node_modules/faust-nx-cli": {
+      "resolved": "packages/faust-nx-cli",
       "link": true
     },
     "node_modules/faust-nx-getting-started": {
@@ -6137,8 +6269,7 @@
     "node_modules/graceful-fs": {
       "version": "4.2.10",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
-      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
-      "dev": true
+      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="
     },
     "node_modules/grapheme-splitter": {
       "version": "1.0.4",
@@ -6423,7 +6554,6 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
-      "dev": true,
       "engines": {
         "node": ">=0.8.19"
       }
@@ -6627,6 +6757,14 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-obj": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
+      "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-path-cwd": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-2.2.0.tgz",
@@ -6766,8 +6904,7 @@
     "node_modules/is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
-      "dev": true
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
     },
     "node_modules/is-weakref": {
       "version": "1.0.2",
@@ -6809,6 +6946,11 @@
         "node-fetch": "^2.6.1",
         "whatwg-fetch": "^3.4.1"
       }
+    },
+    "node_modules/isstream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g=="
     },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.0",
@@ -9206,6 +9348,11 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
     },
+    "node_modules/mute-stream": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
+      "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA=="
+    },
     "node_modules/nanoid": {
       "version": "3.3.4",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
@@ -10002,6 +10149,21 @@
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
     },
+    "node_modules/prompt": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/prompt/-/prompt-1.3.0.tgz",
+      "integrity": "sha512-ZkaRWtaLBZl7KKAKndKYUL8WqNT+cQHKRZnT4RYYms48jQkFw3rrBL+/N5K/KtdEveHkxs982MX2BkDKub2ZMg==",
+      "dependencies": {
+        "@colors/colors": "1.5.0",
+        "async": "3.2.3",
+        "read": "1.0.x",
+        "revalidator": "0.1.x",
+        "winston": "2.x"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
     "node_modules/prompts": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
@@ -10184,6 +10346,17 @@
       "integrity": "sha512-yFNHrlVEReVYKsLI5lF05tZoHveA5pGzjFbFJY/3pOqqjGOmMmqx83N4hIjN2n6E1AOa+eQEUxs3CgRnPmT0RQ==",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/read": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
+      "integrity": "sha512-rSOKNYUmaxy0om1BNjMN4ezNT6VKK+2xF4GBhc81mkH7L60i6dp8qPYrkndNLT3QPphoII3maL9PVC9XmhHwVQ==",
+      "dependencies": {
+        "mute-stream": "~0.0.4"
+      },
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/read-pkg": {
@@ -10383,6 +10556,14 @@
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/revalidator": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/revalidator/-/revalidator-0.1.8.tgz",
+      "integrity": "sha512-xcBILK2pA9oh4SiinPEZfhP8HfrB/ha+a2fTMyl7Om2WjlDVrOQy99N2MXXlUHqGJz4qEu2duXxHJjDWuK/0xg==",
+      "engines": {
+        "node": ">= 0.4.0"
       }
     },
     "node_modules/rimraf": {
@@ -10758,6 +10939,14 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
+    },
+    "node_modules/stack-trace": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+      "integrity": "sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg==",
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/stack-utils": {
       "version": "2.0.5",
@@ -11668,7 +11857,6 @@
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
       "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
-      "dev": true,
       "dependencies": {
         "is-typedarray": "^1.0.0"
       }
@@ -11710,6 +11898,20 @@
         "node": ">=12.18"
       }
     },
+    "node_modules/unique-string": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-3.0.0.tgz",
+      "integrity": "sha512-VGXBUVwxKMBUznyffQweQABPRRW1vHZAbadFZud4pLFAqRGvv/96vafgjWFqzourzr8YonlQiPgH0YCJfawoGQ==",
+      "dependencies": {
+        "crypto-random-string": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/universalify": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
@@ -11732,6 +11934,14 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+    },
+    "node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
     },
     "node_modules/v8-compile-cache": {
       "version": "2.3.0",
@@ -11984,6 +12194,22 @@
         "string-width": "^1.0.2 || 2 || 3 || 4"
       }
     },
+    "node_modules/winston": {
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-2.4.6.tgz",
+      "integrity": "sha512-J5Zu4p0tojLde8mIOyDSsmLmcP8I3Z6wtwpTDHx1+hGcdhxcJaAmG4CFtagkb+NiN1M9Ek4b42pzMWqfc9jm8w==",
+      "dependencies": {
+        "async": "^3.2.3",
+        "colors": "1.0.x",
+        "cycle": "1.0.x",
+        "eyes": "0.1.x",
+        "isstream": "0.1.x",
+        "stack-trace": "0.0.x"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
     "node_modules/word-wrap": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
@@ -12049,7 +12275,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
       "integrity": "sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==",
-      "dev": true,
       "dependencies": {
         "imurmurhash": "^0.1.4",
         "is-typedarray": "^1.0.0",
@@ -12076,6 +12301,17 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/xdg-basedir": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-5.1.0.tgz",
+      "integrity": "sha512-GCPAHLvrIH13+c0SuacwvRYj2SxJXQ4kaVTT5xgL3kPrz56XxkF21IGhjSE1+W0aw7gpBWRGXLCPnPby6lSpmQ==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/xml-name-validator": {
@@ -12239,12 +12475,14 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
+        "configstore": "^6.0.0",
         "deepmerge": "^4.2.2",
         "graphql": "^16.5.0",
         "lodash": "^4.17.21"
       },
       "devDependencies": {
         "@apollo/client": "^3.6.6",
+        "@types/configstore": "^6.0.0",
         "next": "^12.1.6",
         "react": "^17.0.2",
         "react-dom": "^17.0.2"
@@ -12256,6 +12494,24 @@
         "react-dom": ">=17.0.2"
       }
     },
+    "packages/faust-nx-cli": {
+      "version": "0.0.1",
+      "license": "MIT",
+      "dependencies": {
+        "configstore": "^6.0.0",
+        "prompt": "1.3.0",
+        "uuid": "8.3.2"
+      },
+      "bin": {
+        "faustnx": "dist/index.js"
+      },
+      "devDependencies": {
+        "@types/configstore": "^6.0.0",
+        "@types/prompt": "1.1.2",
+        "@types/uuid": "8.3.4"
+      }
+    },
+    "packages/faust-nx-cli/dist/index.js": {},
     "packages/faust-nx/dist/index.js": {},
     "packages/next": {
       "name": "@faustjs/next",
@@ -13077,6 +13333,11 @@
         "human-id": "^1.0.2",
         "prettier": "^1.19.1"
       }
+    },
+    "@colors/colors": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
+      "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ=="
     },
     "@eslint/eslintrc": {
       "version": "1.2.3",
@@ -14238,6 +14499,12 @@
       "integrity": "sha512-20R/mDpKSPWdJs5TOpz3e7zqbeCNuMCPhV7Yndk9KU2Rbij2r5W4RzwDPkzC+2lzUqXYu9rFzTktCBnDjHuNQg==",
       "dev": true
     },
+    "@types/configstore": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@types/configstore/-/configstore-6.0.0.tgz",
+      "integrity": "sha512-GUvNiia85zTDDIx0iPrtF3pI8dwrQkfuokEqxqPDE55qxH0U5SZz4awVZjiJLWN2ZZRkXCUqgsMUbygXY+kytA==",
+      "dev": true
+    },
     "@types/cookie": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.4.1.tgz",
@@ -14395,6 +14662,16 @@
       "integrity": "sha512-XFjFHmaLVifrAKaZ+EKghFHtHSUonyw8P2Qmy2/+osBnrKbH9UYtlK10zg8/kCt47MFilll/DEDKy3DHfJ0URw==",
       "dev": true
     },
+    "@types/prompt": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@types/prompt/-/prompt-1.1.2.tgz",
+      "integrity": "sha512-Zc9YzOvjAWxxGY7qo0Q6yINMVVspAa4p68UCzucWMU+GaPujpjwbOwzI38s7Jq01k0GztzLxXlRiFcZf/aeIWA==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "@types/revalidator": "*"
+      }
+    },
     "@types/prop-types": {
       "version": "15.7.5",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz",
@@ -14430,6 +14707,12 @@
         "@types/react": "*"
       }
     },
+    "@types/revalidator": {
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/@types/revalidator/-/revalidator-0.3.8.tgz",
+      "integrity": "sha512-q6KSi3PklLGQ0CesZ/XuLwly4DXXlnJuucYOG9lrBqrP8rKiuPZThav2h2+pFjaheNpnT0qKK3i304QWIePeJw==",
+      "dev": true
+    },
     "@types/scheduler": {
       "version": "0.16.2",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
@@ -14456,6 +14739,12 @@
       "requires": {
         "@types/jest": "*"
       }
+    },
+    "@types/uuid": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
+      "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==",
+      "dev": true
     },
     "@types/webpack-env": {
       "version": "1.16.4",
@@ -15049,6 +15338,11 @@
       "integrity": "sha512-eBvWn1lvIApYMhzQMsu9ciLfkBY499mFZlNqG+/9WR7PVlroQw0vG30cOQQbaKz3sCEc44TAOu2ykzqXSNnwag==",
       "dev": true
     },
+    "async": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.3.tgz",
+      "integrity": "sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g=="
+    },
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -15491,6 +15785,11 @@
         "simple-swizzle": "^0.2.2"
       }
     },
+    "colors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+      "integrity": "sha512-pFGrxThWcWQ2MsAz6RtgeWe4NK2kUE1WfsrvvlctdII745EW9I0yflqhe7++M5LEc7bV2c/9/5zc8sFcpL0Drw=="
+    },
     "combined-stream": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -15517,6 +15816,18 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
+    },
+    "configstore": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/configstore/-/configstore-6.0.0.tgz",
+      "integrity": "sha512-cD31W1v3GqUlQvbBCGcXmd2Nj9SvLDOP1oQ0YFuLETufzSPaKp11rYBsSOm7rCsW3OnIRAFM3OxRhceaXNYHkA==",
+      "requires": {
+        "dot-prop": "^6.0.1",
+        "graceful-fs": "^4.2.6",
+        "unique-string": "^3.0.0",
+        "write-file-atomic": "^3.0.3",
+        "xdg-basedir": "^5.0.1"
+      }
     },
     "confusing-browser-globals": {
       "version": "1.0.11",
@@ -15569,6 +15880,21 @@
         "lru-cache": "^4.0.1",
         "shebang-command": "^1.2.0",
         "which": "^1.2.9"
+      }
+    },
+    "crypto-random-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-4.0.0.tgz",
+      "integrity": "sha512-x8dy3RnvYdlUcPOjkEHqozhiwzKNSq7GcPuXFbnyMOCHxX8V3OgIg/pYuabl2sbUPfIJaeAQB7PMOK8DFIdoRA==",
+      "requires": {
+        "type-fest": "^1.0.1"
+      },
+      "dependencies": {
+        "type-fest": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
+          "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA=="
+        }
       }
     },
     "css": {
@@ -15646,6 +15972,11 @@
       "resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-5.6.5.tgz",
       "integrity": "sha512-PjiQ659aQ+fUTQqSrd1XEDnOr52jh30RBurfzkscaE2tPaFsDH5wOAHJiw8XAHphRknCwMUE9KRayc4K/NbO8A==",
       "dev": true
+    },
+    "cycle": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz",
+      "integrity": "sha512-TVF6svNzeQCOpjCqsy0/CSy8VgObG3wXusJ73xW2GbG5rGx7lC8zxDSURicsXI2UsGdi2L0QNRCi745/wUDvsA=="
     },
     "damerau-levenshtein": {
       "version": "1.0.8",
@@ -15909,6 +16240,14 @@
           "integrity": "sha512-VlZwKPCkYKxQgeSbH5EyngOmRp7Ww7I9rQLERETtf5ofd9pGeswWiOtogpEO850jziPRarreGxn5QIiTqpb2wA==",
           "dev": true
         }
+      }
+    },
+    "dot-prop": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-6.0.1.tgz",
+      "integrity": "sha512-tE7ztYzXHIeyvc7N+hR3oi7FIbf/NIjVP9hmAt3yMXzrQ072/fpjGLx2GxNxGxUl5V73MEqYzioOMoVhGMJ5cA==",
+      "requires": {
+        "is-obj": "^2.0.0"
       }
     },
     "electron-to-chromium": {
@@ -16732,6 +17071,11 @@
         "tmp": "^0.0.33"
       }
     },
+    "eyes": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
+      "integrity": "sha512-GipyPsXO1anza0AOZdy69Im7hGFCNB7Y/NGjDlZGJ3GJJLtwNSb2vrzYrTYJRrRloVx7pl+bhUaTB8yiccPvFQ=="
+    },
     "fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -16790,6 +17134,8 @@
       "version": "file:packages/faust-nx",
       "requires": {
         "@apollo/client": "^3.6.6",
+        "@types/configstore": "^6.0.0",
+        "configstore": "^6.0.0",
         "deepmerge": "^4.2.2",
         "graphql": "^16.5.0",
         "lodash": "^4.17.21",
@@ -16798,11 +17144,23 @@
         "react-dom": "^17.0.2"
       }
     },
+    "faust-nx-cli": {
+      "version": "file:packages/faust-nx-cli",
+      "requires": {
+        "@types/configstore": "^6.0.0",
+        "@types/prompt": "1.1.2",
+        "@types/uuid": "8.3.4",
+        "configstore": "^6.0.0",
+        "prompt": "1.3.0",
+        "uuid": "8.3.2"
+      }
+    },
     "faust-nx-getting-started": {
       "version": "file:examples/next/faust-nx",
       "requires": {
         "@apollo/client": "^3.6.6",
         "faust-nx": "file:../../../packages/faust-nx/dist/index.js",
+        "faust-nx-cli": "file:../../../packages/faust-nx-cli/dist/index.js",
         "next": "^12.1.6",
         "react": "^17.0.2",
         "react-dom": "^17.0.2"
@@ -16810,6 +17168,9 @@
       "dependencies": {
         "faust-nx": {
           "version": "file:packages/faust-nx/dist/index.js"
+        },
+        "faust-nx-cli": {
+          "version": "file:packages/faust-nx-cli/dist/index.js"
         }
       }
     },
@@ -17133,8 +17494,7 @@
     "graceful-fs": {
       "version": "4.2.10",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
-      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
-      "dev": true
+      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="
     },
     "grapheme-splitter": {
       "version": "1.0.4",
@@ -17338,8 +17698,7 @@
     "imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
-      "dev": true
+      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
     },
     "indent-string": {
       "version": "4.0.0",
@@ -17480,6 +17839,11 @@
         "has-tostringtag": "^1.0.0"
       }
     },
+    "is-obj": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
+      "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w=="
+    },
     "is-path-cwd": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-2.2.0.tgz",
@@ -17577,8 +17941,7 @@
     "is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
-      "dev": true
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
     },
     "is-weakref": {
       "version": "1.0.2",
@@ -17614,6 +17977,11 @@
         "node-fetch": "^2.6.1",
         "whatwg-fetch": "^3.4.1"
       }
+    },
+    "isstream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g=="
     },
     "istanbul-lib-coverage": {
       "version": "3.2.0",
@@ -19430,6 +19798,11 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
     },
+    "mute-stream": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
+      "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA=="
+    },
     "nanoid": {
       "version": "3.3.4",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
@@ -20130,6 +20503,18 @@
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
     },
+    "prompt": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/prompt/-/prompt-1.3.0.tgz",
+      "integrity": "sha512-ZkaRWtaLBZl7KKAKndKYUL8WqNT+cQHKRZnT4RYYms48jQkFw3rrBL+/N5K/KtdEveHkxs982MX2BkDKub2ZMg==",
+      "requires": {
+        "@colors/colors": "1.5.0",
+        "async": "3.2.3",
+        "read": "1.0.x",
+        "revalidator": "0.1.x",
+        "winston": "2.x"
+      }
+    },
     "prompts": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
@@ -20269,6 +20654,14 @@
       "resolved": "https://registry.npmjs.org/react-ssr-prepass/-/react-ssr-prepass-1.5.0.tgz",
       "integrity": "sha512-yFNHrlVEReVYKsLI5lF05tZoHveA5pGzjFbFJY/3pOqqjGOmMmqx83N4hIjN2n6E1AOa+eQEUxs3CgRnPmT0RQ==",
       "requires": {}
+    },
+    "read": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
+      "integrity": "sha512-rSOKNYUmaxy0om1BNjMN4ezNT6VKK+2xF4GBhc81mkH7L60i6dp8qPYrkndNLT3QPphoII3maL9PVC9XmhHwVQ==",
+      "requires": {
+        "mute-stream": "~0.0.4"
+      }
     },
     "read-pkg": {
       "version": "5.2.0",
@@ -20417,6 +20810,11 @@
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
       "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
       "dev": true
+    },
+    "revalidator": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/revalidator/-/revalidator-0.1.8.tgz",
+      "integrity": "sha512-xcBILK2pA9oh4SiinPEZfhP8HfrB/ha+a2fTMyl7Om2WjlDVrOQy99N2MXXlUHqGJz4qEu2duXxHJjDWuK/0xg=="
     },
     "rimraf": {
       "version": "3.0.2",
@@ -20695,6 +21093,11 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
+    },
+    "stack-trace": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+      "integrity": "sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg=="
     },
     "stack-utils": {
       "version": "2.0.5",
@@ -21354,7 +21757,6 @@
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
       "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
-      "dev": true,
       "requires": {
         "is-typedarray": "^1.0.0"
       }
@@ -21383,6 +21785,14 @@
       "integrity": "sha512-MEvryPLf18HvlCbLSzCW0U00IMftKGI5udnjrQbC5D4P0Hodwffhv+iGfWuJwg16Y/TK11ZFK8i+BPVW2z/eAw==",
       "dev": true
     },
+    "unique-string": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-3.0.0.tgz",
+      "integrity": "sha512-VGXBUVwxKMBUznyffQweQABPRRW1vHZAbadFZud4pLFAqRGvv/96vafgjWFqzourzr8YonlQiPgH0YCJfawoGQ==",
+      "requires": {
+        "crypto-random-string": "^4.0.0"
+      }
+    },
     "universalify": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
@@ -21402,6 +21812,11 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+    },
+    "uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
     },
     "v8-compile-cache": {
       "version": "2.3.0",
@@ -21616,6 +22031,19 @@
         "string-width": "^1.0.2 || 2 || 3 || 4"
       }
     },
+    "winston": {
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-2.4.6.tgz",
+      "integrity": "sha512-J5Zu4p0tojLde8mIOyDSsmLmcP8I3Z6wtwpTDHx1+hGcdhxcJaAmG4CFtagkb+NiN1M9Ek4b42pzMWqfc9jm8w==",
+      "requires": {
+        "async": "^3.2.3",
+        "colors": "1.0.x",
+        "cycle": "1.0.x",
+        "eyes": "0.1.x",
+        "isstream": "0.1.x",
+        "stack-trace": "0.0.x"
+      }
+    },
     "word-wrap": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
@@ -21668,7 +22096,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
       "integrity": "sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==",
-      "dev": true,
       "requires": {
         "imurmurhash": "^0.1.4",
         "is-typedarray": "^1.0.0",
@@ -21682,6 +22109,11 @@
       "integrity": "sha512-KMvVuFzpKBuiIXW3E4u3mySRO2/mCHSyZDJQM5NQ9Q9KHWHWh0NHgfbRMLLrceUK5qAL4ytALJbpRMjixFZh8A==",
       "dev": true,
       "requires": {}
+    },
+    "xdg-basedir": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-5.1.0.tgz",
+      "integrity": "sha512-GCPAHLvrIH13+c0SuacwvRYj2SxJXQ4kaVTT5xgL3kPrz56XxkF21IGhjSE1+W0aw7gpBWRGXLCPnPby6lSpmQ=="
     },
     "xml-name-validator": {
       "version": "3.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12574,7 +12574,7 @@
         "chalk": "^4.1.2",
         "configstore": "^6.0.0",
         "dotenv-flow": "^3.2.0",
-        "node-fetch": "^3.2.8",
+        "node-fetch": "^2.6.7",
         "prompt": "1.3.0",
         "uuid": "8.3.2"
       },
@@ -17336,7 +17336,7 @@
         "chalk": "^4.1.2",
         "configstore": "^6.0.0",
         "dotenv-flow": "^3.2.0",
-        "node-fetch": "^3.2.8",
+        "node-fetch": "^2.6.7",
         "prompt": "1.3.0",
         "uuid": "8.3.2"
       },
@@ -17377,8 +17377,7 @@
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
         },
         "node-fetch": {
-          "version": "3.2.8",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.2.8.tgz",
+          "version": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.2.8.tgz",
           "integrity": "sha512-KtpD1YhGszhntMpBDyp5lyagk8KIMopC1LEb7cQUAh7zcosaX5uK8HnbNb2i3NTQK3sIawCItS0uFC3QzcLHdg==",
           "requires": {
             "data-uri-to-buffer": "^4.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,8 +50,8 @@
       "name": "next-headless-getting-started",
       "version": "0.1.0",
       "dependencies": {
-        "@faustjs/core": "^0.15.6",
-        "@faustjs/next": "^0.15.6",
+        "@faustjs/core": "^0.15.7",
+        "@faustjs/next": "^0.15.7",
         "next": "^12.1.0",
         "normalize.css": "^8.0.1",
         "react": "^17.0.2",
@@ -12472,7 +12472,7 @@
     },
     "packages/core": {
       "name": "@faustjs/core",
-      "version": "0.15.6",
+      "version": "0.15.7",
       "license": "MIT",
       "dependencies": {
         "cookie": "^0.4.1",
@@ -12673,11 +12673,11 @@
     "packages/faust-nx/dist/index.js": {},
     "packages/next": {
       "name": "@faustjs/next",
-      "version": "0.15.6",
+      "version": "0.15.7",
       "license": "MIT",
       "dependencies": {
-        "@faustjs/core": "^0.15.6",
-        "@faustjs/react": "^0.15.6",
+        "@faustjs/core": "^0.15.7",
+        "@faustjs/react": "^0.15.7",
         "@gqty/logger": "^2.0.1",
         "@gqty/react": "^2.1.0",
         "common-tags": "^1.8.2",
@@ -12763,10 +12763,10 @@
     },
     "packages/react": {
       "name": "@faustjs/react",
-      "version": "0.15.6",
+      "version": "0.15.7",
       "license": "MIT",
       "dependencies": {
-        "@faustjs/core": "^0.15.6",
+        "@faustjs/core": "^0.15.7",
         "@gqty/react": "^2.1.0",
         "gqty": "^2.1.0",
         "graphql": ">=15.6",
@@ -12846,7 +12846,7 @@
       }
     },
     "plugins/faustwp": {
-      "version": "0.7.9"
+      "version": "0.7.10"
     }
   },
   "dependencies": {
@@ -13585,8 +13585,8 @@
     "@faustjs/next": {
       "version": "file:packages/next",
       "requires": {
-        "@faustjs/core": "^0.15.6",
-        "@faustjs/react": "^0.15.6",
+        "@faustjs/core": "^0.15.7",
+        "@faustjs/react": "^0.15.7",
         "@gqty/logger": "^2.0.1",
         "@gqty/react": "^2.1.0",
         "@testing-library/jest-dom": "^5.15.0",
@@ -13647,7 +13647,7 @@
     "@faustjs/react": {
       "version": "file:packages/react",
       "requires": {
-        "@faustjs/core": "^0.15.6",
+        "@faustjs/core": "^0.15.7",
         "@gqty/react": "^2.1.0",
         "@testing-library/jest-dom": "^5.15.0",
         "@testing-library/react": "^12.1.2",
@@ -17333,7 +17333,7 @@
         "@types/dotenv-flow": "^3.2.0",
         "@types/prompt": "1.1.2",
         "@types/uuid": "8.3.4",
-        "chalk": "4.1.2",
+        "chalk": "^4.1.2",
         "configstore": "^6.0.0",
         "dotenv-flow": "^3.2.0",
         "node-fetch": "^3.2.8",
@@ -20110,8 +20110,8 @@
     "next-headless-getting-started": {
       "version": "file:examples/next/getting-started",
       "requires": {
-        "@faustjs/core": "^0.15.6",
-        "@faustjs/next": "^0.15.6",
+        "@faustjs/core": "^0.15.7",
+        "@faustjs/next": "^0.15.7",
         "@gqty/cli": "^3.1.0",
         "@types/node": "^17.0.17",
         "@types/react": "^17.0.37",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12571,7 +12571,7 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
-        "chalk": "^5.0.1",
+        "chalk": "^4.1.2",
         "configstore": "^6.0.0",
         "dotenv-flow": "^3.2.0",
         "node-fetch": "^3.2.8",
@@ -12589,15 +12589,57 @@
       }
     },
     "packages/faust-nx-cli/dist/index.js": {},
-    "packages/faust-nx-cli/node_modules/chalk": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.0.1.tgz",
-      "integrity": "sha512-Fo07WOYGqMfCWHOzSXOt2CxDbC6skS/jO9ynEcmpANMoPrD+W1r1K6Vx7iNm+AQmETU1Xr2t+n8nzkV9t6xh3w==",
+    "packages/faust-nx-cli/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
       "engines": {
-        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "packages/faust-nx-cli/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "packages/faust-nx-cli/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "packages/faust-nx-cli/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "packages/faust-nx-cli/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "engines": {
+        "node": ">=8"
       }
     },
     "packages/faust-nx-cli/node_modules/node-fetch": {
@@ -12615,6 +12657,17 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "packages/faust-nx-cli/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "packages/faust-nx/dist/index.js": {},
@@ -17280,7 +17333,7 @@
         "@types/dotenv-flow": "^3.2.0",
         "@types/prompt": "1.1.2",
         "@types/uuid": "8.3.4",
-        "chalk": "^5.0.1",
+        "chalk": "4.1.2",
         "configstore": "^6.0.0",
         "dotenv-flow": "^3.2.0",
         "node-fetch": "^3.2.8",
@@ -17288,10 +17341,40 @@
         "uuid": "8.3.2"
       },
       "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
         "chalk": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.0.1.tgz",
-          "integrity": "sha512-Fo07WOYGqMfCWHOzSXOt2CxDbC6skS/jO9ynEcmpANMoPrD+W1r1K6Vx7iNm+AQmETU1Xr2t+n8nzkV9t6xh3w=="
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
         },
         "node-fetch": {
           "version": "3.2.8",
@@ -17301,6 +17384,14 @@
             "data-uri-to-buffer": "^4.0.0",
             "fetch-blob": "^3.1.4",
             "formdata-polyfill": "^4.0.10"
+          }
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "requires": {
+            "has-flag": "^4.0.0"
           }
         }
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -125,25 +125,6 @@
         "fsevents": "~2.3.2"
       }
     },
-    "examples/next/getting-started/node_modules/dotenv": {
-      "version": "8.6.0",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "examples/next/getting-started/node_modules/dotenv-flow": {
-      "version": "3.2.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "dotenv": "^8.0.0"
-      },
-      "engines": {
-        "node": ">= 8.0.0"
-      }
-    },
     "examples/next/getting-started/node_modules/eslint-config-next": {
       "version": "12.1.0",
       "dev": true,
@@ -2454,6 +2435,12 @@
       "integrity": "sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q==",
       "dev": true
     },
+    "node_modules/@types/dotenv-flow": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@types/dotenv-flow/-/dotenv-flow-3.2.0.tgz",
+      "integrity": "sha512-A79hbPwocbYkcTwGcDOFbKDuqyVo5mLAz/6Iq465YZ7R7Go5bT1PIM8I2jlPQkaD9u9fbotGVLkUPhX+9XUHfw==",
+      "dev": true
+    },
     "node_modules/@types/eslint": {
       "version": "8.4.2",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.4.2.tgz",
@@ -4313,6 +4300,14 @@
       "integrity": "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==",
       "dev": true
     },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.0.tgz",
+      "integrity": "sha512-Vr3mLBA8qWmcuschSLAOogKgQ/Jwxulv3RNE4FXnYWRGujzrRWQI4m12fQqRkwX06C0KanhLr4hK+GydchZsaA==",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/data-urls": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-2.0.0.tgz",
@@ -4662,6 +4657,25 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.6.0.tgz",
+      "integrity": "sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/dotenv-flow": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/dotenv-flow/-/dotenv-flow-3.2.0.tgz",
+      "integrity": "sha512-GEB6RrR4AbqDJvNSFrYHqZ33IKKbzkvLYiD5eo4+9aFXr4Y4G+QaFrB/fNp0y6McWBmvaPn3ZNjIufnj8irCtg==",
+      "dependencies": {
+        "dotenv": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
       }
     },
     "node_modules/electron-to-chromium": {
@@ -5842,6 +5856,28 @@
         "bser": "2.1.1"
       }
     },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
     "node_modules/fetch-mock": {
       "version": "9.11.0",
       "resolved": "https://registry.npmjs.org/fetch-mock/-/fetch-mock-9.11.0.tgz",
@@ -5952,6 +5988,17 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
       }
     },
     "node_modules/fs-constants": {
@@ -9476,6 +9523,24 @@
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-5.0.0.tgz",
       "integrity": "sha512-CvkDw2OEnme7ybCykJpVcKH+uAOLV2qLqiyla128dN9TkEWfrYmxG6C2boDe5KcNQqZF3orkqzGgOMvZ/JNekA=="
     },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
     "node_modules/node-fetch": {
       "version": "2.6.7",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
@@ -12035,6 +12100,14 @@
         "defaults": "^1.0.3"
       }
     },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz",
+      "integrity": "sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/webidl-conversions": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-6.1.0.tgz",
@@ -12498,7 +12571,10 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
+        "chalk": "^5.0.1",
         "configstore": "^6.0.0",
+        "dotenv-flow": "^3.2.0",
+        "node-fetch": "^3.2.8",
         "prompt": "1.3.0",
         "uuid": "8.3.2"
       },
@@ -12507,11 +12583,40 @@
       },
       "devDependencies": {
         "@types/configstore": "^6.0.0",
+        "@types/dotenv-flow": "^3.2.0",
         "@types/prompt": "1.1.2",
         "@types/uuid": "8.3.4"
       }
     },
     "packages/faust-nx-cli/dist/index.js": {},
+    "packages/faust-nx-cli/node_modules/chalk": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.0.1.tgz",
+      "integrity": "sha512-Fo07WOYGqMfCWHOzSXOt2CxDbC6skS/jO9ynEcmpANMoPrD+W1r1K6Vx7iNm+AQmETU1Xr2t+n8nzkV9t6xh3w==",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "packages/faust-nx-cli/node_modules/node-fetch": {
+      "version": "3.2.8",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.2.8.tgz",
+      "integrity": "sha512-KtpD1YhGszhntMpBDyp5lyagk8KIMopC1LEb7cQUAh7zcosaX5uK8HnbNb2i3NTQK3sIawCItS0uFC3QzcLHdg==",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
     "packages/faust-nx/dist/index.js": {},
     "packages/next": {
       "name": "@faustjs/next",
@@ -14511,6 +14616,12 @@
       "integrity": "sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q==",
       "dev": true
     },
+    "@types/dotenv-flow": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@types/dotenv-flow/-/dotenv-flow-3.2.0.tgz",
+      "integrity": "sha512-A79hbPwocbYkcTwGcDOFbKDuqyVo5mLAz/6Iq465YZ7R7Go5bT1PIM8I2jlPQkaD9u9fbotGVLkUPhX+9XUHfw==",
+      "dev": true
+    },
     "@types/eslint": {
       "version": "8.4.2",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.4.2.tgz",
@@ -15984,6 +16095,11 @@
       "integrity": "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==",
       "dev": true
     },
+    "data-uri-to-buffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.0.tgz",
+      "integrity": "sha512-Vr3mLBA8qWmcuschSLAOogKgQ/Jwxulv3RNE4FXnYWRGujzrRWQI4m12fQqRkwX06C0KanhLr4hK+GydchZsaA=="
+    },
     "data-urls": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-2.0.0.tgz",
@@ -16248,6 +16364,19 @@
       "integrity": "sha512-tE7ztYzXHIeyvc7N+hR3oi7FIbf/NIjVP9hmAt3yMXzrQ072/fpjGLx2GxNxGxUl5V73MEqYzioOMoVhGMJ5cA==",
       "requires": {
         "is-obj": "^2.0.0"
+      }
+    },
+    "dotenv": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.6.0.tgz",
+      "integrity": "sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g=="
+    },
+    "dotenv-flow": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/dotenv-flow/-/dotenv-flow-3.2.0.tgz",
+      "integrity": "sha512-GEB6RrR4AbqDJvNSFrYHqZ33IKKbzkvLYiD5eo4+9aFXr4Y4G+QaFrB/fNp0y6McWBmvaPn3ZNjIufnj8irCtg==",
+      "requires": {
+        "dotenv": "^8.0.0"
       }
     },
     "electron-to-chromium": {
@@ -17148,11 +17277,32 @@
       "version": "file:packages/faust-nx-cli",
       "requires": {
         "@types/configstore": "^6.0.0",
+        "@types/dotenv-flow": "^3.2.0",
         "@types/prompt": "1.1.2",
         "@types/uuid": "8.3.4",
+        "chalk": "^5.0.1",
         "configstore": "^6.0.0",
+        "dotenv-flow": "^3.2.0",
+        "node-fetch": "^3.2.8",
         "prompt": "1.3.0",
         "uuid": "8.3.2"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.0.1.tgz",
+          "integrity": "sha512-Fo07WOYGqMfCWHOzSXOt2CxDbC6skS/jO9ynEcmpANMoPrD+W1r1K6Vx7iNm+AQmETU1Xr2t+n8nzkV9t6xh3w=="
+        },
+        "node-fetch": {
+          "version": "3.2.8",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.2.8.tgz",
+          "integrity": "sha512-KtpD1YhGszhntMpBDyp5lyagk8KIMopC1LEb7cQUAh7zcosaX5uK8HnbNb2i3NTQK3sIawCItS0uFC3QzcLHdg==",
+          "requires": {
+            "data-uri-to-buffer": "^4.0.0",
+            "fetch-blob": "^3.1.4",
+            "formdata-polyfill": "^4.0.10"
+          }
+        }
       }
     },
     "faust-nx-getting-started": {
@@ -17184,6 +17334,15 @@
       "dev": true,
       "requires": {
         "bser": "2.1.1"
+      }
+    },
+    "fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "requires": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
       }
     },
     "fetch-mock": {
@@ -17266,6 +17425,14 @@
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "mime-types": "^2.1.12"
+      }
+    },
+    "formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "requires": {
+        "fetch-blob": "^3.1.2"
       }
     },
     "fs-constants": {
@@ -19902,17 +20069,6 @@
             "readdirp": "~3.6.0"
           }
         },
-        "dotenv": {
-          "version": "8.6.0",
-          "dev": true
-        },
-        "dotenv-flow": {
-          "version": "3.2.0",
-          "dev": true,
-          "requires": {
-            "dotenv": "^8.0.0"
-          }
-        },
         "eslint-config-next": {
           "version": "12.1.0",
           "dev": true,
@@ -20009,6 +20165,11 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-5.0.0.tgz",
       "integrity": "sha512-CvkDw2OEnme7ybCykJpVcKH+uAOLV2qLqiyla128dN9TkEWfrYmxG6C2boDe5KcNQqZF3orkqzGgOMvZ/JNekA=="
+    },
+    "node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ=="
     },
     "node-fetch": {
       "version": "2.6.7",
@@ -21899,6 +22060,11 @@
       "requires": {
         "defaults": "^1.0.3"
       }
+    },
+    "web-streams-polyfill": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz",
+      "integrity": "sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q=="
     },
     "webidl-conversions": {
       "version": "6.1.0",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
       "examples/next/getting-started",
       "plugins/faustwp",
       "packages/faust-nx",
+      "packages/faust-nx-cli",
       "examples/next/faust-nx"
     ]
   },

--- a/packages/faust-nx-cli/LICENSE
+++ b/packages/faust-nx-cli/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2022 WP Engine
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/faust-nx-cli/index.ts
+++ b/packages/faust-nx-cli/index.ts
@@ -5,15 +5,20 @@ import Configstore from 'configstore';
 import { spawn } from 'child_process';
 import prompt from 'prompt';
 import { v4 as uuid } from 'uuid';
+import fs from 'fs';
 
 const GA_TRACKING_ENDPOINT = 'http://www.google-analytics.com/debug/collect';
 const GA_TRACKING_ID = 'GA-xxxx';
 const CONFIG_STORE_NAME = 'faustnx';
+const packageJson = JSON.parse(fs.readFileSync('package.json', 'utf8'));
 
 export interface TelemetryPayload {
-  cpuCount: number;
-  platform: string;
-  arch: string;
+  faustNxVersion: string;
+  faustNxCliVersion: string;
+  apolloClientVersion: string;
+  nodeVersion: string;
+  nextJsVersion: string;
+  isDevelopment: boolean;
 }
 
 /**
@@ -109,10 +114,13 @@ const sendTelemetryData = (
   }
 
   // The telemetry data to collect
-  const telemetryData = {
-    cpuCount: os.cpus().length,
-    platform: os.platform(),
-    arch: os.arch(),
+  const telemetryData: TelemetryPayload = {
+    faustNxVersion: packageJson?.dependencies?.['faust-nx'],
+    faustNxCliVersion: packageJson?.dependencies?.['faust-nx-cli'],
+    apolloClientVersion: packageJson?.dependencies?.['@apollo/client'],
+    nodeVersion: process.versions.node,
+    nextJsVersion: packageJson?.dependencies?.['next'],
+    isDevelopment: nextCliArgs[0] === 'dev',
   };
 
   /**
@@ -120,7 +128,7 @@ const sendTelemetryData = (
    * anonymousId exists, send the telemetry data.
    */
   if (
-    nextCliArgs[0] === 'build' &&
+    (nextCliArgs[0] === 'dev' || nextCliArgs[0] === 'build') &&
     config.get('telemetry.enabled') === true &&
     config.get('telemetry.anonymousId')
   ) {

--- a/packages/faust-nx-cli/index.ts
+++ b/packages/faust-nx-cli/index.ts
@@ -1,0 +1,130 @@
+#!/usr/bin/env node
+
+import os from 'os';
+import Configstore from 'configstore';
+import { spawn } from 'child_process';
+import prompt from 'prompt';
+import { v4 as uuid } from 'uuid';
+
+const GA_TRACKING_ENDPOINT = 'http://www.google-analytics.com/debug/collect';
+const GA_TRACKING_ID = 'GA-xxxx';
+const CONFIG_STORE_NAME = 'faustnx';
+
+export interface TelemetryPayload {
+  cpuCount: number;
+  platform: string;
+  arch: string;
+}
+
+/**
+ * Used to fire Google Analytics requests
+ *
+ * @param category GA Category
+ * @param action GA Action
+ * @param label GA Label
+ * @param payload The data being sent to GA
+ * @param anonymousId The anonymous ID of the machine we captured during init
+ */
+const sendTelemetryData = (
+  category: string,
+  action: string,
+  label: string,
+  payload: TelemetryPayload,
+  anonymousId: string,
+) => {
+  const data = {
+    // API Version.
+    v: '1',
+    // Tracking ID / Property ID.
+    tid: GA_TRACKING_ID,
+    // Anonymous Client Identifier. Ideally, this should be a UUID that
+    // is associated with particular user, device, or browser instance.
+    cid: anonymousId,
+    // Event hit type.
+    t: 'event',
+    // Event category.
+    ec: category,
+    // Event action.
+    ea: action,
+    // Event label.
+    el: label,
+    // Event value.
+    ev: payload,
+  };
+
+  return fetch(GA_TRACKING_ENDPOINT, {
+    method: 'POST',
+    body: JSON.stringify(data),
+  });
+};
+
+(async () => {
+  const nextCliArgs = process.argv.filter((arg, index) => index > 1);
+  const config = new Configstore(CONFIG_STORE_NAME);
+
+  /**
+   * If there is no config (or a non-valid config), prompt the user for their
+   * permission to collect anonymous telemetry information and save their
+   * preferences on their machine.
+   */
+  if (
+    !config.all?.telemetry ||
+    !config.all?.telemetry?.enabled ||
+    !config.all?.telemetry?.anonymousId
+  ) {
+    prompt.start();
+
+    const { isTelemetryEnabled } = await prompt.get({
+      properties: {
+        isTelemetryEnabled: {
+          description:
+            'Would you like to enable telemetry in FaustNX? This helps us make more informed feature decisions. true/false',
+          required: true,
+          type: 'boolean',
+        },
+      },
+    });
+
+    config.set('telemetry', {
+      notifiedAt: new Date().getTime(),
+      anonymousId: uuid(),
+      enabled: isTelemetryEnabled,
+    });
+  }
+
+  // The telemetry data to collect
+  const telemetryData = {
+    cpuCount: os.cpus().length,
+    platform: os.platform(),
+    arch: os.arch(),
+  };
+
+  /**
+   * If the script being ran is "faustnx build", telemetry is enabled, and the
+   * anonymousId exists, send the telemetry data.
+   */
+  if (
+    nextCliArgs[0] === 'build' &&
+    config.get('telemetry.enabled') === true &&
+    !config.get('telemetry.anonymousId')
+  ) {
+    try {
+      sendTelemetryData(
+        'ga-category',
+        'ga-action',
+        'ga-label',
+        telemetryData,
+        config.get('telemetry.anonymousId'),
+      );
+    } catch (err) {
+      console.log('request failed');
+      // Fail silently
+    }
+  }
+
+  /**
+   * Spawn a child process using the args captured in argv and continue the
+   * standard i/o for the Next.js CLI.
+   */
+  const nextCommand = spawn('next', nextCliArgs, { stdio: 'inherit' });
+})();

--- a/packages/faust-nx-cli/package.json
+++ b/packages/faust-nx-cli/package.json
@@ -16,7 +16,7 @@
         "@types/uuid": "8.3.4"
     },
     "dependencies": {
-        "chalk": "^5.0.1",
+        "chalk": "^4.1.2",
         "configstore": "^6.0.0",
         "dotenv-flow": "^3.2.0",
         "node-fetch": "^3.2.8",

--- a/packages/faust-nx-cli/package.json
+++ b/packages/faust-nx-cli/package.json
@@ -1,0 +1,38 @@
+{
+    "name": "faust-nx-cli",
+    "version": "0.0.1",
+    "private": true,
+    "description": "FaustNX Cli",
+    "main": "dist/index.js",
+    "type": "module",
+    "types": "dist/index.d.ts",
+    "bin": {
+      "faustnx": "dist/index.js"
+    },
+    "devDependencies": {
+      "@types/configstore": "^6.0.0",
+      "@types/uuid": "8.3.4",
+      "@types/prompt": "1.1.2"
+    },
+    "dependencies": {
+      "configstore": "^6.0.0",
+      "uuid": "8.3.2",
+      "prompt": "1.3.0"
+    },
+    "scripts": {
+      "test": "npm test",
+      "build": "tsc -p tsconfig.json",
+      "dev": "tsc -p tsconfig.json --watch"
+    },
+    "repository": {
+      "type": "git",
+      "url": "git+https://github.com/wpengine/faustjs.git"
+    },
+    "author": "Faust.js Team",
+    "license": "MIT",
+    "bugs": {
+      "url": "https://github.com/wpengine/faustjs/issues"
+    },
+    "homepage": "https://github.com/wpengine/faustjs#readme"
+  }
+  

--- a/packages/faust-nx-cli/package.json
+++ b/packages/faust-nx-cli/package.json
@@ -7,32 +7,35 @@
     "type": "module",
     "types": "dist/index.d.ts",
     "bin": {
-      "faustnx": "dist/index.js"
+        "faustnx": "dist/index.js"
     },
     "devDependencies": {
-      "@types/configstore": "^6.0.0",
-      "@types/uuid": "8.3.4",
-      "@types/prompt": "1.1.2"
+        "@types/configstore": "^6.0.0",
+        "@types/dotenv-flow": "^3.2.0",
+        "@types/prompt": "1.1.2",
+        "@types/uuid": "8.3.4"
     },
     "dependencies": {
-      "configstore": "^6.0.0",
-      "uuid": "8.3.2",
-      "prompt": "1.3.0"
+        "chalk": "^5.0.1",
+        "configstore": "^6.0.0",
+        "dotenv-flow": "^3.2.0",
+        "node-fetch": "^3.2.8",
+        "prompt": "1.3.0",
+        "uuid": "8.3.2"
     },
     "scripts": {
-      "test": "npm test",
-      "build": "tsc -p tsconfig.json",
-      "dev": "tsc -p tsconfig.json --watch"
+        "test": "npm test",
+        "build": "tsc -p tsconfig.json",
+        "dev": "tsc -p tsconfig.json --watch"
     },
     "repository": {
-      "type": "git",
-      "url": "git+https://github.com/wpengine/faustjs.git"
+        "type": "git",
+        "url": "git+https://github.com/wpengine/faustjs.git"
     },
     "author": "Faust.js Team",
     "license": "MIT",
     "bugs": {
-      "url": "https://github.com/wpengine/faustjs/issues"
+        "url": "https://github.com/wpengine/faustjs/issues"
     },
     "homepage": "https://github.com/wpengine/faustjs#readme"
-  }
-  
+}

--- a/packages/faust-nx-cli/package.json
+++ b/packages/faust-nx-cli/package.json
@@ -19,7 +19,7 @@
         "chalk": "^4.1.2",
         "configstore": "^6.0.0",
         "dotenv-flow": "^3.2.0",
-        "node-fetch": "^3.2.8",
+        "node-fetch": "^2.6.7",
         "prompt": "1.3.0",
         "uuid": "8.3.2"
     },

--- a/packages/faust-nx-cli/tsconfig.json
+++ b/packages/faust-nx-cli/tsconfig.json
@@ -6,7 +6,7 @@
       "target": "ES2017",
       "esModuleInterop": true,
       "moduleResolution": "node",
-      "declaration": true
+      "declaration": true,
     },
     "exclude": ["dist", "./*.d.ts"]
   }

--- a/packages/faust-nx-cli/tsconfig.json
+++ b/packages/faust-nx-cli/tsconfig.json
@@ -1,0 +1,13 @@
+{
+    "compilerOptions": {
+      "strict": true,
+      "outDir": "dist",
+      "module": "ES2015",
+      "target": "ES2017",
+      "esModuleInterop": true,
+      "moduleResolution": "node",
+      "declaration": true
+    },
+    "exclude": ["dist", "./*.d.ts"]
+  }
+  

--- a/packages/faust-nx-cli/utils/getCliArgs.ts
+++ b/packages/faust-nx-cli/utils/getCliArgs.ts
@@ -1,0 +1,4 @@
+/**
+ * Gets the args from the argv process mines the runtime portion.
+ */
+export const getCliArgs = () => process.argv.filter((arg, index) => index > 1);

--- a/packages/faust-nx-cli/utils/index.ts
+++ b/packages/faust-nx-cli/utils/index.ts
@@ -1,0 +1,20 @@
+import { getCliArgs } from './getCliArgs.js';
+import { errorLog, noticeLog } from './log.js';
+import { marshallTelemetryData } from './marshallTelemetryData.js';
+import { promptUserForTelemetryPref } from './promptUserForTelemetryPref.js';
+import { requestWPTelemetryData } from './requestWPTelemetryData.js';
+import { sendTelemetryData } from './sendTelemetryData.js';
+import { validateFaustNXEnvVars } from './validateFaustNXEnvVars.js';
+import type {TelemetryData} from './marshallTelemetryData.js'
+
+export {
+  getCliArgs,
+  errorLog,
+  noticeLog,
+  marshallTelemetryData,
+  promptUserForTelemetryPref,
+  sendTelemetryData,
+  validateFaustNXEnvVars,
+  requestWPTelemetryData,
+  TelemetryData
+};

--- a/packages/faust-nx-cli/utils/log.ts
+++ b/packages/faust-nx-cli/utils/log.ts
@@ -1,0 +1,29 @@
+import chalk from 'chalk';
+
+export const noticeLog = (message: string, ...args: any) => {
+  log('notice', message, ...args);
+};
+
+export const errorLog = (message: string, ...args: any) => {
+  log('error', message, ...args);
+};
+
+export const log = (
+  logLevel: 'notice' | 'error',
+  message: string,
+  ...args: any
+) => {
+  let logLevelMessage = chalk.whiteBright('faustnx: ');
+
+  switch (logLevel) {
+    case 'notice': {
+      logLevelMessage += chalk.yellow('notice');
+      break;
+    }
+    case 'error': {
+      logLevelMessage += chalk.red('error');
+    }
+  }
+
+  console.log(`${logLevelMessage} - ${message}`, ...args);
+};

--- a/packages/faust-nx-cli/utils/marshallTelemetryData.ts
+++ b/packages/faust-nx-cli/utils/marshallTelemetryData.ts
@@ -1,0 +1,100 @@
+import fs from 'fs';
+import { getCliArgs } from './getCliArgs.js';
+import { WPTelemetryResponseData } from './requestWPTelemetryData.js';
+
+export interface TelemetryData {
+  wordpress: {
+    faustwp_settings: {
+      has_frontend_uri?: boolean;
+      redirects_enabled?: boolean;
+      rewrites_enabled?: boolean;
+      themes_disabled?: boolean;
+      image_source_replacement_enabled?: boolean;
+    };
+    faustwp_version?: string;
+    is_wpe?: boolean;
+    multisite?: boolean;
+    php_version?: string;
+    wp_version?: string;
+  };
+  node: {
+    faustnx_version?: string;
+    faustnx_cli_version?: string;
+    apollo_client_version?: string;
+    node_version?: string;
+    next_version?: string;
+    is_development?: boolean;
+  };
+}
+
+/**
+ * Sanitizes the version from a dependency in package.json.
+ *
+ * @param version The dependency version.
+ * @returns A sanitized version or undefined if the version is a path.
+ */
+const sanitizePackageJsonVersion = (version: string | undefined) => {
+  if (!version) {
+    return undefined;
+  }
+
+  if (version.charAt(0) === '^' || version.charAt(0) === '~') {
+    version = version.substring(1);
+  }
+
+  /**
+   * If a dependency is a file path set the value to undefined as we
+   * don't want to collect file paths in telemetry
+   */
+  if (version.startsWith('file:')) {
+    version = undefined;
+  }
+
+  return version;
+};
+
+/**
+ * Marshall the JS and WP telemetry data into a single object for GA.
+ * @param wpTelemetryData
+ */
+export const marshallTelemetryData = (
+  wpTelemetryData: WPTelemetryResponseData | undefined,
+): TelemetryData => {
+  const packageJson = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+
+  let telemetryData: TelemetryData = {
+    node: {
+      faustnx_version: sanitizePackageJsonVersion(
+        packageJson?.dependencies?.['faust-nx'],
+      ),
+      faustnx_cli_version: sanitizePackageJsonVersion(
+        packageJson?.dependencies?.['faust-nx-cli'],
+      ),
+      apollo_client_version: sanitizePackageJsonVersion(
+        packageJson?.dependencies?.['@apollo/client'],
+      ),
+      node_version: process.versions.node,
+      next_version: sanitizePackageJsonVersion(
+        packageJson?.dependencies?.['next'],
+      ),
+      is_development: getCliArgs()[0] === 'dev',
+    },
+    wordpress: {
+      faustwp_settings: {
+        has_frontend_uri: wpTelemetryData?.faustwp?.has_frontend_uri,
+        redirects_enabled: wpTelemetryData?.faustwp?.redirects_enabled,
+        rewrites_enabled: wpTelemetryData?.faustwp?.rewrites_enabled,
+        themes_disabled: wpTelemetryData?.faustwp?.themes_disabled,
+        image_source_replacement_enabled:
+          wpTelemetryData?.faustwp?.image_source_replacement_enabled,
+      },
+      faustwp_version: wpTelemetryData?.faustwp?.version,
+      is_wpe: wpTelemetryData?.is_wpe,
+      multisite: wpTelemetryData?.multisite,
+      php_version: wpTelemetryData?.php_version,
+      wp_version: wpTelemetryData?.wp_version,
+    },
+  };
+
+  return telemetryData;
+};

--- a/packages/faust-nx-cli/utils/promptUserForTelemetryPref.ts
+++ b/packages/faust-nx-cli/utils/promptUserForTelemetryPref.ts
@@ -1,0 +1,37 @@
+import Configstore from 'configstore';
+import prompt from 'prompt';
+import { v4 as uuid } from 'uuid';
+
+prompt.start();
+
+/**
+ * Prompt the user for their telemetry preferences.
+ *
+ * @param isInit boolean Based on this value, we will either save a new telemetry config, or update the "enabled" value in the config.
+ * @param config The Configstore config
+ */
+export const promptUserForTelemetryPref = async (
+  isInit: boolean,
+  config: Configstore,
+) => {
+  const { isTelemetryEnabled } = await prompt.get({
+    properties: {
+      isTelemetryEnabled: {
+        description:
+          'Would you like to enable telemetry in FaustNX? This helps us make more informed feature decisions. true/false',
+        required: true,
+        type: 'boolean',
+      },
+    },
+  });
+
+  if (isInit) {
+    config.set('telemetry', {
+      notifiedAt: new Date().getTime(),
+      anonymousId: uuid(),
+      enabled: isTelemetryEnabled,
+    });
+  } else {
+    config.set('telemetry.enabled', isTelemetryEnabled);
+  }
+};

--- a/packages/faust-nx-cli/utils/requestWPTelemetryData.ts
+++ b/packages/faust-nx-cli/utils/requestWPTelemetryData.ts
@@ -1,0 +1,46 @@
+import fetch from 'node-fetch';
+
+const WP_TELEMETRY_ENDPOINT = '/wp-json/faustwp/v1/telemetry';
+
+export interface WPTelemetryResponseData {
+  faustwp: {
+    version: string;
+    has_frontend_uri: boolean;
+    redirects_enabled: boolean;
+    rewrites_enabled: boolean;
+    themes_disabled: boolean;
+    image_source_replacement_enabled: boolean;
+  };
+  is_wpe: boolean;
+  multisite: boolean;
+  php_version: string;
+  wp_version: string;
+}
+
+/**
+ * Request the telemetry data from WordPress.
+ *
+ * @param headlessWpUrl The headless WordPress URL
+ * @param headlessSecretKey The headless WordPress secret key for authorizing the request.
+ * @returns WPTelemetryResponseData
+ */
+export const requestWPTelemetryData = async (
+  headlessWpUrl: string,
+  headlessSecretKey: string,
+): Promise<WPTelemetryResponseData | undefined> => {
+  const res = await fetch(`${headlessWpUrl}${WP_TELEMETRY_ENDPOINT}`, {
+    method: 'POST',
+    headers: {
+      'x-faustwp-secret': headlessSecretKey,
+    },
+  });
+
+  // If the response is invalid, return undefined for appropriate error handling.
+  if (res.status !== 200) {
+    return undefined;
+  }
+
+  const json = (await res.json()) as WPTelemetryResponseData;
+
+  return json;
+};

--- a/packages/faust-nx-cli/utils/sendTelemetryData.ts
+++ b/packages/faust-nx-cli/utils/sendTelemetryData.ts
@@ -1,0 +1,47 @@
+import fetch from 'node-fetch';
+import { TelemetryData } from './marshallTelemetryData';
+
+const GA_TRACKING_ENDPOINT = 'http://www.google-analytics.com/debug/collect';
+const GA_TRACKING_ID = 'GA-xxxx';
+
+/**
+ * Send the marshalled telemetry data to GA.
+ *
+ * @param category GA Category
+ * @param action GA Action
+ * @param label GA Label
+ * @param payload The data being sent to GA
+ * @param anonymousId The anonymous ID of the machine we captured during init
+ */
+export const sendTelemetryData = (
+  category: string,
+  action: string,
+  label: string,
+  payload: TelemetryData,
+  anonymousId: string,
+) => {
+  const data = {
+    // API Version.
+    v: '1',
+    // Tracking ID / Property ID.
+    tid: GA_TRACKING_ID,
+    // Anonymous Client Identifier. Ideally, this should be a UUID that
+    // is associated with particular user, device, or browser instance.
+    cid: anonymousId,
+    // Event hit type.
+    t: 'event',
+    // Event category.
+    ec: category,
+    // Event action.
+    ea: action,
+    // Event label.
+    el: label,
+    // Event value.
+    ev: payload,
+  };
+
+  return fetch(GA_TRACKING_ENDPOINT, {
+    method: 'POST',
+    body: JSON.stringify(data),
+  });
+};

--- a/packages/faust-nx-cli/utils/validateFaustNXEnvVars.ts
+++ b/packages/faust-nx-cli/utils/validateFaustNXEnvVars.ts
@@ -1,0 +1,18 @@
+import { errorLog, noticeLog } from './log.js';
+
+/**
+ * Validates that the appropriate FaustNX related environment variables are set.
+ */
+export const validateFaustNXEnvVars = () => {
+  if (!process.env.NEXT_PUBLIC_WORDPRESS_URL) {
+    errorLog('Please provide a NEXT_PUBLIC_WORDPRESS_URL environment variable');
+
+    process.exit(0);
+  }
+
+  if (!process.env.HEADLESS_SECRET_KEY) {
+    noticeLog(
+      'You do not have a headless secret key specified. Some functionality may be limited.',
+    );
+  }
+};

--- a/packages/faust-nx/package.json
+++ b/packages/faust-nx/package.json
@@ -6,18 +6,20 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "peerDependencies": {
+    "@apollo/client": ">=3.6.6",
     "next": ">=12.1.6",
     "react": ">=17.0.2",
-    "react-dom": ">=17.0.2",
-    "@apollo/client": ">=3.6.6"
+    "react-dom": ">=17.0.2"
   },
   "devDependencies": {
+    "@apollo/client": "^3.6.6",
+    "@types/configstore": "^6.0.0",
     "next": "^12.1.6",
     "react": "^17.0.2",
-    "react-dom": "^17.0.2",
-    "@apollo/client": "^3.6.6"
+    "react-dom": "^17.0.2"
   },
   "dependencies": {
+    "configstore": "^6.0.0",
     "deepmerge": "^4.2.2",
     "graphql": "^16.5.0",
     "lodash": "^4.17.21"


### PR DESCRIPTION
The `faustnx` CLI will allow us to implement telemetry, and better position us in the future for other features that require our input before the `next` CLI runs.

## Description

This PR introduces a `faustnx` CLI that acts as a pass through to the `next` CLI, however, with our own telemetry that runs prior to the `next` CLI.

When running the `faustnx` CLI for the first time, you are asked if you would like to enroll in FaustNX Telemetry. By responding with either `true` or `false`, your preferences are then saved to your local machine (`~/.config/configstore/faustnx.json` on Mac) as a JSON file:

```jsonc
{
  telemetry: {
    notifiedAt: '12345', // timestamp the user was first notified about FaustNX telemetry
    anonymousId: '0000-0000-0000', // An anonymous v4 UUID for GA
    enabled: true // Either true or false based on user preferences
  }
}
```

From there, any time the `faustnx` CLI is ran, we check the users' preferences, and if telemetry is enabled, we send a GA event with relevant information.

In addition to the basic Next CLI commands like `faustnx start`, `faustnx dev`, and `faustnx build`, there is also a new command `faustnx faustnx-telemetry`, which allows the user to modify their telemetry preferences.

## Testing

1. Checkout `faustnx-cli` branch
2. Run `npm run build -w faust-nx` from the monorepo root
3. Run `npm run build -w faust-nx-cli` from the monorepo root
4. Run `npm run dev -w faust-nx-getting-started` to start the FaustNX example app in dev mode
5. Notice the FaustNX Telemetry prompt
6. Type `true`
7. Exit out of `dev` mode
8. Run `npm run build -w faust-nx-getting-started`
9. Based on your preference, you will see a telemetry event being `console.log`'d
10. Now, run `npx faustnx faustnx-telemetry` and change your preferences to `false`
11. Run `npm run build -w faust-nx-getting-started` notice that the telemetry event is not being `console.log`'d

**NOTE**: WordPress telemetry info will not be collected and will display as `undefined` since the WP telemetry endpoint doesn't exist on this branch.

## Telemetry Data

Currently the following data is being captured in a telemetry event:

```ts
export interface TelemetryData {
  wordpress: {
    faustwp_settings: {
      has_frontend_uri?: boolean;
      redirects_enabled?: boolean;
      rewrites_enabled?: boolean;
      themes_disabled?: boolean;
      image_source_replacement_enabled?: boolean;
    };
    faustwp_version?: string;
    is_wpe?: boolean;
    multisite?: boolean;
    php_version?: string;
    wp_version?: string;
  };
  node: {
    faustnx_version?: string;
    faustnx_cli_version?: string;
    apollo_client_version?: string;
    node_version?: string;
    next_version?: string;
    is_development?: boolean;
  };
}
```