### PR TITLE
Download Changelogs

### DIFF
--- a/internal/legacy.faustjs.org/.gitignore
+++ b/internal/legacy.faustjs.org/.gitignore
@@ -3,6 +3,7 @@
 
 # Production
 /build
+.changelogs
 
 # Generated files
 .docusaurus

--- a/internal/legacy.faustjs.org/docs/changelog/core.mdx
+++ b/internal/legacy.faustjs.org/docs/changelog/core.mdx
@@ -4,13 +4,13 @@ title: Changelog for @faustjs/core
 description: A central place for Faust.js changelogs
 ---
 
-import Changelog, {toc as ChangelogTOC} from "@site/../../packages/core/CHANGELOG.md"
+import Changelog, { toc as ChangelogTOC } from '@site/.changelogs/core.md';
 
 <Changelog />
 
 export const toc = (() => {
-	return ChangelogTOC.map((item) => {
-		item.children = [];
-		return item;
-	});
+  return ChangelogTOC.map((item) => {
+    item.children = [];
+    return item;
+  });
 })();

--- a/internal/legacy.faustjs.org/docs/changelog/faustwp.mdx
+++ b/internal/legacy.faustjs.org/docs/changelog/faustwp.mdx
@@ -4,13 +4,13 @@ title: Changelog for FaustWP
 description: A central place for Faust.js changelogs
 ---
 
-import Changelog, {toc as ChangelogTOC} from "@site/../../plugins/faustwp/CHANGELOG.md"
+import Changelog, { toc as ChangelogTOC } from '@site/.changelogs/faustwp.md';
 
 <Changelog />
 
 export const toc = (() => {
-	return ChangelogTOC.map((item) => {
-		item.children = [];
-		return item;
-	});
+  return ChangelogTOC.map((item) => {
+    item.children = [];
+    return item;
+  });
 })();

--- a/internal/legacy.faustjs.org/docs/changelog/next.mdx
+++ b/internal/legacy.faustjs.org/docs/changelog/next.mdx
@@ -4,13 +4,13 @@ title: Changelog for @faustjs/next
 description: A central place for Faust.js changelogs
 ---
 
-import Changelog, {toc as ChangelogTOC} from "@site/../../packages/next/CHANGELOG.md"
+import Changelog, { toc as ChangelogTOC } from '@site/.changelogs/next.md';
 
 <Changelog />
 
 export const toc = (() => {
-	return ChangelogTOC.map((item) => {
-		item.children = [];
-		return item;
-	});
+  return ChangelogTOC.map((item) => {
+    item.children = [];
+    return item;
+  });
 })();

--- a/internal/legacy.faustjs.org/docs/changelog/react.mdx
+++ b/internal/legacy.faustjs.org/docs/changelog/react.mdx
@@ -4,13 +4,13 @@ title: Changelog for @faustjs/react
 description: A central place for Faust.js changelogs
 ---
 
-import Changelog, {toc as ChangelogTOC} from "@site/../../packages/react/CHANGELOG.md"
+import Changelog, { toc as ChangelogTOC } from '@site/.changelogs/react.md';
 
 <Changelog />
 
 export const toc = (() => {
-	return ChangelogTOC.map((item) => {
-		item.children = [];
-		return item;
-	});
+  return ChangelogTOC.map((item) => {
+    item.children = [];
+    return item;
+  });
 })();

--- a/internal/legacy.faustjs.org/package-lock.json
+++ b/internal/legacy.faustjs.org/package-lock.json
@@ -14,6 +14,7 @@
         "@svgr/webpack": "^6.4.0",
         "clsx": "^1.1.1",
         "file-loader": "^6.2.0",
+        "isomorphic-fetch": "^3.0.0",
         "prism-react-renderer": "^1.2.1",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
@@ -4861,6 +4862,25 @@
         "node-fetch": "2.6.7"
       }
     },
+    "node_modules/cross-fetch/node_modules/node-fetch": {
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -7339,6 +7359,34 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/isomorphic-fetch": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-3.0.0.tgz",
+      "integrity": "sha512-qvUtwJ3j6qwsF3jLxkZ72qCgjMysPzDfeV240JHiGZsANBYd+EEuu35v7dfrJ9Up0Ak07D7GGSkGhCHTqg/5wA==",
+      "dependencies": {
+        "node-fetch": "^2.6.1",
+        "whatwg-fetch": "^3.4.1"
+      }
+    },
+    "node_modules/isomorphic-fetch/node_modules/node-fetch": {
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/jest-util": {
       "version": "29.1.2",
       "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.1.2.tgz",
@@ -7971,25 +8019,6 @@
       "integrity": "sha512-wo2DpQkQp7Sjm2A0cq+sN7EHKO6Sl0ctXeBdFZrL9T9+UywORbufTcTZxom8YqpLQt/FqNMUkOpkZrJVYSKD3A==",
       "dependencies": {
         "lodash": "^4.17.21"
-      }
-    },
-    "node_modules/node-fetch": {
-      "version": "2.6.7",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
       }
     },
     "node_modules/node-forge": {
@@ -12242,6 +12271,11 @@
         "node": ">=0.8.0"
       }
     },
+    "node_modules/whatwg-fetch": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.2.tgz",
+      "integrity": "sha512-bJlen0FcuU/0EMLrdbJ7zOnW6ITZLrZMIarMUVmdKtsGvZna8vxKYaexICWPfZ8qwf9fzNq+UEIZrnSaApt6RA=="
+    },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
@@ -15983,6 +16017,16 @@
       "integrity": "sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==",
       "requires": {
         "node-fetch": "2.6.7"
+      },
+      "dependencies": {
+        "node-fetch": {
+          "version": "2.6.7",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+          "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+          "requires": {
+            "whatwg-url": "^5.0.0"
+          }
+        }
       }
     },
     "cross-spawn": {
@@ -17742,6 +17786,25 @@
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
       "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg=="
     },
+    "isomorphic-fetch": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-3.0.0.tgz",
+      "integrity": "sha512-qvUtwJ3j6qwsF3jLxkZ72qCgjMysPzDfeV240JHiGZsANBYd+EEuu35v7dfrJ9Up0Ak07D7GGSkGhCHTqg/5wA==",
+      "requires": {
+        "node-fetch": "^2.6.1",
+        "whatwg-fetch": "^3.4.1"
+      },
+      "dependencies": {
+        "node-fetch": {
+          "version": "2.6.7",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+          "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+          "requires": {
+            "whatwg-url": "^5.0.0"
+          }
+        }
+      }
+    },
     "jest-util": {
       "version": "29.1.2",
       "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.1.2.tgz",
@@ -18211,14 +18274,6 @@
       "integrity": "sha512-wo2DpQkQp7Sjm2A0cq+sN7EHKO6Sl0ctXeBdFZrL9T9+UywORbufTcTZxom8YqpLQt/FqNMUkOpkZrJVYSKD3A==",
       "requires": {
         "lodash": "^4.17.21"
-      }
-    },
-    "node-fetch": {
-      "version": "2.6.7",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
-      "requires": {
-        "whatwg-url": "^5.0.0"
       }
     },
     "node-forge": {
@@ -21207,6 +21262,11 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.4.tgz",
       "integrity": "sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg=="
+    },
+    "whatwg-fetch": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.2.tgz",
+      "integrity": "sha512-bJlen0FcuU/0EMLrdbJ7zOnW6ITZLrZMIarMUVmdKtsGvZna8vxKYaexICWPfZ8qwf9fzNq+UEIZrnSaApt6RA=="
     },
     "whatwg-url": {
       "version": "5.0.0",

--- a/internal/legacy.faustjs.org/package.json
+++ b/internal/legacy.faustjs.org/package.json
@@ -21,6 +21,7 @@
     "@svgr/webpack": "^6.4.0",
     "clsx": "^1.1.1",
     "file-loader": "^6.2.0",
+    "isomorphic-fetch": "^3.0.0",
     "prism-react-renderer": "^1.2.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",

--- a/internal/legacy.faustjs.org/package.json
+++ b/internal/legacy.faustjs.org/package.json
@@ -4,12 +4,13 @@
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",
-    "start": "docusaurus start",
-    "build": "docusaurus build",
+    "start": "npm run downloadChangelogs && docusaurus start",
+    "build": "npm run downloadChangelogs && docusaurus build",
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",
     "clear": "docusaurus clear",
     "serve": "docusaurus serve",
+    "downloadChangelogs": "node ./scripts/downloadChangelogs.js",
     "serve:prod": "npm run serve -- --build --port 8080 --host 0.0.0.0",
     "write-translations": "docusaurus write-translations",
     "write-heading-ids": "docusaurus write-heading-ids"

--- a/internal/legacy.faustjs.org/scripts/downloadChangelogs.js
+++ b/internal/legacy.faustjs.org/scripts/downloadChangelogs.js
@@ -1,0 +1,47 @@
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const fs = require('fs');
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const fetch = require('isomorphic-fetch');
+
+void (async () => {
+  const changelogs = [
+    {
+      url: 'https://raw.githubusercontent.com/wpengine/faustjs/main/packages/core/CHANGELOG.md',
+      filename: 'core.md',
+    },
+    {
+      url: 'https://raw.githubusercontent.com/wpengine/faustjs/main/packages/next/CHANGELOG.md',
+      filename: 'next.md',
+    },
+    {
+      url: 'https://raw.githubusercontent.com/wpengine/faustjs/main/packages/react/CHANGELOG.md',
+      filename: 'react.md',
+    },
+    {
+      url: 'https://raw.githubusercontent.com/wpengine/faustjs/main/plugins/faustwp/CHANGELOG.md',
+      filename: 'faustwp.md',
+    },
+  ];
+
+  try {
+    if (!fs.existsSync('./.changelogs')) {
+      fs.mkdirSync('./.changelogs');
+    }
+
+    await Promise.all(
+      changelogs.map(async (changelog) => {
+        const res = await fetch(changelog.url);
+        fs.writeFileSync(
+          `./.changelogs/${changelog.filename}`,
+          await res.text(),
+        );
+      }),
+    );
+
+    // eslint-disable-next-line no-console
+    console.log('Successfully downloaded changelogs');
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.log('There was an error downloading changelogs', err);
+  }
+})();


### PR DESCRIPTION
## Description

This PR introduces a script in the docs site that first downloads the changelogs from the Git repo and places them in a `.changelogs` directory for consuption for our Docusaurus app. This approach has changed from pulling the changelogs from the relative directory above because we are now using an Atlas site with the root directory specified as `internal/website`. This means that our Atlas instance will no longer have access to the whole monorepo, instead just the website files.
