### PR TITLE
Use `GET` method in Telemetry Rest endpoint

### DIFF
--- a/plugins/faustwp/includes/rest/callbacks.php
+++ b/plugins/faustwp/includes/rest/callbacks.php
@@ -79,7 +79,7 @@ function register_rest_routes() {
 		'faustwp/v1',
 		'/telemetry',
 		array(
-			'methods'             => 'GET',
+			'methods'             => 'POST',
 			'callback'            => __NAMESPACE__ . '\\handle_rest_telemetry_callback',
 			'permission_callback' => __NAMESPACE__ . '\\rest_telemetry_permission_callback',
 		)

--- a/plugins/faustwp/tests/acceptance/TelemetryCest.php
+++ b/plugins/faustwp/tests/acceptance/TelemetryCest.php
@@ -12,7 +12,7 @@ class TelemetryCest
 		$I->haveFaustWPSetting('frontend_uri', 'http://localhost:3000');
 		$I->haveFaustWPSetting('secret_key', $secret_key);
 		$I->haveHttpHeader('x-faustwp-secret', $secret_key);
-		$I->sendGet('/wp-json/faustwp/v1/telemetry');
+		$I->sendPost('/wp-json/faustwp/v1/telemetry');
 		$I->seeResponseCodeIsSuccessful();
 		$I->seeResponseIsJson();
 		$I->seeResponseContains('{"faustwp":{"has_frontend_uri":true}}');

--- a/plugins/faustwp/tests/acceptance/TelemetryCest.php
+++ b/plugins/faustwp/tests/acceptance/TelemetryCest.php
@@ -12,7 +12,7 @@ class TelemetryCest
 		$I->haveFaustWPSetting('frontend_uri', 'http://localhost:3000');
 		$I->haveFaustWPSetting('secret_key', $secret_key);
 		$I->haveHttpHeader('x-faustwp-secret', $secret_key);
-		$I->sendGet('/wp-json/faustwp/v1/telemetry');
+		$I->sendPost('/wp-json/faustwp/v1/telemetry', []);
 		$I->seeResponseCodeIsSuccessful();
 		$I->seeResponseIsJson();
 		$I->seeResponseContains('{"faustwp":{"has_frontend_uri":true}}');

--- a/plugins/faustwp/tests/acceptance/TelemetryCest.php
+++ b/plugins/faustwp/tests/acceptance/TelemetryCest.php
@@ -12,7 +12,7 @@ class TelemetryCest
 		$I->haveFaustWPSetting('frontend_uri', 'http://localhost:3000');
 		$I->haveFaustWPSetting('secret_key', $secret_key);
 		$I->haveHttpHeader('x-faustwp-secret', $secret_key);
-		$I->sendPost('/wp-json/faustwp/v1/telemetry');
+		$I->sendGet('/wp-json/faustwp/v1/telemetry');
 		$I->seeResponseCodeIsSuccessful();
 		$I->seeResponseIsJson();
 		$I->seeResponseContains('{"faustwp":{"has_frontend_uri":true}}');


### PR DESCRIPTION
Use the `POST` method for telemetry endpoint as `GET` requests could be cached.