### PR TITLE
Use jest version defined by project

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -71,7 +71,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@faustjs/core": "^0.15.7",
-        "@faustjs/next": "^0.15.7",
+        "@faustjs/next": "^0.15.8",
         "next": "^12.1.0",
         "normalize.css": "^8.0.1",
         "react": "^17.0.2",
@@ -15294,7 +15294,7 @@
     },
     "packages/next": {
       "name": "@faustjs/next",
-      "version": "0.15.7",
+      "version": "0.15.8",
       "license": "MIT",
       "dependencies": {
         "@faustjs/core": "^0.15.7",
@@ -17621,7 +17621,7 @@
       }
     },
     "plugins/faustwp": {
-      "version": "0.7.10"
+      "version": "0.7.11"
     }
   },
   "dependencies": {
@@ -24573,7 +24573,7 @@
         "graphql": "^16.5.0",
         "isomorphic-fetch": "^3.0.0",
         "jest": "^28.1.3",
-        "jest-environment-jsdom": "*",
+        "jest-environment-jsdom": "^29.0.1",
         "lodash": "^4.17.21",
         "next": "^12.1.6",
         "react": "^17.0.2",
@@ -28358,7 +28358,7 @@
       "version": "file:examples/next/getting-started",
       "requires": {
         "@faustjs/core": "^0.15.7",
-        "@faustjs/next": "^0.15.7",
+        "@faustjs/next": "^0.15.8",
         "@gqty/cli": "^3.1.0",
         "@types/node": "^17.0.17",
         "@types/react": "^17.0.34",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -42,7 +42,7 @@
     "test": "jest",
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage",
-    "test:coverage:ci": "npx jest@27.3.1 --ci --json --coverage --testLocationInResults --outputFile=report.json",
+    "test:coverage:ci": "jest --ci --json --coverage --testLocationInResults --outputFile=report.json",
     "ts": "tsc -p .",
     "ts:cjs": "tsc -p tsconfig-cjs.json",
     "ts:watch": "tsc -p . --watch",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -42,7 +42,7 @@
     "test": "jest",
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage",
-    "test:coverage:ci": "npx jest --ci --json --coverage --testLocationInResults --outputFile=report.json",
+    "test:coverage:ci": "npx jest@27.0.7 --ci --json --coverage --testLocationInResults --outputFile=report.json",
     "ts": "tsc -p .",
     "ts:cjs": "tsc -p tsconfig-cjs.json",
     "ts:watch": "tsc -p . --watch",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -42,7 +42,7 @@
     "test": "jest",
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage",
-    "test:coverage:ci": "npx jest@27.0.7 --ci --json --coverage --testLocationInResults --outputFile=report.json",
+    "test:coverage:ci": "npx jest@27.3.1 --ci --json --coverage --testLocationInResults --outputFile=report.json",
     "ts": "tsc -p .",
     "ts:cjs": "tsc -p tsconfig-cjs.json",
     "ts:watch": "tsc -p . --watch",

--- a/packages/faust-nx/package.json
+++ b/packages/faust-nx/package.json
@@ -40,7 +40,7 @@
     "dev": "npm run ts:watch",
     "package": "node ../../scripts/package.js",
     "prepublish": "npm run build",
-    "test:coverage:ci": "npx jest@28.1.3 --ci --json --coverage --testLocationInResults --outputFile=report.json",
+    "test:coverage:ci": "jest --ci --json --coverage --testLocationInResults --outputFile=report.json",
     "test:coverage": "jest --coverage",
     "test:watch": "jest --watch",
     "test": "jest",

--- a/packages/faust-nx/package.json
+++ b/packages/faust-nx/package.json
@@ -40,7 +40,7 @@
     "dev": "npm run ts:watch",
     "package": "node ../../scripts/package.js",
     "prepublish": "npm run build",
-    "test:coverage:ci": "npx jest --ci --json --coverage --testLocationInResults --outputFile=report.json",
+    "test:coverage:ci": "npx jest@28.1.3 --ci --json --coverage --testLocationInResults --outputFile=report.json",
     "test:coverage": "jest --coverage",
     "test:watch": "jest --watch",
     "test": "jest",

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -48,7 +48,7 @@
     "lint": "eslint \"src/**/*.{ts,tsx}\" --parser-options=project:tsconfig.json",
     "package": "node ../../scripts/package.js",
     "prepublish": "npm run build",
-    "test:coverage:ci": "npx jest --ci --json --coverage --testLocationInResults --outputFile=report.json",
+    "test:coverage:ci": "npx jest@27.3.1 --ci --json --coverage --testLocationInResults --outputFile=report.json",
     "test:coverage": "jest --coverage",
     "test:watch": "jest --watch",
     "test": "jest",

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -48,7 +48,7 @@
     "lint": "eslint \"src/**/*.{ts,tsx}\" --parser-options=project:tsconfig.json",
     "package": "node ../../scripts/package.js",
     "prepublish": "npm run build",
-    "test:coverage:ci": "npx jest@27.3.1 --ci --json --coverage --testLocationInResults --outputFile=report.json",
+    "test:coverage:ci": "jest --ci --json --coverage --testLocationInResults --outputFile=report.json",
     "test:coverage": "jest --coverage",
     "test:watch": "jest --watch",
     "test": "jest",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -22,7 +22,7 @@
     "test": "jest",
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage",
-    "test:coverage:ci": "npx jest --ci --json --coverage --testLocationInResults --outputFile=report.json",
+    "test:coverage:ci": "npx jest@27.3.1 --ci --json --coverage --testLocationInResults --outputFile=report.json",
     "ts": "tsc -p .",
     "ts:cjs": "tsc -p tsconfig-cjs.json",
     "ts:watch": "tsc -p . --watch",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -22,7 +22,7 @@
     "test": "jest",
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage",
-    "test:coverage:ci": "npx jest@27.3.1 --ci --json --coverage --testLocationInResults --outputFile=report.json",
+    "test:coverage:ci": "jest --ci --json --coverage --testLocationInResults --outputFile=report.json",
     "ts": "tsc -p .",
     "ts:cjs": "tsc -p tsconfig-cjs.json",
     "ts:watch": "tsc -p . --watch",


### PR DESCRIPTION
Signed-off-by: Joe Fusco <joe.fusco@wpengine.com>

## Description

These proposed changes ensure that our CI/CD actions are using the jest version defined by the project. This is in an effort to clear the jest related issues with #986  