### PR TITLE
fix(auth): invalid url encoding for code

### DIFF
--- a/packages/core/src/auth/client/accessToken.ts
+++ b/packages/core/src/auth/client/accessToken.ts
@@ -140,7 +140,7 @@ export async function fetchAccessToken(code?: string): Promise<string | null> {
 
   // Add the code to the url if it exists
   if (isString(code) && code.length > 0) {
-    url += `?code=${code}`;
+    url += `?code=${encodeURIComponent(code)}`;
   }
 
   try {


### PR DESCRIPTION
## Description

Fix some 401/403 ? response when using preview and code contains characters that should be encoded.

We can see a lot of redirection in preview until it get a valid code.


## Related Issue(s):
See bug #1018 (faustwp)
Internal Task LEDE-501

## Testing

Tested by updating the code before in calling fetchAccessToken with encodeURIComponent() to use a custom useLogin.
Could not test yet with a generated build.

## Note
I didn't include a fix for the / redirect caused by NextConfig.trailingSlash = true since it seems that nextConfig?.trailingSlash is not available in config() - aka faustConfig. It is use in withFaust.ts for redirects.