### PR TITLE
Setup FaustNX config getter/setter

### DIFF
--- a/examples/next/faust-nx/faustnx.config.js
+++ b/examples/next/faust-nx/faustnx.config.js
@@ -1,0 +1,9 @@
+import { setConfig } from 'faust-nx';
+import templates from './wp-templates';
+
+/**
+ * @type {import('faust-nx').FaustNXConfig}
+ **/
+export default setConfig({
+  templates,
+});

--- a/examples/next/faust-nx/pages/[...wordpressNode].tsx
+++ b/examples/next/faust-nx/pages/[...wordpressNode].tsx
@@ -1,14 +1,14 @@
+import 'faustnx.config';
 import { getWordPressProps, WordPressTemplate } from 'faust-nx';
 import { GetStaticPropsContext } from 'next';
-import templates from 'wp-templates';
 import client from 'client';
 
 export default function Page(props: any) {
-  return <WordPressTemplate templates={templates} {...props} />;
+  return <WordPressTemplate {...props} />;
 }
 
 export function getStaticProps(ctx: GetStaticPropsContext) {
-  return getWordPressProps({ client, templates, ctx });
+  return getWordPressProps({ client, ctx });
 }
 
 export async function getStaticPaths() {

--- a/packages/faust-nx/components/WordPressTemplate.tsx
+++ b/packages/faust-nx/components/WordPressTemplate.tsx
@@ -4,6 +4,7 @@ import { PropsWithChildren } from 'react';
 import { getTemplate } from '../getTemplate';
 import { WordPressTemplate } from '../getWordPressProps';
 import { SeedNode } from '../queries/seedQuery';
+import { getConfig } from '../config';
 
 export type WordPressTemplateProps = PropsWithChildren<{
   __SEED_NODE__: SeedNode;
@@ -11,7 +12,13 @@ export type WordPressTemplateProps = PropsWithChildren<{
 }>;
 
 export function WordPressTemplate(props: WordPressTemplateProps) {
-  const { __SEED_NODE__: seedNode, templates } = props;
+  const { templates } = getConfig();
+
+  if (!templates) {
+    throw new Error('Templates are required. Please add them to your config.');
+  }
+
+  const { __SEED_NODE__: seedNode } = props;
   const template = getTemplate(seedNode, templates);
 
   if (!template) {
@@ -25,10 +32,14 @@ export function WordPressTemplate(props: WordPressTemplateProps) {
   res = useQuery(query, {
     variables: variables ? variables(seedNode) : undefined,
     ssr: true,
-    skip: !query
+    skip: !query,
   });
 
   const { data, error, loading } = res ?? {};
 
-  return React.cloneElement(<Component />, { ...props, data, error, loading }, null);
+  return React.cloneElement(
+    <Component />,
+    { ...props, data, error, loading },
+    null,
+  );
 }

--- a/packages/faust-nx/config/index.ts
+++ b/packages/faust-nx/config/index.ts
@@ -1,0 +1,15 @@
+import { WordPressTemplate } from '../getWordPressProps.js';
+
+export interface FaustNXConfig {
+  templates: { [key: string]: WordPressTemplate };
+}
+
+let config = {};
+
+export function setConfig(_config: FaustNXConfig) {
+  config = _config;
+}
+
+export function getConfig(): Partial<FaustNXConfig> {
+  return config;
+}

--- a/packages/faust-nx/getWordPressProps.tsx
+++ b/packages/faust-nx/getWordPressProps.tsx
@@ -4,6 +4,7 @@ import type { DocumentNode } from 'graphql'
 import { SeedNode, SEED_QUERY } from './queries/seedQuery';
 import { getTemplate } from './getTemplate';
 import { addApolloState } from './client';
+import { getConfig } from './config';
 
 function isSSR(
   ctx: GetServerSidePropsContext | GetStaticPropsContext,
@@ -19,12 +20,22 @@ export interface WordPressTemplate {
 
 export interface getWordPressPropsConfig {
     client: ApolloClient<NormalizedCacheObject>;
-    templates: {[key: string]: WordPressTemplate};
     ctx: GetServerSidePropsContext | GetStaticPropsContext
 }
 
 export async function getWordPressProps(options: getWordPressPropsConfig) {
-  const { client, templates, ctx } = options;
+  const {templates} = getConfig()
+
+  if (!templates) {
+    throw new Error('Templates are required. Please add them to your config.');
+  }
+
+  const { client, ctx } = options;
+
+  if(!client) {
+    throw new Error('getWordPressProps: client is required. Please add it as a prop.')
+  }
+
   let resolvedUrl = null;
 
   if (!isSSR(ctx)) {

--- a/packages/faust-nx/index.ts
+++ b/packages/faust-nx/index.ts
@@ -1,5 +1,13 @@
 import { FaustNXProvider } from './components/FaustNXProvider';
 import { WordPressTemplate } from './components/WordPressTemplate';
 import { getWordPressProps } from './getWordPressProps';
+import { getConfig, setConfig, FaustNXConfig } from './config/index.js';
 
-export { FaustNXProvider, WordPressTemplate, getWordPressProps };
+export {
+  FaustNXProvider,
+  WordPressTemplate,
+  getWordPressProps,
+  getConfig,
+  setConfig,
+  FaustNXConfig,
+};

--- a/packages/faust-nx/package.json
+++ b/packages/faust-nx/package.json
@@ -24,7 +24,8 @@
   },
   "scripts": {
     "test": "npm test",
-    "build": "tsc -p tsconfig.json"
+    "build": "tsc -p tsconfig.json",
+    "dev": "tsc -p tsconfig.json --watch"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Description

Creates a basic config getter/setter. This will be required for auth with the `client` config.

## Testing

1. Run `npm run build -w faust-nx` from the monorepo root
2. Run `npm run dev -w faust-nx-getting-started` from the monorepo root
3. Ensure pages and posts are still rendered from the template hierarchy
4. Remove the `templates` from `faustnx.config.js` and ensure an error appears
