### PR TITLE
Update new faust readmes

### DIFF
--- a/.changeset/large-bobcats-relax.md
+++ b/.changeset/large-bobcats-relax.md
@@ -1,5 +1,5 @@
 ---
-'@faustwp/cli': minor
+'@faustwp/cli': patch
 ---
 
 Added new command, `generatePossibleTypes`, that enables users to update their project's possible types schema for the Apollo GraphQL Client.

--- a/packages/faustwp-cli/README.md
+++ b/packages/faustwp-cli/README.md
@@ -1,0 +1,24 @@
+# @faustwp/cli
+
+<p align="center">
+  <a aria-label="NPM version" href="https://www.npmjs.com/package/@faustwp/cli">
+    <img alt="" src="https://img.shields.io/npm/v/@faustwp/cli?color=7e5cef&style=for-the-badge">
+  </a>
+
+  <a aria-label="License" href="https://github.com/wpengine/faustjs/blob/canary/LICENSE">
+    <img alt="" src="https://img.shields.io/npm/l/@faustwp/cli?color=7e5cef&style=for-the-badge">
+  </a>
+</p>
+
+<p align="center">
+  <a aria-label="Faust.js Next Downloads Per Month" href="https://www.npmjs.com/package/@faustwp/cli">
+    <img alt="" src="https://img.shields.io/npm/dm/@faustwp/cli?color=7e5cef&style=for-the-badge&label=@faustwp/cli">
+  </a>
+  <a aria-label="Faust.js Next Downloads Per Week" href="https://www.npmjs.com/package/@faustwp/cli">
+    <img alt="" src="https://img.shields.io/npm/dw/@faustwp/cli?color=7e5cef&style=for-the-badge&label=@faustwp/cli">
+  </a>
+</p>
+
+🚧 Please note this is prerelease software and breaking changes may occur.
+
+`@faustwp/cli` provides a CLI to develop, build, and serve your Faust apps.

--- a/packages/faustwp-core/README.md
+++ b/packages/faustwp-core/README.md
@@ -1,3 +1,24 @@
 # @faustwp/core
 
-Welcome to the Faust project.
+<p align="center">
+  <a aria-label="NPM version" href="https://www.npmjs.com/package/@faustwp/core">
+    <img alt="" src="https://img.shields.io/npm/v/@faustwp/core?color=7e5cef&style=for-the-badge">
+  </a>
+
+  <a aria-label="License" href="https://github.com/wpengine/faustjs/blob/canary/LICENSE">
+    <img alt="" src="https://img.shields.io/npm/l/@faustwp/core?color=7e5cef&style=for-the-badge">
+  </a>
+</p>
+
+<p align="center">
+  <a aria-label="Faust.js Next Downloads Per Month" href="https://www.npmjs.com/package/@faustwp/core">
+    <img alt="" src="https://img.shields.io/npm/dm/@faustwp/core?color=7e5cef&style=for-the-badge&label=@faustwp/core">
+  </a>
+  <a aria-label="Faust.js Next Downloads Per Week" href="https://www.npmjs.com/package/@faustwp/core">
+    <img alt="" src="https://img.shields.io/npm/dw/@faustwp/core?color=7e5cef&style=for-the-badge&label=@faustwp/core">
+  </a>
+</p>
+
+🚧 Please note this is prerelease software and breaking changes may occur.
+
+Faust is a framework that aims to make headless WordPress as streamlined as classic WordPress for both developers and publishers.


### PR DESCRIPTION
## Description

This PR updates the `@faustwp` package readmes and modifies a changeset to reflect a `patch` bump instead of a `minor` bump.

## View the Readmes

`@faustwp/core`: https://github.com/wpengine/faustjs/blob/update-new-faust-readmes/packages/faustwp-core/README.md

`@faustwp/cli`: https://github.com/wpengine/faustjs/blob/update-new-faust-readmes/packages/faustwp-cli/README.md