### PR TITLE
Add `front-page` and `home` templates

### DIFF
--- a/examples/next/faust-nx/pages/index.tsx
+++ b/examples/next/faust-nx/pages/index.tsx
@@ -1,3 +1,10 @@
-export default function Page() {
-  return <div>Home</div>;
+import { getWordPressProps, WordPressTemplate } from 'faust-nx';
+import { GetStaticPropsContext } from 'next';
+
+export default function Page(props: any) {
+  return <WordPressTemplate {...props} />;
+}
+
+export function getStaticProps(ctx: GetStaticPropsContext) {
+  return getWordPressProps({ ctx });
 }

--- a/examples/next/faust-nx/wp-templates/front-page.tsx
+++ b/examples/next/faust-nx/wp-templates/front-page.tsx
@@ -1,0 +1,3 @@
+export default function Component() {
+  return <>My home page</>;
+}

--- a/examples/next/faust-nx/wp-templates/index.ts
+++ b/examples/next/faust-nx/wp-templates/index.ts
@@ -1,9 +1,11 @@
-import page from "./page";
-import archive from "./archive";
-import single from "./single";
+import page from './page';
+import archive from './archive';
+import single from './single';
+import frontPage from './front-page';
 
 export default {
   page,
   archive,
   single,
+  'front-page': frontPage,
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -17622,6 +17622,21 @@
     },
     "plugins/faustwp": {
       "version": "0.7.11"
+    },
+    "packages/faust-nx/node_modules/@next/swc-freebsd-x64": {
+      "version": "12.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-freebsd-x64/-/swc-freebsd-x64-12.2.3.tgz",
+      "integrity": "sha512-V4bZU1qBFkULTPW53phY8ypioh3EERzHu9YKAasm9RxU4dj+8c/4s60y+kbFkFEEpIUgEU6yNuYZRR4lHHbUGA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
     }
   },
   "dependencies": {

--- a/packages/faust-nx/src/components/WordPressTemplate.tsx
+++ b/packages/faust-nx/src/components/WordPressTemplate.tsx
@@ -9,8 +9,8 @@ import { SeedNode, SEED_QUERY } from '../queries/seedQuery.js';
 import { getQueryParam } from '../utils/convert.js';
 
 export type WordPressTemplateProps = PropsWithChildren<{
-  __SEED_NODE__?: SeedNode;
-  __TEMPLATE_QUERY_DATA__?: any;
+  __SEED_NODE__: SeedNode | null;
+  __TEMPLATE_QUERY_DATA__: any | null;
 }>;
 
 function cleanTemplate(
@@ -32,9 +32,9 @@ export function WordPressTemplate(props: WordPressTemplateProps) {
     __TEMPLATE_QUERY_DATA__: templateQueryDataProp,
   } = props;
 
-  const [seedNode, setSeedNode] = useState<SeedNode | undefined>(seedNodeProp);
+  const [seedNode, setSeedNode] = useState<SeedNode | null>(seedNodeProp);
   const template = getTemplate(seedNode, templates);
-  const [data, setData] = useState<any | undefined>(templateQueryDataProp);
+  const [data, setData] = useState<any | null>(templateQueryDataProp);
   const [loading, setLoading] = useState(template === null);
   const [isPreview, setIsPreview] = useState<boolean | null>(
     templateQueryDataProp ? false : null,

--- a/packages/faust-nx/src/getTemplate.ts
+++ b/packages/faust-nx/src/getTemplate.ts
@@ -5,6 +5,16 @@ import { hooks } from './hooks/index.js';
 export function getPossibleTemplates(node: SeedNode) {
   let possibleTemplates: string[] = [];
 
+  // Front page
+  if (node.isFrontPage) {
+    possibleTemplates.push('front-page');
+  }
+
+  // Blog page
+  if (node.isPostsPage) {
+    possibleTemplates.push('home');
+  }
+
   // CPT archive page
   // eslint-disable-next-line no-underscore-dangle
   if (node.__typename === 'ContentType' && node.isPostsPage === false) {
@@ -133,7 +143,7 @@ export function getPossibleTemplates(node: SeedNode) {
 }
 
 export function getTemplate(
-  seedNode: SeedNode | undefined,
+  seedNode: SeedNode | null | undefined,
   templates: { [key: string]: WordPressTemplate },
 ): WordPressTemplate | null {
   if (!seedNode) {

--- a/packages/faust-nx/src/getWordPressProps.tsx
+++ b/packages/faust-nx/src/getWordPressProps.tsx
@@ -92,8 +92,12 @@ export async function getWordPressProps(options: GetWordPressPropsConfig) {
   // eslint-disable-next-line @typescript-eslint/no-unsafe-return
   return addApolloState(client, {
     props: {
-      __SEED_NODE__: seedNode,
-      __TEMPLATE_QUERY_DATA__: templateQueryRes?.data,
+      /**
+       * The following props may be null coalesced as an "undefined"
+       * value is not able to be serialized
+       */
+      __SEED_NODE__: seedNode ?? null,
+      __TEMPLATE_QUERY_DATA__: templateQueryRes?.data ?? null,
     },
   });
 }

--- a/packages/faust-nx/src/queries/seedQuery.ts
+++ b/packages/faust-nx/src/queries/seedQuery.ts
@@ -41,6 +41,7 @@ export const SEED_QUERY = gql`
     ...TermNode
     ...ContentNode
     ...MediaItem
+    ...Page
   }
 
   fragment DatabaseIdentifier on DatabaseIdentifier {
@@ -54,6 +55,15 @@ export const SEED_QUERY = gql`
 
   fragment ContentType on ContentType {
     name
+    isFrontPage
+
+    # This is currently broken. The home page (blog page) can not be
+    # resolved when set to a custom page until the below issue is resolved.
+    # Link: https://github.com/wp-graphql/wp-graphql/issues/2514
+    isPostsPage
+  }
+
+  fragment Page on Page {
     isFrontPage
     isPostsPage
   }


### PR DESCRIPTION
## Description

This PR adds the `front-page` and `home` templates as possible templates in template hierarchy solution. This PR also drops the requirement of having a `query` in your WP Template.
