### PR TITLE
Use proper Lodash import statement to reduce bundle size

### DIFF
--- a/.changeset/dry-kings-heal.md
+++ b/.changeset/dry-kings-heal.md
@@ -1,0 +1,5 @@
+---
+'@faustwp/core': patch
+---
+
+Reduce bundle size by using proper lodash import

--- a/packages/faustwp-core/src/config/withFaust.ts
+++ b/packages/faustwp-core/src/config/withFaust.ts
@@ -1,4 +1,4 @@
-import { trim } from 'lodash';
+import trim from 'lodash/trim.js';
 import isFunction from 'lodash/isFunction.js';
 import { NextConfig } from 'next';
 import {

--- a/packages/faustwp-core/tests/auth/authorize.test.ts
+++ b/packages/faustwp-core/tests/auth/authorize.test.ts
@@ -1,6 +1,6 @@
 import 'isomorphic-fetch';
 import fetchMock from 'fetch-mock';
-import { trim } from 'lodash';
+import trim from 'lodash/trim.js';
 import * as authorize from '../../src/auth/authorize';
 import * as getWpUrl from '../../src/lib/getWpUrl';
 import * as getWpSecret from '../../src/lib/getWpSecret';


### PR DESCRIPTION
## Description

Fixing this improper Lodash import saves about ~20k of JS to the bundle.

`@faustwp/core` before fix: 164k
`@faustwp/core` after fix: 141k