### PR TITLE
Prevent tests from running against docs

### DIFF
--- a/.github/workflows/e2e-next-example.yml
+++ b/.github/workflows/e2e-next-example.yml
@@ -3,7 +3,7 @@ name: E2E Test - Next Getting Started Example
 on:
   pull_request:
     paths-ignore:
-      - '**.md'
+      - '**/*.md'
 
 jobs:
   e2e-test-next-getting-started-example:

--- a/.github/workflows/e2e-next-example.yml
+++ b/.github/workflows/e2e-next-example.yml
@@ -1,5 +1,10 @@
 name: E2E Test - Next Getting Started Example
-on: pull_request
+
+on:
+  pull_request:
+    paths-ignore:
+      - '**.md'
+
 jobs:
   e2e-test-next-getting-started-example:
     runs-on: ubuntu-latest

--- a/.github/workflows/e2e-test-plugin.yml
+++ b/.github/workflows/e2e-test-plugin.yml
@@ -1,5 +1,10 @@
 name: E2E Test Plugin
-on: pull_request
+
+on:
+  pull_request:
+    paths-ignore:
+      - '**.md'
+
 jobs:
   e2e_test_plugin:
     timeout-minutes: 10

--- a/.github/workflows/e2e-test-plugin.yml
+++ b/.github/workflows/e2e-test-plugin.yml
@@ -3,7 +3,7 @@ name: E2E Test Plugin
 on:
   pull_request:
     paths-ignore:
-      - '**.md'
+      - '**/*.md'
 
 jobs:
   e2e_test_plugin:

--- a/.github/workflows/lint-packages.yml
+++ b/.github/workflows/lint-packages.yml
@@ -3,7 +3,7 @@ name: Lint Packages
 on:
   pull_request:
     paths-ignore:
-      - '**.md'
+      - '**/*.md'
 
 jobs:
   lint_packages:

--- a/.github/workflows/lint-packages.yml
+++ b/.github/workflows/lint-packages.yml
@@ -1,5 +1,10 @@
 name: Lint Packages
-on: pull_request
+
+on:
+  pull_request:
+    paths-ignore:
+      - '**.md'
+
 jobs:
   lint_packages:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint-plugin.yml
+++ b/.github/workflows/lint-plugin.yml
@@ -1,5 +1,10 @@
 name: Lint Plugin
-on: pull_request
+
+on:
+  pull_request:
+    paths-ignore:
+      - '**.md'
+
 jobs:
   lint_plugin:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint-plugin.yml
+++ b/.github/workflows/lint-plugin.yml
@@ -3,7 +3,7 @@ name: Lint Plugin
 on:
   pull_request:
     paths-ignore:
-      - '**.md'
+      - '**/*.md'
 
 jobs:
   lint_plugin:

--- a/.github/workflows/sonarqube-scan.yml
+++ b/.github/workflows/sonarqube-scan.yml
@@ -6,7 +6,7 @@ on:
     branches:
       - canary
     paths-ignore:
-      - '**.md'
+      - '**/*.md'
 
 name: SonarQube Scan
 jobs:

--- a/.github/workflows/sonarqube-scan.yml
+++ b/.github/workflows/sonarqube-scan.yml
@@ -5,6 +5,8 @@ on:
   pull_request:
     branches:
       - canary
+    paths-ignore:
+      - '**.md'
 
 name: SonarQube Scan
 jobs:

--- a/.github/workflows/test-packages.yml
+++ b/.github/workflows/test-packages.yml
@@ -3,7 +3,7 @@ name: Test Packages
 on:
   pull_request:
     paths-ignore:
-      - '**.md'
+      - '**/*.md'
 
 jobs:
   test_packages:

--- a/.github/workflows/test-packages.yml
+++ b/.github/workflows/test-packages.yml
@@ -1,5 +1,10 @@
 name: Test Packages
-on: pull_request
+
+on:
+  pull_request:
+    paths-ignore:
+      - '**.md'
+
 jobs:
   test_packages:
     strategy:

--- a/.github/workflows/test-plugin.yml
+++ b/.github/workflows/test-plugin.yml
@@ -3,7 +3,7 @@ name: Test Plugin
 on:
   pull_request:
     paths-ignore:
-      - '**.md'
+      - '**/*.md'
 
 jobs:
   test_plugin:

--- a/.github/workflows/test-plugin.yml
+++ b/.github/workflows/test-plugin.yml
@@ -1,5 +1,10 @@
 name: Test Plugin
-on: pull_request
+
+on:
+  pull_request:
+    paths-ignore:
+      - '**.md'
+
 jobs:
   test_plugin:
     runs-on: ubuntu-latest

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -35,7 +35,7 @@ Instead, you can create symlinks to the themes/plugins in this repository. Best 
 **Setup**
 To begin working with the FaustWP WordPress plugin, you will need to symlink the plugin from the monorepo to your WordPress plugin development directory.
 
-```
+```sh
 ln -s /path/to/faustjs/plugins/faustwp /path/to/wordpress/wp-content/plugins/faustwp
 ```
 
@@ -44,19 +44,19 @@ ln -s /path/to/faustjs/plugins/faustwp /path/to/wordpress/wp-content/plugins/fau
 
 Install the composer packages from within `plugins/faustwp` directory if you haven't already.
 
-```
+```sh
 composer install
 ```
 
 Run the syntax check.
 
-```
+```sh
 composer phpcs
 ```
 
 Use `phpcs` to fix some syntax errors:
 
-```
+```sh
 composer phpcs:fix
 ```
 
@@ -64,37 +64,37 @@ composer phpcs:fix
 
 To run WordPress unit tests, first start the Docker application from the `plugins/faustwp` directory:
 
-```
+```sh
 composer run docker:start
 ```
 
 If desired, you may specify the WP_VERSION you'd like to run tests against:
 
-```
+```sh
 WP_VERSION=5.5 composer run docker:start
 ```
 
 Once the containers are up, set up the test framework. If you want to enable code coverage reporting, make sure you provide the `COVERAGE=1` environment variable as a parameter:
 
-```
+```sh
 docker-compose exec -e COVERAGE=1 wordpress init-testing-environment.sh
 ```
 
 Install and activate WP GraphQL:
 
-```
+```sh
 docker-compose exec --workdir=/var/www/html/wp-content/plugins/faustwp --user=www-data wordpress wp plugin install wp-graphql --activate
 ```
 
 Run the unit tests:
 
-```
+```sh
 docker-compose exec -w /var/www/html/wp-content/plugins/faustwp wordpress composer test
 ```
 
 Finally, to remove the containers:
 
-```
+```sh
 composer run docker:stop
 ```
 
@@ -118,7 +118,7 @@ Use [Codeception](https://codeception.com/) for running end-2-end tests in the b
 
 1. Create the following `.env.test` in `examples/next/getting-started`.
 
-```
+```sh
 # Your WordPress site URL
 NEXT_PUBLIC_WORDPRESS_URL=http://localhost:8080
 


### PR DESCRIPTION
Signed-off-by: Joe Fusco <joe.fusco@wpengine.com>

## Description

These changes prevent the project's GitHub workflows from running against markdown files, and can be seen working in [this test pull request](https://github.com/wpengine/faustjs/pull/995). Notice that only the changeset-bot has posted with no coverage reports.