### PR TITLE
Move ESLint next line comment to same line

### DIFF
--- a/packages/core/src/auth/client/accessToken.ts
+++ b/packages/core/src/auth/client/accessToken.ts
@@ -107,8 +107,7 @@ export function setAccessTokenRefreshTimer(): void {
     secondsUntilExpiration - TIME_UNTIL_REFRESH_BEFORE_TOKEN_EXPIRES;
 
   setRefreshTimer(
-    // eslint-disable-next-line @typescript-eslint/no-use-before-define
-    setTimeout(() => void fetchAccessToken(), secondsUntilRefresh * 1000),
+    setTimeout(() => void fetchAccessToken(), secondsUntilRefresh * 1000), // eslint-disable-line @typescript-eslint/no-use-before-define
   );
 }
 

--- a/packages/core/src/utils/assert.ts
+++ b/packages/core/src/utils/assert.ts
@@ -54,8 +54,7 @@ export function isValidUrl(url: string): boolean {
 }
 
 export const emailRegex =
-  // eslint-disable-next-line no-useless-escape
-  /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
+  /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/; // eslint-disable-line no-useless-escape
 
 /**
  * Returns whether or not a string is a valid email address


### PR DESCRIPTION
## Description

This PR converts some ESLint `eslint-disable-next-line` comments to inline with `eslint-disable-line` to avoid the comments being picked up by the interpreter.
