### PR TITLE
Finalize telemetry

### DIFF
--- a/.changeset/twenty-flies-tap.md
+++ b/.changeset/twenty-flies-tap.md
@@ -1,0 +1,19 @@
+---
+'@faustwp/cli': patch
+---
+
+Implements telemetry in the Faust CLI. Telemetry is opt-in by default: if you do not have any preferences, the CLI will ask if you'd like to enroll in Telemetry. Thereafter, you can use the `npx faust faust-telemetry` command to update your preferences. The following information is collected if you enroll:
+
+- Which settings are enabled/disabled in the Faust plugin
+- Faust plugin version
+- If the WP site is hosted on WP Engine
+- If the WP site is multisite
+- PHP Version of the WP site
+- WP version
+- `@faustwp/core` version
+- `@faustwp/cli` version
+- `@apollo/client` version
+- Node version
+- `next` version
+- If the Node environment is in dev mode (was `npm run dev` ran)
+- The command that gets ran (i.e. `npm run dev`, `npm run build`)

--- a/packages/faustwp-cli/index.ts
+++ b/packages/faustwp-cli/index.ts
@@ -44,7 +44,14 @@ const config = new Configstore(CONFIG_STORE_NAME);
     config.all?.telemetry?.enabled === undefined ||
     !config.all?.telemetry?.anonymousId
   ) {
-    await promptUserForTelemetryPref(true, config);
+    /**
+     * Do not prompt for telemetry if preferences are not set and the command
+     * that is being ran is build. We do not want to halt the build of a
+     * production site that likely does not have preferences saved.
+     */
+    if (arg1 !== 'build') {
+      await promptUserForTelemetryPref(true, config);
+    }
   }
 
   // eslint-disable-next-line default-case

--- a/packages/faustwp-cli/index.ts
+++ b/packages/faustwp-cli/index.ts
@@ -78,7 +78,7 @@ const config = new Configstore(CONFIG_STORE_NAME);
         process.env.FAUSTWP_SECRET_KEY!,
       );
 
-      const telemetryData = marshallTelemetryData(wpTelemetryData);
+      const telemetryData = marshallTelemetryData(wpTelemetryData, arg1);
 
       // infoLog('Telemetry event being sent', telemetryData);
 

--- a/packages/faustwp-cli/utils/marshallTelemetryData.ts
+++ b/packages/faustwp-cli/utils/marshallTelemetryData.ts
@@ -19,6 +19,7 @@ export interface TelemetryData {
   node_version?: string;
   node_next_version?: string;
   node_is_development?: boolean;
+  command?: string;
 }
 
 /**
@@ -55,6 +56,7 @@ const sanitizePackageJsonVersion = (_version: string | undefined) => {
  */
 export const marshallTelemetryData = (
   wpTelemetryData: WPTelemetryResponseData | undefined,
+  command: string,
 ): TelemetryData => {
   const packageJson = JSON.parse(fs.readFileSync('package.json', 'utf8'));
 
@@ -84,6 +86,7 @@ export const marshallTelemetryData = (
     multisite: wpTelemetryData?.multisite,
     php_version: wpTelemetryData?.php_version,
     wp_version: wpTelemetryData?.wp_version,
+    command,
   };
 
   return telemetryData;

--- a/packages/faustwp-cli/utils/sendTelemetryData.ts
+++ b/packages/faustwp-cli/utils/sendTelemetryData.ts
@@ -2,8 +2,7 @@ import 'isomorphic-fetch';
 
 import { TelemetryData } from './marshallTelemetryData.js';
 
-const GA_TRACKING_ENDPOINT =
-  'https://www.google-analytics.com/debug/mp/collect';
+const GA_TRACKING_ENDPOINT = 'https://www.google-analytics.com/mp/collect';
 const GA_TRACKING_ID = 'G-KPVSTHK1G4';
 const GA_API_SECRET = '-SLuZb8JTbWkWcT5BD032w';
 


### PR DESCRIPTION
## Description

This PR finalizes the telemetry implementation by removing the debug endpoint with the production endpoint and also collects the command that was run.

## Testing

Events are being displayed in Google Analytics:

<img width="319" alt="Screenshot 2022-10-24 at 10 02 56 PM" src="https://user-images.githubusercontent.com/5946219/197673286-0d8edc15-ab83-4512-a43f-616081d473da.png">

<img width="332" alt="Screenshot 2022-10-24 at 10 03 00 PM" src="https://user-images.githubusercontent.com/5946219/197673308-e2f2293c-c91c-4e26-9b81-78fad7864755.png">

