### PR TITLE
[MERL-376] Add POC example of file based pages

### DIFF
--- a/examples/next/faust-nx/pages/sample-page.tsx
+++ b/examples/next/faust-nx/pages/sample-page.tsx
@@ -1,0 +1,26 @@
+import { GetStaticPropsContext } from 'next';
+import { getNextStaticProps } from 'faust-nx';
+import { useQuery, gql } from '@apollo/client';
+import client from 'client';
+
+export default function Page(props: any) {
+  const {data} = useQuery(Page.query);
+  const title = data?.page?.title;
+  return <div>{title}</div>
+}
+
+Page.query = gql`
+  query SamplePage {
+    page(id: "sample-page", idType: URI) {
+      title
+      content
+    }
+  }
+`;
+
+export function getStaticProps(ctx: GetStaticPropsContext) {
+  return getNextStaticProps(ctx, {
+    client: client,
+    Page,
+  });
+}

--- a/examples/next/faust-nx/pages/sample-page.tsx
+++ b/examples/next/faust-nx/pages/sample-page.tsx
@@ -6,7 +6,11 @@ import client from 'client';
 export default function Page(props: any) {
   const {data} = useQuery(Page.query);
   const title = data?.page?.title;
-  return <div>{title}</div>
+  const content = data?.page?.content;
+  return <div>
+    <h1>{title}</h1>
+    <div dangerouslySetInnerHTML={{ __html: content}} />
+  </div>
 }
 
 Page.query = gql`

--- a/packages/faust-nx/src/getProps.ts
+++ b/packages/faust-nx/src/getProps.ts
@@ -1,0 +1,101 @@
+import { ApolloClient, NormalizedCacheObject } from '@apollo/client';
+import {
+  GetStaticPropsContext,
+  GetServerSidePropsResult,
+  GetServerSidePropsContext,
+  Redirect,
+} from 'next';
+import type { DocumentNode } from 'graphql';
+import isBoolean from 'lodash/isBoolean.js';
+import isObject from 'lodash/isObject.js';
+import { addApolloState, initializeApollo } from './client.js';
+
+export interface GetNextServerSidePropsConfig<Props = Record<string, unknown>> {
+  client: ApolloClient<NormalizedCacheObject>;
+  Page: {
+    query?: DocumentNode;
+    variables?: (
+      context: GetStaticPropsContext | GetServerSidePropsContext,
+    ) => { [key: string]: any };
+  };
+  props?: Props;
+  notFound?: boolean;
+  redirect?: Redirect;
+}
+
+export interface GetNextStaticPropsConfig<Props = Record<string, unknown>>
+  extends GetNextServerSidePropsConfig<Props> {
+  revalidate?: number | boolean;
+}
+
+/**
+ * This helper function lets you build a static site with your WordPress data
+ *
+ * @param {GetStaticPropsContext} context
+ * @param {GetNextStaticPropsConfig} cfg
+ */
+export async function getNextStaticProps<Props>(
+  context: GetStaticPropsContext,
+  cfg: GetNextStaticPropsConfig<Props>,
+) {
+  const { notFound, redirect, client, Page } = cfg;
+  const apolloClient = initializeApollo(client);
+
+  if (isBoolean(notFound) && notFound === true) {
+    return {
+      notFound,
+    };
+  }
+
+  if (isObject(redirect)) {
+    return {
+      redirect,
+    };
+  }
+
+  if (Page.query) {
+    await apolloClient.query({
+      query: Page.query,
+      variables: Page?.variables ? Page?.variables(context) : undefined,
+    });
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+  return addApolloState(apolloClient, { props: {} });
+}
+
+/**
+ * This helper function lets you server side render your page with WordPress data
+ *
+ * @param {GetServerSidePropsContext} context
+ * @param {GetNextServerSidePropsConfig} cfg
+ */
+export async function getNextServerSideProps<Props>(
+  context: GetServerSidePropsContext,
+  cfg: GetNextServerSidePropsConfig<Props>,
+): Promise<GetServerSidePropsResult<Props>> {
+  const { notFound, redirect, client, Page } = cfg;
+  const apolloClient = initializeApollo(client);
+
+  if (isBoolean(notFound) && notFound === true) {
+    return {
+      notFound,
+    };
+  }
+
+  if (isObject(redirect)) {
+    return {
+      redirect,
+    };
+  }
+
+  if (Page.query) {
+    await apolloClient.query({
+      query: Page.query,
+      variables: Page?.variables ? Page?.variables(context) : undefined,
+    });
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+  return addApolloState(apolloClient, { props: {} });
+}

--- a/packages/faust-nx/src/index.ts
+++ b/packages/faust-nx/src/index.ts
@@ -1,6 +1,7 @@
 import { FaustNXProvider } from './components/FaustNXProvider.js';
 import { WordPressTemplate } from './components/WordPressTemplate.js';
 import { getWordPressProps } from './getWordPressProps.js';
+import { getNextStaticProps } from './getProps.js';
 import { getConfig, setConfig, FaustNXConfig } from './config/index.js';
 import { ensureAuthorization } from './auth/index.js';
 import { authorizeHandler, logoutHandler, apiRouter } from './server/index.js';
@@ -9,6 +10,7 @@ export {
   FaustNXProvider,
   WordPressTemplate,
   getWordPressProps,
+  getNextStaticProps,
   getConfig,
   setConfig,
   FaustNXConfig,


### PR DESCRIPTION
## Description

<!--
Include a summary of the change and some contextual information.
-->

This PR adds an example of how we can support Next.js file based pages in faustNX. It introduces two familiar helper functions:

* `getNextStaticProps`: Used within the `getStaticProps`
* `getNextServerSideProps`: Used within the `getNextServerSideProps`

## Related Issue(s):

<!--
Provide the GitHub issue(s) number for issue tracking purposes, use the following syntax:

- #1234
-->

## Testing

<!--
Describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Also list any relevant details for your test configuration such as how to test the changes locally or in staging.
-->

1. Build the project
2. Create a new page named `sample-page` in WordPress
3. Navigate to the `/sample-page` path in Faust.js
4. Check that the title is populated from the `sample-page` page.

## Screenshots

<!--
If this is a visual change include relevant screenshots about the behavior of the application before and after this change.
-->
<img width="1792" alt="Screenshot 2022-08-09 at 17 15 10" src="https://user-images.githubusercontent.com/328805/183704247-0682534f-13b1-49b1-9347-ab34a5aba550.png">

## Documentation Changes

<!--
List corresponding changes to the documentation.
-->

## Dependant PRs

<!--
List any dependent PR's that are awaiting review. Use the following syntax:

- #1234
-->
