### PR TITLE
Adds the missing changeset to fix the `Type `{}` is missing...` bug

### DIFF
--- a/.changeset/angry-cameras-stare.md
+++ b/.changeset/angry-cameras-stare.md
@@ -1,0 +1,5 @@
+---
+'@faustjs/next': patch
+---
+
+Fixes the `Type '{}' is missing the following properties from type...` bug some users may experience when building a Faust.js app. #1013


### PR DESCRIPTION
## Description

This PR adds the appropriate changeset that was left out when fixing the `Type '{}' is missing...` bug in #1013 ([`packages/next/src/server/getProps.tsx`](https://github.com/wpengine/faustjs/pull/1013/files#diff-89624db982206bbb7e486fe2bf3ab218bde8d45c7749fb44a7882297f45e71e9R51-R52))