### PR TITLE
Remove WP from human readable text in plugin

### DIFF
--- a/.changeset/wicked-buttons-relax.md
+++ b/.changeset/wicked-buttons-relax.md
@@ -1,0 +1,5 @@
+---
+'@faustwp/wordpress-plugin': minor
+---
+
+Renamed plugin from `FaustWP` to `Faust`.

--- a/.changeset/wicked-lamps-hang.md
+++ b/.changeset/wicked-lamps-hang.md
@@ -1,0 +1,5 @@
+---
+'@faustwp/wordpress-plugin': minor
+---
+
+Updated settings menu text from _Headless_ to _Faust_.

--- a/internal/faustjs.org/docs/faustwp/settings.mdx
+++ b/internal/faustjs.org/docs/faustwp/settings.mdx
@@ -1,10 +1,10 @@
 ---
 slug: /faustwp/settings
-title: FaustWP Plugin Headless Settings
-description: This section describes the various WP Plugin Headless Settings.
+title: Faust WordPress Plugin Settings
+description: This section describes the various WordPress Plugin Settings.
 ---
 
-The `Headless` page of the FaustWP Plugin (located within the WP Admin `Settings` Sidebar)
+The `Faust` page of the Faust WordPress Plugin (located within the WP Admin `Settings` Sidebar)
 allows you to customize the behavior of the plugin by configuring certain features. We explain those features in detail:
 
 

--- a/internal/faustjs.org/docs/next/getting-started.mdx
+++ b/internal/faustjs.org/docs/next/getting-started.mdx
@@ -71,13 +71,13 @@ Once the necessary plugins have been installed, open the `.env.local` file you c
 # Your WordPress site URL
 NEXT_PUBLIC_WORDPRESS_URL=https://headlessfw.wpengine.com
 
-# Plugin secret found in WordPress Settings->Headless
+# Plugin secret found in WordPress Settings->Faust
 FAUSTWP_SECRET_KEY=YOUR_PLUGIN_SECRET
 ```
 
 Update the `NEXT_PUBLIC_WORDPRESS_URL` value with your WordPress site URL (be sure to include `http://` or `https://`).
 
-Additionally, update the `FAUSTWP_SECRET_KEY` value with the secret key found in Settings → Headless in your WordPress admin area to support previews.
+Additionally, update the `FAUSTWP_SECRET_KEY` value with the secret key found in Settings → Faust in your WordPress admin area to support previews.
 
 <img
   src="/docs/img/headless-admin-secret.png"

--- a/internal/faustjs.org/docs/tutorial/setup-faustjs.mdx
+++ b/internal/faustjs.org/docs/tutorial/setup-faustjs.mdx
@@ -93,7 +93,7 @@ NEXT_PUBLIC_WORDPRESS_URL=http://your-wordpress-site.com
 FAUSTWP_SECRET_KEY=YOUR_PLUGIN_SECRET
 ```
 
-Replace the `NEXT_PUBLIC_WORDPRESS_URL` value with the URL of your WordPress site. Additionally, grab the Headless Secret from WordPress Settings -> Headless and replace it with the `FAUSTWP_SECRET_KEY` value.
+Replace the `NEXT_PUBLIC_WORDPRESS_URL` value with the URL of your WordPress site. Additionally, grab the Headless Secret from WordPress Settings -> Faust and replace it with the `FAUSTWP_SECRET_KEY` value.
 
 <img
   src="/docs/img/headless-admin-secret.png"

--- a/internal/faustjs.org/docs/tutorial/setup-faustjs.mdx
+++ b/internal/faustjs.org/docs/tutorial/setup-faustjs.mdx
@@ -89,7 +89,7 @@ You'll also need a `.env.local` file to hold your environment variables:
 # Your WordPress site URL
 NEXT_PUBLIC_WORDPRESS_URL=http://your-wordpress-site.com
 
-# Plugin secret found in WordPress Settings->Headless
+# Plugin secret found in WordPress Settings->Faust
 FAUSTWP_SECRET_KEY=YOUR_PLUGIN_SECRET
 ```
 

--- a/internal/legacy.faustjs.org/docs/next/guides/post-page-previews.mdx
+++ b/internal/legacy.faustjs.org/docs/next/guides/post-page-previews.mdx
@@ -16,7 +16,7 @@ Your headless secret is a value that authenticates requests to WordPress. This s
 
 ### Copy your Headless Secret
 
-Find your Headless Secre in **WP-Admin -> Settings -> Headless**. Copy this value:
+Find your Headless Secret in **WP-Admin -> Settings -> Headless**. Copy this value:
 
 <img
   src="/docs/img/headless-admin-secret.png"

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,8 +45,8 @@
       "version": "0.1.0",
       "dependencies": {
         "@apollo/client": "^3.6.6",
-        "@faustwp/cli": "0.0.1",
-        "@faustwp/core": "0.0.1",
+        "@faustwp/cli": "0.1.0",
+        "@faustwp/core": "0.1.0",
         "@wordpress/base-styles": "^4.7.0",
         "@wordpress/block-library": "^7.13.0",
         "classnames": "^2.3.1",
@@ -1194,6 +1194,10 @@
     },
     "node_modules/@faustwp/getting-started-example": {
       "resolved": "examples/next/faustwp-getting-started",
+      "link": true
+    },
+    "node_modules/@faustwp/wordpress-plugin": {
+      "resolved": "plugins/faustwp",
       "link": true
     },
     "node_modules/@floating-ui/core": {
@@ -13581,7 +13585,7 @@
     },
     "packages/faustwp-cli": {
       "name": "@faustwp/cli",
-      "version": "0.0.1",
+      "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.1.2",
@@ -13593,7 +13597,7 @@
         "uuid": "8.3.2"
       },
       "bin": {
-        "faustwp": "dist/index.js"
+        "faust": "dist/index.js"
       },
       "devDependencies": {
         "@types/configstore": "^6.0.0",
@@ -13679,7 +13683,7 @@
     },
     "packages/faustwp-core": {
       "name": "@faustwp/core",
-      "version": "0.0.1",
+      "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
         "@wordpress/hooks": "^3.14.0",
@@ -13788,9 +13792,7 @@
         "react-dom": ">=17.0.2"
       }
     },
-    "plugins/faustwp": {
-      "extraneous": true
-    }
+    "plugins/faustwp": {}
   },
   "dependencies": {
     "@ampproject/remapping": {
@@ -14696,7 +14698,7 @@
         "chalk": "^4.1.2",
         "configstore": "^6.0.0",
         "dotenv-flow": "^3.2.0",
-        "isomorphic-fetch": "*",
+        "isomorphic-fetch": "^3.0.0",
         "node-fetch": "^2.6.7",
         "prompt": "1.3.0",
         "rimraf": "^3.0.2",
@@ -14782,8 +14784,8 @@
       "version": "file:examples/next/faustwp-getting-started",
       "requires": {
         "@apollo/client": "^3.6.6",
-        "@faustwp/cli": "0.0.1",
-        "@faustwp/core": "0.0.1",
+        "@faustwp/cli": "0.1.0",
+        "@faustwp/core": "0.1.0",
         "@wordpress/base-styles": "^4.7.0",
         "@wordpress/block-library": "^7.13.0",
         "classnames": "^2.3.1",
@@ -14792,6 +14794,9 @@
         "react-dom": "^17.0.2",
         "sass": "^1.54.9"
       }
+    },
+    "@faustwp/wordpress-plugin": {
+      "version": "file:plugins/faustwp"
     },
     "@floating-ui/core": {
       "version": "1.0.1",

--- a/plugins/faustwp/faustwp.php
+++ b/plugins/faustwp/faustwp.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Faust
  * Plugin URI: https://faustjs.org/
- * Description: Companion plugin for working with Faust, the Headless WordPress Framework.
+ * Description: Plugin for working with Faust, the Headless WordPress Framework.
  * Author: WP Engine
  * Author URI: https://wpengine.com/
  * License: GPLv2 or later

--- a/plugins/faustwp/faustwp.php
+++ b/plugins/faustwp/faustwp.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * Plugin Name: FaustWP
+ * Plugin Name: Faust
  * Plugin URI: https://faustjs.org/
- * Description: Plugin for working with Faust.js, the Headless WordPress Framework.
+ * Description: Companion plugin for working with Faust, the Headless WordPress Framework.
  * Author: WP Engine
  * Author URI: https://wpengine.com/
  * License: GPLv2 or later

--- a/plugins/faustwp/includes/detect-conflicts/callbacks.php
+++ b/plugins/faustwp/includes/detect-conflicts/callbacks.php
@@ -35,8 +35,8 @@ function show_warning() {
 			<p>%s</p>
 		</div>',
 		esc_attr( NOTICE_ID ),
-		esc_html__( 'FaustWP detected incompatible plugins', 'faustwp' ),
-		esc_html__( 'The following active plugins are known to conflict with FaustWP and may cause unexpected behavior:', 'faustwp' ),
+		esc_html__( 'Faust detected incompatible plugins', 'faustwp' ),
+		esc_html__( 'The following active plugins are known to conflict with Faust and may cause unexpected behavior:', 'faustwp' ),
 		esc_html( implode( ', ', $warnings ) )
 	);
 }

--- a/plugins/faustwp/includes/detect-conflicts/functions.php
+++ b/plugins/faustwp/includes/detect-conflicts/functions.php
@@ -50,7 +50,7 @@ function get_plugin_conflicts( $conflict_list = null, $include_dismissed = false
 /**
  * Determines whether the plugin conflicts warning should be shown.
  *
- * The warning is only shown on the plugins page and FaustWP settings page
+ * The warning is only shown on the plugins page and Faust settings page
  * when the user has the activate_plugins capability and there are active
  * conflicts.
  *
@@ -119,4 +119,3 @@ function dismiss_active_conflicts( $conflict_list = null ) {
 
 	update_user_meta( get_current_user_id(), DISMISSED_CONFLICTS_META_KEY, $dismissed );
 }
-

--- a/plugins/faustwp/includes/settings/callbacks.php
+++ b/plugins/faustwp/includes/settings/callbacks.php
@@ -25,8 +25,8 @@ add_action( 'admin_menu', __NAMESPACE__ . '\\register_settings_menu' );
 function register_settings_menu() {
 	add_submenu_page(
 		'options-general.php',
-		__( 'Headless', 'faustwp' ),
-		__( 'Headless', 'faustwp' ),
+		__( 'Faust', 'faustwp' ),
+		__( 'Faust', 'faustwp' ),
 		'manage_options',
 		'faustwp-settings',
 		__NAMESPACE__ . '\\display_settings_page'

--- a/plugins/faustwp/includes/settings/callbacks.php
+++ b/plugins/faustwp/includes/settings/callbacks.php
@@ -127,16 +127,16 @@ function register_settings_fields() {
 
 add_filter( 'sanitize_option_faustwp_settings', __NAMESPACE__ . '\\sanitize_faustwp_settings', 10, 2 );
 /**
- * Validates and sanitizes FaustWP settings.
+ * Validates and sanitizes Faust settings.
  *
  * The plugin settings page will display any relevant errors when
- * rejecting invalid settings values. Updates to FaustWP settings that
+ * rejecting invalid settings values. Updates to Faust settings that
  * are not initiated from the plugin settings page will not return or
  * display errors, but will still reject invalid values.
  *
  * Once settings are validated, the sanitized values are returned.
  *
- * @param array  $settings FaustWP settings array to validate and sanitize.
+ * @param array  $settings Faust settings array to validate and sanitize.
  * @param string $option   WP option name where settings are saved.
  * @return array Sanitized settings.
  */

--- a/plugins/faustwp/includes/settings/functions.php
+++ b/plugins/faustwp/includes/settings/functions.php
@@ -58,7 +58,7 @@ function get_secret_key() {
 }
 
 /**
- * Get a FaustWP setting by name.
+ * Get a Faust setting by name.
  *
  * @param string $name    The setting name.
  * @param mixed  $default Optional setting value. Default false.
@@ -84,7 +84,7 @@ function faustwp_get_setting( $name, $default = false ) {
 }
 
 /**
- * Update a FaustWP setting value.
+ * Update a Faust setting value.
  *
  * @link https://developer.wordpress.org/reference/functions/update_option/
  *
@@ -101,7 +101,7 @@ function faustwp_update_setting( $name, $value ) {
 }
 
 /**
- * Get all FaustWP settings.
+ * Get all Faust settings.
  *
  * @return array An array of settings.
  */

--- a/plugins/faustwp/includes/settings/views/headless-settings.php
+++ b/plugins/faustwp/includes/settings/views/headless-settings.php
@@ -11,7 +11,7 @@
 		<svg class="wpengine" width="30" height="30" viewBox="0 0 30 30" fill="none" xmlns="http://www.w3.org/2000/svg">
 			<path fill-rule="evenodd" clip-rule="evenodd" d="M0 2.29413L2.29411 0H9.64706V9.64707H0V2.29413ZM10.1765 0H19.8235V7.35294L17.4706 9.64707H12.4706L10.1765 7.35294V0ZM22.6471 10.1765L20.3529 12.4706V17.5294L22.6471 19.8235H30V10.1765H22.6471ZM10.1765 30H19.8235V22.6471L17.4706 20.3529H12.4706L10.1765 22.6471V30ZM30 30V22.6471L27.7059 20.3529H20.3529V30H30ZM20.3529 0V7.35294L22.6471 9.64707H30V0H20.3529ZM13.6471 15C13.6471 15.7059 14.2353 16.353 15 16.353C15.7647 16.353 16.3529 15.7647 16.3529 15C16.3529 14.2941 15.7647 13.6471 15 13.6471C14.2941 13.6471 13.6471 14.2353 13.6471 15ZM9.64706 10.1765H0V19.8235H7.29411L9.64706 17.5294V10.1765ZM7.29411 20.3529L9.64706 22.6471V27.7059L7.29411 30H0V20.3529H7.29411Z" fill="white"/>
 		</svg>
-		<h1><?php esc_html_e( 'FaustWP by WP&nbsp;Engine', 'faustwp' ); ?></h1>
+		<h1><?php esc_html_e( 'Faust by WP&nbsp;Engine', 'faustwp' ); ?></h1>
 	</header>
 	<?php
 	/**
@@ -85,7 +85,7 @@
 							<li><a href="https://faustjs.org/docs/next/guides/post-page-previews" target="_blank" rel="noopener noreferrer">Previews</a></li>
 							<li><a href="https://faustjs.org/docs/next/guides/auth" target="_blank" rel="noopener noreferrer">Authentication</a></li>
 						</ul>
-						<p><a class="button-primary" href="https://github.com/wpengine/faustjs/" target="_blank" rel="noopener noreferrer">Faust.js on GitHub</a></p>
+						<p><a class="button-primary" href="https://github.com/wpengine/faustjs/" target="_blank" rel="noopener noreferrer">Faust on GitHub</a></p>
 					</section>
 				</div>
 			</div>

--- a/plugins/faustwp/includes/utilities/functions.php
+++ b/plugins/faustwp/includes/utilities/functions.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Various utility functions used through the FaustWP plugin.
+ * Various utility functions used through the Faust plugin.
  *
  * @package FaustWP
  */

--- a/plugins/faustwp/package.json
+++ b/plugins/faustwp/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@faustwp/wordpress-plugin",
+  "version": "0.7.11",
+  "private": true
+}

--- a/plugins/faustwp/readme.txt
+++ b/plugins/faustwp/readme.txt
@@ -1,4 +1,4 @@
-=== FaustWP ===
+=== Faust ===
 Contributors: antpb, apmatthe, blakewpe, chriswiegman, claygriffiths, jasonkonen, joefusco, markkelnar, matthewguywright, mindctrl, modernnerd, rfmeier, TeresaGobble, thdespou, wpengine
 Tags: faustjs, faust, headless, decoupled
 Requires at least: 5.7
@@ -8,25 +8,24 @@ Requires PHP: 7.2
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
-FaustWP transforms your traditional WordPress installation into a flexible headless CMS.
+Faust transforms your traditional WordPress installation into a flexible headless CMS.
 
 == Description ==
 
-In conjunction with Faust.js, FaustWP enables a decoupled front-end to authenticate with WordPress through GraphQL mutations and REST API endpoints. It is the connective glue between a Faust.js-powered front-end app, and a WordPress backend.
+In conjunction with the [Faust NPM packages](https://www.npmjs.com/search?q=%40faustwp), Faust enables a decoupled front-end to authenticate with WordPress through GraphQL mutations and REST API endpoints. It is the bridge between a Faust-powered front-end application, and a WordPress backend.
 
 The plugin also provides useful options for headless sites, such as the ability to:
-<ul>
-<li>Hide “theme” admin pages.</li>
-<li>Redirect public route requests to the front-end application.</li>
-<li>Rewrite WordPress URLs to front-end URLs in queried content.</li>
-</ul>
+
+- Hide “theme” admin pages.
+- Redirect public route requests to the front-end application.
+- Rewrite WordPress URLs to front-end URLs in queried content.
 
 == Installation ==
 
 1. Search for the plugin in WordPress under "Plugins -> Add New".
 2. Click the “Install Now” button, followed by "Activate".
 
-That's it! For more information on getting started with headless WordPress, see <a href="https://faustjs.org/docs/tutorial/dev-env-setup" target="_blank">Getting Started with Faust.js</a>.
+That's it! For more information on getting started with headless WordPress, see [Getting Started with Faust](https://faustjs.org/docs/tutorial/dev-env-setup).
 
 == Changelog ==
 

--- a/plugins/faustwp/readme.txt
+++ b/plugins/faustwp/readme.txt
@@ -1,5 +1,5 @@
 === FaustWP ===
-Contributors: antpb, apmatthe, blakewpe, chriswiegman, claygriffiths, jasonkonen, joefusco, markkelnar, mindctrl, modernnerd, rfmeier, wpengine
+Contributors: antpb, apmatthe, blakewpe, chriswiegman, claygriffiths, jasonkonen, joefusco, markkelnar, matthewguywright, mindctrl, modernnerd, rfmeier, TeresaGobble, wpengine
 Tags: faustjs, faust, headless, decoupled
 Requires at least: 5.7
 Tested up to: 6.0

--- a/plugins/faustwp/readme.txt
+++ b/plugins/faustwp/readme.txt
@@ -1,5 +1,5 @@
 === FaustWP ===
-Contributors: antpb, apmatthe, blakewpe, chriswiegman, claygriffiths, jasonkonen, joefusco, markkelnar, matthewguywright, mindctrl, modernnerd, rfmeier, TeresaGobble, wpengine
+Contributors: antpb, apmatthe, blakewpe, chriswiegman, claygriffiths, jasonkonen, joefusco, markkelnar, matthewguywright, mindctrl, modernnerd, rfmeier, TeresaGobble, thdespou, wpengine
 Tags: faustjs, faust, headless, decoupled
 Requires at least: 5.7
 Tested up to: 6.0

--- a/plugins/faustwp/tests/_support/AcceptanceTester.php
+++ b/plugins/faustwp/tests/_support/AcceptanceTester.php
@@ -39,7 +39,7 @@ class AcceptanceTester extends \Codeception\Actor
     }
 
     /**
-     * Visit the FaustWP settings page.
+     * Visit the Faust settings page.
      */
     public function amOnFaustWPSettingsPage()
     {

--- a/plugins/faustwp/tests/acceptance/SettingsCest.php
+++ b/plugins/faustwp/tests/acceptance/SettingsCest.php
@@ -3,17 +3,17 @@
 class SettingsCest
 {
     /**
-     * Ensure the FaustWP settings page is available.
+     * Ensure the Faust settings page is available.
      */
     public function i_can_access_the_settings_page(AcceptanceTester $I)
     {
         $I->loginAsAdmin();
         $I->amOnFaustWPSettingsPage();
-        $I->see('FaustWP by WP Engine');
+        $I->see('Faust by WP Engine');
     }
 
     /**
-     * Ensure the FaustWP default settings are set when the plugin is
+     * Ensure the Faust default settings are set when the plugin is
      * activated for the first time.
      */
     public function i_can_see_the_default_settings(AcceptanceTester $I)

--- a/scripts/versionPlugin.js
+++ b/scripts/versionPlugin.js
@@ -125,7 +125,7 @@ async function generateReadmeChangelog(readmeTxtFile, changelog) {
     changelog     = await readFile(changelog);
 
     changelog = changelog.replace(
-      "# FaustWP",
+      "# Faust",
       "== Changelog =="
     );
 


### PR DESCRIPTION
## Description

Changes include:

- Removal of "WP" from "FaustWP" and all other references within the human readable text of the plugin
- Adds new contributors 🎉 
- Update settings menu from "Headless" to "Faust"
- Small documentation typo in `/internal/legacy.faust.org`

## Screenshots

<img width="813" alt="Screen Shot 2022-10-10 at 11 11 54 AM" src="https://user-images.githubusercontent.com/6676674/194899802-71a7ba34-57e2-49c5-a425-d9430f52f8a2.png">
<img width="1173" alt="Screen Shot 2022-10-10 at 11 12 22 AM" src="https://user-images.githubusercontent.com/6676674/194899804-eb1ce74c-0b45-44ef-a015-50c46a130f57.png">
<img width="1481" alt="Screen Shot 2022-10-10 at 12 38 11 PM" src="https://user-images.githubusercontent.com/6676674/194914940-28b96a8d-24e9-4382-ba5f-f4db354c0cd5.png">

## Documentation Changes

References to "Settings -> Headless" have been updated within `/internal/faust.org`