### PR TITLE
Add `.npmignore` files to `@faustwp` packages

### DIFF
--- a/.changeset/nine-rats-love.md
+++ b/.changeset/nine-rats-love.md
@@ -1,0 +1,6 @@
+---
+'@faustwp/cli': patch
+'@faustwp/core': patch
+---
+
+Excluded unnecessary files in production release (src, config files, etc.)

--- a/packages/faustwp-cli/.npmignore
+++ b/packages/faustwp-cli/.npmignore
@@ -1,0 +1,9 @@
+utils/**/*
+index.ts
+tests/**/*
+.gitignore
+.eslintignore
+jest.config.js
+jest.setup.ts
+tsconfig.json
+coverage

--- a/packages/faustwp-core/.npmignore
+++ b/packages/faustwp-core/.npmignore
@@ -1,0 +1,9 @@
+src/**/*
+tests/**/*
+.gitignore
+.eslintignore
+jest.config.js
+jest.setup.ts
+tsconfig-cjs.json
+tsconfig.json
+coverage


### PR DESCRIPTION
## Description

Exclude unnecessary files in production NPM release.