### PR TITLE
[MERL-436] refactor: Change signature of wp-template components

### DIFF
--- a/examples/next/faust-nx/wp-templates/archive.tsx
+++ b/examples/next/faust-nx/wp-templates/archive.tsx
@@ -1,15 +1,15 @@
 import { gql } from "@apollo/client";
 import { PropsWithChildren } from "react";
 
-function Component(props: PropsWithChildren<{}>) {
+export default function Component(props: PropsWithChildren<{}>) {
   return <>Archive page</>;
 }
 
-const variables = ({ uri }: any) => {
+Component.variables = ({ uri }: any) => {
   return { uri };
 };
 
-const query = gql`
+Component.query = gql`
   query GetArchivePage($uri: String!) {
     nodeByUri(uri: $uri) {
       ... on Category {
@@ -18,5 +18,3 @@ const query = gql`
     }
   }
 `;
-
-export default { Component, variables, query };

--- a/examples/next/faust-nx/wp-templates/page.tsx
+++ b/examples/next/faust-nx/wp-templates/page.tsx
@@ -1,6 +1,6 @@
 import { gql } from '@apollo/client';
 
-const Component = (props: any) => {
+export default function Component(props: any) {
   const { title, content } = props?.data?.page;
   return (
     <>
@@ -10,11 +10,11 @@ const Component = (props: any) => {
   );
 };
 
-const variables = ({ uri }: any) => {
+Component.variables = ({ uri }: any) => {
   return { uri };
 };
 
-const query = gql`
+Component.query = gql`
   query GetPage($uri: ID!) {
     page(id: $uri, idType: URI) {
       title
@@ -23,4 +23,3 @@ const query = gql`
   }
 `;
 
-export default { Component, variables, query };

--- a/examples/next/faust-nx/wp-templates/single.tsx
+++ b/examples/next/faust-nx/wp-templates/single.tsx
@@ -1,6 +1,6 @@
 import { gql } from '@apollo/client';
 
-const Component = (props: any) => {
+export default function Component(props: any) {
   const { title, content } = props.data.post;
 
   return (
@@ -11,7 +11,7 @@ const Component = (props: any) => {
   );
 };
 
-const query = gql`
+Component.query = gql`
   query GetPost($uri: ID!) {
     post(id: $uri, idType: URI) {
       title
@@ -20,12 +20,10 @@ const query = gql`
   }
 `;
 
-const variables = (seedQuery: any) => {
+Component.variables = (seedQuery: any) => {
   console.log(seedQuery);
 
   return {
     uri: seedQuery.uri,
   };
 };
-
-export default { Component, variables, query };

--- a/packages/faust-nx/src/components/WordPressTemplate.tsx
+++ b/packages/faust-nx/src/components/WordPressTemplate.tsx
@@ -13,7 +13,7 @@ function cleanTemplate(
   template: WordPressTemplateType,
 ): React.FC<{ [key: string]: any }> {
   const copy = (template as React.FC<{ [key: string]: any }>).bind({});
-  return copy as React.FC<{ [key: string]: any }>;
+  return copy;
 }
 
 export function WordPressTemplate(props: WordPressTemplateProps) {

--- a/packages/faust-nx/src/components/WordPressTemplate.tsx
+++ b/packages/faust-nx/src/components/WordPressTemplate.tsx
@@ -1,9 +1,9 @@
-import React, { PropsWithChildren, ReactNode } from 'react';
+import React, { PropsWithChildren } from 'react';
 import { DocumentNode, useQuery } from '@apollo/client';
 import { getTemplate } from '../getTemplate.js';
 import { SeedNode } from '../queries/seedQuery.js';
 import { getConfig } from '../config/index.js';
-import { WordPressTemplate as WordPressTemplateType } from '../getWordPressProps';
+import { WordPressTemplate as WordPressTemplateType } from '../getWordPressProps.js';
 
 export type WordPressTemplateProps = PropsWithChildren<{
   __SEED_NODE__: SeedNode;
@@ -12,9 +12,7 @@ export type WordPressTemplateProps = PropsWithChildren<{
 function cleanTemplate(
   template: WordPressTemplateType,
 ): React.FC<{ [key: string]: any }> {
-  const copy = template;
-  delete copy.query;
-  delete copy.variables;
+  const copy = (template as React.FC<{ [key: string]: any }>).bind({});
   return copy as React.FC<{ [key: string]: any }>;
 }
 

--- a/packages/faust-nx/src/components/WordPressTemplate.tsx
+++ b/packages/faust-nx/src/components/WordPressTemplate.tsx
@@ -1,12 +1,22 @@
-import React, { PropsWithChildren } from 'react';
+import React, { PropsWithChildren, ReactNode } from 'react';
 import { DocumentNode, useQuery } from '@apollo/client';
 import { getTemplate } from '../getTemplate.js';
 import { SeedNode } from '../queries/seedQuery.js';
 import { getConfig } from '../config/index.js';
+import { WordPressTemplate as WordPressTemplateType } from '../getWordPressProps';
 
 export type WordPressTemplateProps = PropsWithChildren<{
   __SEED_NODE__: SeedNode;
 }>;
+
+function cleanTemplate(
+  template: WordPressTemplateType,
+): React.FC<{ [key: string]: any }> {
+  const copy = template;
+  delete copy.query;
+  delete copy.variables;
+  return copy as React.FC<{ [key: string]: any }>;
+}
 
 export function WordPressTemplate(props: WordPressTemplateProps) {
   const { templates } = getConfig();
@@ -32,13 +42,12 @@ export function WordPressTemplate(props: WordPressTemplateProps) {
     console.error('No template found');
     return null;
   }
-
-  const { Component } = template;
-
+  // Remove unnecessary properties from component before rendering
+  const Component = cleanTemplate(template);
   const { data, error, loading } = res ?? {};
 
-  return React.cloneElement(
-    <Component />,
+  return React.createElement(
+    Component,
     { ...props, data, error, loading },
     null,
   );

--- a/packages/faust-nx/src/getTemplate.ts
+++ b/packages/faust-nx/src/getTemplate.ts
@@ -135,7 +135,7 @@ export function getPossibleTemplates(node: SeedNode) {
 export function getTemplate(
   seedNode: SeedNode,
   templates: { [key: string]: WordPressTemplate },
-) {
+): WordPressTemplate | null {
   const possibleTemplates = getPossibleTemplates(seedNode);
   // eslint-disable-next-line no-console
   console.log('possible templates: ', possibleTemplates);

--- a/packages/faust-nx/src/getWordPressProps.tsx
+++ b/packages/faust-nx/src/getWordPressProps.tsx
@@ -1,3 +1,4 @@
+import { ReactNode } from 'react';
 import { GetServerSidePropsContext, GetStaticPropsContext } from 'next';
 import type { DocumentNode } from 'graphql';
 import { SeedNode, SEED_QUERY } from './queries/seedQuery.js';
@@ -12,11 +13,10 @@ function isSSR(
   return (ctx as GetServerSidePropsContext).req !== undefined;
 }
 
-export interface WordPressTemplate {
-  query: DocumentNode;
-  variables: (seedNode: SeedNode) => { [key: string]: any };
-  Component: React.FC<{ [key: string]: any }>;
-}
+export type WordPressTemplate = ReactNode & {
+  query?: DocumentNode;
+  variables?: (seedNode: SeedNode) => { [key: string]: any };
+};
 
 export interface GetWordPressPropsConfig {
   ctx: GetServerSidePropsContext | GetStaticPropsContext;
@@ -80,7 +80,9 @@ export async function getWordPressProps(options: GetWordPressPropsConfig) {
   if (template.query) {
     await client.query({
       query: template.query,
-      variables: template?.variables ? template.variables(seedNode) : undefined,
+      variables: template?.variables
+        ? template?.variables(seedNode)
+        : undefined,
     });
   }
 


### PR DESCRIPTION
## Description

<!--
Include a summary of the change and some contextual information.
-->

This PR refactors the  current `wp-templates` to adopt a conventional way to access the `query` and `variables` from the component itself instead of individual exports.

## Related Issue(s):

<!--
Provide the GitHub issue(s) number for issue tracking purposes, use the following syntax:

- #1234
-->

https://wpengine.atlassian.net/browse/MERL-436

## Testing

<!--
Describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Also list any relevant details for your test configuration such as how to test the changes locally or in staging.
-->

1. Smoke test the wp-templates by previewing a page and a post

## Screenshots

<!--
If this is a visual change include relevant screenshots about the behavior of the application before and after this change.
-->

## Documentation Changes

<!--
List corresponding changes to the documentation.
-->

## Dependant PRs

<!--
List any dependent PR's that are awaiting review. Use the following syntax:

- #1234
-->
