### PR TITLE
Use node 16 in actions

### DIFF
--- a/.github/workflows/test-packages.yml
+++ b/.github/workflows/test-packages.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: ${{ matrix.version }}
+          node-version: '16'
       - run: rm package-lock.json
 
       - name: Install

--- a/packages/next/src/server/getProps.tsx
+++ b/packages/next/src/server/getProps.tsx
@@ -84,7 +84,7 @@ export async function getProps<
             {/* eslint-disable-next-line react/jsx-no-constructed-context-values */}
             <FaustContext.Provider value={{ client }}>
               {/* eslint-disable-next-line react/jsx-props-no-spreading */}
-              <Page {...(props as Props)} />
+              <Page {...(props as any)} />
             </FaustContext.Provider>
           </RouterContext.Provider>,
         );


### PR DESCRIPTION
## Description

This PR sets the test packages action to use version `16` of Node, which it was previously using 16 and 18 (which we don't support).

Additionally, this PR addresses a small TS issue that was causing tests to fail.