### PR TITLE
Moves migration guide sidebar item from legacy to new faust docs site

### DIFF
--- a/internal/faustjs.org/sidebars.js
+++ b/internal/faustjs.org/sidebars.js
@@ -69,5 +69,16 @@ module.exports = {
         },
       ],
     },
+    {
+      type: 'category',
+      label: 'Migration Path from Faust.js < v1.0.0',
+      items: [
+        {
+          type: 'doc',
+          label: 'Overview',
+          id: 'migrationPath/overview',
+        },
+      ],
+    },
   ],
 };

--- a/internal/legacy.faustjs.org/sidebars.js
+++ b/internal/legacy.faustjs.org/sidebars.js
@@ -276,17 +276,6 @@ module.exports = {
     },
     {
       type: 'category',
-      label: 'Migration Path from Faust.js < v1.0.0',
-      items: [
-        {
-          type: 'doc',
-          label: 'Overview',
-          id: 'migrationPath/overview',
-        },
-      ],
-    },
-    {
-      type: 'category',
       label: 'Companion WordPress Plugin',
       items: [
         {


### PR DESCRIPTION
## Description

Moves the migration guide sidebar menu item from `internal/legacy.faustjs.org/sidebar.js` to `internal/faustjs.org/sidebars.js`