### PR TITLE
[MERL-409] Add note for custom `previewDestination` path

### DIFF
--- a/internal/website/docs/next/reference/with-faust.mdx
+++ b/internal/website/docs/next/reference/with-faust.mdx
@@ -72,6 +72,6 @@ module.exports = withFaust(nextConfig, withFaustConfig);
 ```
 
 :::note
-If you change the `previewDestination` path, do not forget to create an assotiated page with the same name for that destination.
-Otherwise the framework will redirect to a non existing page and it will show a 404 response.
+If you change the `previewDestination` path, do not forget to create an associated `page` with the same name for that destination.
+Otherwise the framework will redirect to a non existing page and it will show a `404` response.
 :::

--- a/internal/website/docs/next/reference/with-faust.mdx
+++ b/internal/website/docs/next/reference/with-faust.mdx
@@ -70,3 +70,8 @@ const withFaustConfig = {
  **/
 module.exports = withFaust(nextConfig, withFaustConfig);
 ```
+
+:::note
+If you change the `previewDestination` path, do not forget to create an assotiated page with the same name for that destination.
+Otherwise the framework will redirect to a non existing page and it will show a 404 response.
+:::


### PR DESCRIPTION
## Description

<!--
Include a summary of the change and some contextual information.
-->

When using the custom `previewDestination` the section in the docs does not mention that we need to add a relevant next.js page with the same name. This would cause 404 issues.

## Related Issue(s):

[MERL-409]

<!--
Provide the GitHub issue(s) number for issue tracking purposes, use the following syntax:

- #1234
-->

## Testing

<!--
Describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Also list any relevant details for your test configuration such as how to test the changes locally or in staging.
-->

## Screenshots

<!--
If this is a visual change include relevant screenshots about the behavior of the application before and after this change.
-->
<img width="1077" alt="Screenshot 2022-08-02 at 17 41 42" src="https://user-images.githubusercontent.com/328805/182428338-80075f73-8516-4b87-b6bb-f71c878bc2c4.png">

## Documentation Changes

<!--
List corresponding changes to the documentation.
-->

Add small note within `/docs/next/reference/with-faust` regarding `previewDestination` paths

## Dependant PRs

<!--
List any dependent PR's that are awaiting review. Use the following syntax:

- #1234
-->


[MERL-409]: https://wpengine.atlassian.net/browse/MERL-409?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ