### PR TITLE
Setup `possibleTemplatesList` and `seedQueryDocumentNode` filters

### DIFF
--- a/packages/faust-nx/src/getTemplate.ts
+++ b/packages/faust-nx/src/getTemplate.ts
@@ -1,8 +1,9 @@
 import { WordPressTemplate } from './getWordPressProps.js';
 import { SeedNode } from './queries/seedQuery.js';
+import { hooks } from './hooks/index.js';
 
 export function getPossibleTemplates(node: SeedNode) {
-  const possibleTemplates = [];
+  let possibleTemplates: string[] = [];
 
   // CPT archive page
   // eslint-disable-next-line no-underscore-dangle
@@ -121,6 +122,12 @@ export function getPossibleTemplates(node: SeedNode) {
   }
 
   possibleTemplates.push('index');
+
+  possibleTemplates = hooks.applyFilters(
+    'possibleTemplatesList',
+    possibleTemplates,
+    node,
+  ) as string[];
 
   return possibleTemplates;
 }

--- a/packages/faust-nx/src/getTemplate.ts
+++ b/packages/faust-nx/src/getTemplate.ts
@@ -126,7 +126,7 @@ export function getPossibleTemplates(node: SeedNode) {
   possibleTemplates = hooks.applyFilters(
     'possibleTemplatesList',
     possibleTemplates,
-    node,
+    { seedNode: node },
   ) as string[];
 
   return possibleTemplates;

--- a/packages/faust-nx/src/getWordPressProps.tsx
+++ b/packages/faust-nx/src/getWordPressProps.tsx
@@ -5,6 +5,7 @@ import { SeedNode, SEED_QUERY } from './queries/seedQuery.js';
 import { getTemplate } from './getTemplate.js';
 import { addApolloState } from './client.js';
 import { getConfig } from './config/index.js';
+import { hooks } from './hooks/index.js';
 
 function isSSR(
   ctx: GetServerSidePropsContext | GetStaticPropsContext,
@@ -57,8 +58,12 @@ export async function getWordPressProps(options: GetWordPressPropsConfig) {
     };
   }
 
+  const seedQuery = hooks.applyFilters('seedQueryDocumentNode', SEED_QUERY, {
+    resolvedUrl,
+  }) as DocumentNode;
+
   const seedQueryRes = await client.query({
-    query: SEED_QUERY,
+    query: seedQuery,
     variables: { uri: resolvedUrl },
   });
 


### PR DESCRIPTION
## Description

This PR introduces two filters for the plugin system:

## `possibleTemplatesList`

This filter allows a plugin to mutate the returned possible templates list to resolve a template. It can be used like:

```js
class HelloWorld {
  apply({addFilter}) {
    addFilter('possibleTemplatesList', 'faust-nx', (possibleTemplates, ctx) => {
      return [...possibleTemplates, 'new-template']
    })
  }
}
```

## `seedQueryDocumentNode`

This filter allows a plugin to mutate the returned seed query document node. We leave the implementation on how they'll mutate the seed query document node up to the user, but we should consider providing utility functions in the callback `ctx` for merging our seed query `DocumentNode` with a user provided one. It can be used like:

```js
class HelloWorld {
  apply({addFilter}) {
    addFilter('seedQueryDocumentNode', 'faust-nx', (seedQuery, ctx) => {
      return gql`
        query SeedQuery {
          ...
        }
      `
    })
  }
}
```
