### PR TITLE
[MERL-425] Extracted faust-nx-cli from telemetry

### DIFF
--- a/examples/next/faust-nx/package.json
+++ b/examples/next/faust-nx/package.json
@@ -3,16 +3,17 @@
   "private": true,
   "version": "0.1.0",
   "scripts": {
-    "dev": "next dev",
-    "build": "next build",
-    "start": "next start"
+    "dev": "faustnx dev",
+    "build": "faustnx build",
+    "start": "faustnx start"
   },
   "dependencies": {
     "next": "^12.1.6",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "@apollo/client": "^3.6.6",
-    "faust-nx": "file:../../../packages/faust-nx/dist/index.js"
+    "faust-nx": "file:../../../packages/faust-nx/dist/index.js",
+    "faust-nx-cli": "file:../../../packages/faust-nx-cli/dist/index.js"
   },
   "devDependencies": {
     "@types/node": "^17.0.17",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
       "examples/next/getting-started",
       "plugins/faustwp",
       "packages/faust-nx",
+      "packages/faust-nx-cli",
       "examples/next/faust-nx"
     ]
   },

--- a/packages/faust-nx-cli/LICENSE
+++ b/packages/faust-nx-cli/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2022 WP Engine
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/faust-nx-cli/index.ts
+++ b/packages/faust-nx-cli/index.ts
@@ -1,0 +1,15 @@
+#!/usr/bin/env node
+
+import { spawn } from 'child_process';
+import dotenv from 'dotenv-flow';
+
+import { getCliArgs, validateFaustNXEnvVars } from './utils/index.js';
+
+dotenv.config();
+validateFaustNXEnvVars();
+
+/**
+ * Spawn a child process using the args captured in argv and continue the
+ * standard i/o for the Next.js CLI.
+ */
+spawn('next', getCliArgs(), { stdio: 'inherit' });

--- a/packages/faust-nx-cli/package.json
+++ b/packages/faust-nx-cli/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "faust-nx-cli",
+  "version": "0.0.1",
+  "private": true,
+  "description": "FaustNX Cli",
+  "main": "dist/index.js",
+  "type": "module",
+  "types": "dist/index.d.ts",
+  "bin": {
+    "faustnx": "dist/index.js"
+  },
+  "devDependencies": {
+    "@types/configstore": "^6.0.0",
+    "@types/dotenv-flow": "^3.2.0",
+    "@types/prompt": "1.1.2",
+    "@types/uuid": "8.3.4"
+  },
+  "dependencies": {
+    "chalk": "^4.1.2",
+    "configstore": "^6.0.0",
+    "dotenv-flow": "^3.2.0",
+    "node-fetch": "^2.6.7",
+    "prompt": "1.3.0",
+    "uuid": "8.3.2"
+  },
+  "scripts": {
+    "test": "npm test",
+    "build": "tsc -p tsconfig.json",
+    "dev": "tsc -p tsconfig.json --watch"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/wpengine/faustjs.git"
+  },
+  "author": "Faust.js Team",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/wpengine/faustjs/issues"
+  },
+  "homepage": "https://github.com/wpengine/faustjs#readme"
+}

--- a/packages/faust-nx-cli/tsconfig.json
+++ b/packages/faust-nx-cli/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "outDir": "dist",
+    "module": "ES2015",
+    "target": "ES2017",
+    "esModuleInterop": true,
+    "moduleResolution": "node",
+    "declaration": true
+  },
+  "exclude": ["dist", "./*.d.ts"]
+}

--- a/packages/faust-nx-cli/utils/getCliArgs.ts
+++ b/packages/faust-nx-cli/utils/getCliArgs.ts
@@ -1,0 +1,4 @@
+/**
+ * Gets the args from the argv process mines the runtime portion.
+ */
+export const getCliArgs = () => process.argv.filter((arg, index) => index > 1);

--- a/packages/faust-nx-cli/utils/index.ts
+++ b/packages/faust-nx-cli/utils/index.ts
@@ -1,0 +1,5 @@
+import { getCliArgs } from './getCliArgs.js';
+import { errorLog, noticeLog } from './log.js';
+import { validateFaustNXEnvVars } from './validateFaustNXEnvVars.js';
+
+export { getCliArgs, errorLog, noticeLog, validateFaustNXEnvVars };

--- a/packages/faust-nx-cli/utils/log.ts
+++ b/packages/faust-nx-cli/utils/log.ts
@@ -1,0 +1,35 @@
+import chalk from 'chalk';
+
+export const log = (
+  logLevel: 'notice' | 'error',
+  message: string,
+  ...args: any
+) => {
+  let logLevelMessage = chalk.whiteBright('faustnx: ');
+
+  switch (logLevel) {
+    case 'notice': {
+      logLevelMessage += chalk.yellow('notice');
+      break;
+    }
+    case 'error': {
+      logLevelMessage += chalk.red('error');
+      break;
+    }
+    default: {
+      break;
+    }
+  }
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, no-console
+  console.log(`${logLevelMessage} - ${message}`, ...args);
+};
+
+export const noticeLog = (message: string, ...args: any) => {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+  log('notice', message, ...args);
+};
+
+export const errorLog = (message: string, ...args: any) => {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+  log('error', message, ...args);
+};

--- a/packages/faust-nx-cli/utils/validateFaustNXEnvVars.ts
+++ b/packages/faust-nx-cli/utils/validateFaustNXEnvVars.ts
@@ -1,0 +1,18 @@
+import { errorLog, noticeLog } from './log.js';
+
+/**
+ * Validates that the appropriate FaustNX related environment variables are set.
+ */
+export const validateFaustNXEnvVars = () => {
+  if (!process.env.NEXT_PUBLIC_WORDPRESS_URL) {
+    errorLog('Please provide a NEXT_PUBLIC_WORDPRESS_URL environment variable');
+
+    process.exit(0);
+  }
+
+  if (!process.env.HEADLESS_SECRET_KEY) {
+    noticeLog(
+      'You do not have a headless secret key specified. Some functionality may be limited.',
+    );
+  }
+};


### PR DESCRIPTION
## Description

<!--
Include a summary of the change and some contextual information.
-->

This PR extracts the faustnx CLI that acts as a pass through to the next CLI as previously delivered in https://github.com/wpengine/faustjs/tree/MERL-171-telemetry

## Related Issue(s):

<!--
Provide the GitHub issue(s) number for issue tracking purposes, use the following syntax:

- #1234
-->

https://wpengine.atlassian.net/browse/MERL-425

## Testing

1. Checkout  the branch
2. Run `npm run build -w faust-nx` from the monorepo root
3. Run `npm run build -w faust-nx-cli` from the monorepo root
4. Run `npm i` from the monorepo root
5. Run `npm run dev -w faust-nx-getting-started` to start the FaustNX example app in dev mode

You should also check that the following scripts work as expected:
`npm run build -w faust-nx-getting-started`
`npm run start -w faust-nx-getting-started`


<!--
Describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Also list any relevant details for your test configuration such as how to test the changes locally or in staging.
-->

## Screenshots

<!--
If this is a visual change include relevant screenshots about the behavior of the application before and after this change.
-->

## Documentation Changes

<!--
List corresponding changes to the documentation.
-->

## Dependant PRs

<!--
List any dependent PR's that are awaiting review. Use the following syntax:

- #1234
-->
