### PR TITLE
Use jest version defined by project

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -42,7 +42,7 @@
     "test": "jest",
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage",
-    "test:coverage:ci": "npx jest --ci --json --coverage --testLocationInResults --outputFile=report.json",
+    "test:coverage:ci": "jest --ci --json --coverage --testLocationInResults --outputFile=report.json",
     "ts": "tsc -p .",
     "ts:cjs": "tsc -p tsconfig-cjs.json",
     "ts:watch": "tsc -p . --watch",

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -48,7 +48,7 @@
     "lint": "eslint \"src/**/*.{ts,tsx}\" --parser-options=project:tsconfig.json",
     "package": "node ../../scripts/package.js",
     "prepublish": "npm run build",
-    "test:coverage:ci": "npx jest --ci --json --coverage --testLocationInResults --outputFile=report.json",
+    "test:coverage:ci": "jest --ci --json --coverage --testLocationInResults --outputFile=report.json",
     "test:coverage": "jest --coverage",
     "test:watch": "jest --watch",
     "test": "jest",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -22,7 +22,7 @@
     "test": "jest",
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage",
-    "test:coverage:ci": "npx jest --ci --json --coverage --testLocationInResults --outputFile=report.json",
+    "test:coverage:ci": "jest --ci --json --coverage --testLocationInResults --outputFile=report.json",
     "ts": "tsc -p .",
     "ts:cjs": "tsc -p tsconfig-cjs.json",
     "ts:watch": "tsc -p . --watch",


### PR DESCRIPTION
Signed-off-by: Joe Fusco <joe.fusco@wpengine.com>

## Description

These proposed changes ensure that our CI/CD actions are using the jest version defined by the project. This is in an effort to clear the jest related issues with https://github.com/wpengine/faustjs/pull/1043.

This issue was seen before when adding new packages - https://github.com/wpengine/faustjs/pull/1003

And later reverted when removing those packages - https://github.com/wpengine/faustjs/pull/1025

## Dependent PRs

- https://github.com/wpengine/faustjs/pull/1043
