### PR TITLE
Use `faustexample` domain for the example project wp url

### DIFF
--- a/examples/next/faustwp-getting-started/.env.local.sample
+++ b/examples/next/faustwp-getting-started/.env.local.sample
@@ -1,5 +1,5 @@
 # Your WordPress site URL
-NEXT_PUBLIC_WORDPRESS_URL=https://headlessfw.wpengine.com
+NEXT_PUBLIC_WORDPRESS_URL=https://faustexample.wpengine.com
 
 # Plugin secret found in WordPress Settings->Headless
-FAUSTWP_SECRET_KEY=YOUR_PLUGIN_SECRET
+# FAUSTWP_SECRET_KEY=YOUR_PLUGIN_SECRET


### PR DESCRIPTION
## Description

Update the example project `.env.local.sample` to use the https://faustexample.wpengine.com WP instance @josephfusco created.