### PR TITLE
Fix missing jest build issue

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -42,7 +42,7 @@
     "test": "jest",
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage",
-    "test:coverage:ci": "jest --ci --json --coverage --testLocationInResults --outputFile=report.json",
+    "test:coverage:ci": "npx jest --ci --json --coverage --testLocationInResults --outputFile=report.json",
     "ts": "tsc -p .",
     "ts:cjs": "tsc -p tsconfig-cjs.json",
     "ts:watch": "tsc -p . --watch",

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -48,7 +48,7 @@
     "lint": "eslint \"src/**/*.{ts,tsx}\" --parser-options=project:tsconfig.json",
     "package": "node ../../scripts/package.js",
     "prepublish": "npm run build",
-    "test:coverage:ci": "jest --ci --json --coverage --testLocationInResults --outputFile=report.json",
+    "test:coverage:ci": "npx jest --ci --json --coverage --testLocationInResults --outputFile=report.json",
     "test:coverage": "jest --coverage",
     "test:watch": "jest --watch",
     "test": "jest",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -22,7 +22,7 @@
     "test": "jest",
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage",
-    "test:coverage:ci": "jest --ci --json --coverage --testLocationInResults --outputFile=report.json",
+    "test:coverage:ci": "npx jest --ci --json --coverage --testLocationInResults --outputFile=report.json",
     "ts": "tsc -p .",
     "ts:cjs": "tsc -p tsconfig-cjs.json",
     "ts:watch": "tsc -p . --watch",


### PR DESCRIPTION
Signed-off-by: Joe Fusco <joe.fusco@wpengine.com>

## Description

When faust-nx was added to this project, `npx` was removed from the `test:coverage:ci` script as it was causing CI/CD issues.

Since faust-nx has been removed from this project, builds are failing as jest cannot be found.

These changes add `npx` back which resolves the error.