### PR TITLE
Remove the `rm package-lock.json` step from the release packages action

### DIFF
--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -21,10 +21,6 @@ jobs:
         with:
           node-version: 16.x
 
-      - name: Remove package-lock.json
-        run: |
-          rm package-lock.json
-
       - name: Install Dependencies
         run: npm install
 


### PR DESCRIPTION
## Description

This pr removes the `rm package-lock.json` step from the release packages action as it was not removed in #1013