### PR TITLE
Ability to publish FaustNX packages

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -8,5 +8,5 @@
   "access": "public",
   "baseBranch": "canary",
   "updateInternalDependencies": "patch",
-  "ignore": ["next-headless-getting-started", "faust-nx", "faust-nx-getting-started"]
+  "ignore": ["next-headless-getting-started", "faust-nx-getting-started"]
 }

--- a/.changeset/slow-windows-march.md
+++ b/.changeset/slow-windows-march.md
@@ -1,0 +1,6 @@
+---
+'faust-nx': patch
+'faust-nx-cli': patch
+---
+
+Publish FaustNX packages to NPM

--- a/packages/faust-nx-cli/package.json
+++ b/packages/faust-nx-cli/package.json
@@ -1,7 +1,6 @@
 {
   "name": "faust-nx-cli",
   "version": "0.0.1",
-  "private": true,
   "description": "FaustNX Cli",
   "main": "dist/index.js",
   "type": "module",

--- a/packages/faust-nx/package.json
+++ b/packages/faust-nx/package.json
@@ -1,7 +1,6 @@
 {
   "name": "faust-nx",
   "version": "0.0.1",
-  "private": true,
   "description": "Experimental next version of Faust.js",
   "main": "dist/cjs/index.js",
   "module": "dist/mjs/index.js",


### PR DESCRIPTION
## Description

This PR removes the `private` property from the `faust-nx` and `faust-nx-cli` packages so that they can be published to NPM.