### PR TITLE
Introduce tests for plugin system

### DIFF
--- a/packages/faust-nx/src/hooks/index.ts
+++ b/packages/faust-nx/src/hooks/index.ts
@@ -4,7 +4,6 @@ import { _Hooks } from '@wordpress/hooks/build-types/createHooks';
 
 export interface Plugin {
   apply?: (hooks: _Hooks) => void;
-  [key: string]: unknown;
 }
 
 export const hooks = createHooks();

--- a/packages/faust-nx/tests/config/index.test.ts
+++ b/packages/faust-nx/tests/config/index.test.ts
@@ -1,0 +1,52 @@
+import { Hooks } from '@wordpress/hooks/build-types';
+import { setConfig } from '../../src/config/index';
+
+class HelloWorldTestPlugin {
+  constructor() {}
+
+  apply(hooks: Hooks) {
+    console.log('Plugin called');
+  }
+}
+
+// Plugins must have an apply method.
+class InvalidPlugin {
+  constructor() {}
+}
+
+describe('config', () => {
+  test('plugins apply method is called', () => {
+    const consoleLogSpy = jest.spyOn(console, 'log');
+
+    setConfig({
+      // @ts-ignore
+      templates: [],
+      // @ts-ignore
+      experimentalPlugins: [
+        new HelloWorldTestPlugin(),
+        new HelloWorldTestPlugin(),
+      ],
+    });
+
+    expect(consoleLogSpy).toBeCalledTimes(2);
+  });
+
+  test('plugin without apply method fails silently', () => {
+    expect(() =>
+      setConfig({
+        // @ts-ignore
+        templates: [],
+        experimentalPlugins: [new HelloWorldTestPlugin(), new InvalidPlugin()],
+      }),
+    ).not.toThrowError();
+  });
+
+  test('config without plugins is still valid', () => {
+    expect(() =>
+      setConfig({
+        // @ts-ignore
+        templates: [],
+      }),
+    ).not.toThrowError();
+  });
+});


### PR DESCRIPTION
## Description

This PR introduces some tests for the plugin system. We're now checking that:
* Plugins that are instantiated in the `experimentalPlugins` config property have their `apply` methods called
* Plugins that do not have an `apply` method fail silently when specified in the `experimentalPlugins` config property
* The lack of the `experimentalPlugins` property does not introduce any adverse effects