### PR TITLE
Indicate support for WordPress 6.1

### DIFF
--- a/plugins/faustwp/readme.txt
+++ b/plugins/faustwp/readme.txt
@@ -2,7 +2,7 @@
 Contributors: antpb, apmatthe, blakewpe, chriswiegman, claygriffiths, jasonkonen, joefusco, markkelnar, matthewguywright, mindctrl, modernnerd, rfmeier, TeresaGobble, thdespou, wpengine
 Tags: faustjs, faust, headless, decoupled
 Requires at least: 5.7
-Tested up to: 6.0
+Tested up to: 6.1
 Stable tag: 0.7.11
 Requires PHP: 7.2
 License: GPLv2 or later


### PR DESCRIPTION
Signed-off-by: Joe Fusco <joe.fusco@wpengine.com>

## Description

This change updates the [faustwp plugin](https://wordpress.org/plugins/faustwp) to indicate its support for WordPress version 6.1.