### PR TITLE
Use npm ci

### DIFF
--- a/.github/workflows/e2e-next-example.yml
+++ b/.github/workflows/e2e-next-example.yml
@@ -41,7 +41,7 @@ jobs:
       - name: install and build packages
         working-directory: ./
         run: |
-          npm install
+          npm ci
           npm run build
       # To ensure PR changes are tested accurately, we replace the
       # faust node_modules downloaded from NPM with the faust packages

--- a/.github/workflows/e2e-test-plugin.yml
+++ b/.github/workflows/e2e-test-plugin.yml
@@ -18,7 +18,7 @@ jobs:
           node-version: '16'
       - name: Install NPM Deps
         run: |
-          npm install
+          npm ci
           npm run build
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/lint-packages.yml
+++ b/.github/workflows/lint-packages.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: '16'
-      - run: npm install
+      - run: npm ci
       - run: npm run build
       - run: npm run lint
         continue-on-error: FALSE

--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -22,7 +22,7 @@ jobs:
           node-version: 16.x
 
       - name: Install Dependencies
-        run: npm install
+        run: npm ci
 
       - name: Create .npmrc
         run: |

--- a/.github/workflows/test-packages.yml
+++ b/.github/workflows/test-packages.yml
@@ -22,7 +22,7 @@ jobs:
           node-version: '16'
 
       - name: Install
-        run: npm install
+        run: npm ci
 
       - run: npm run build
 


### PR DESCRIPTION
Signed-off-by: Joe Fusco <joe.fusco@wpengine.com>

## Description

These changes update the project's GitHub actions to use `npm ci` [as recommended by npmjs.org](https://docs.npmjs.com/cli/v8/commands/npm-ci) for usage within continuous integration environments.