### PR TITLE
Trim backslashes from `NEXT_PUBLIC_WORDPRESS_URL`

### DIFF
--- a/.changeset/serious-lizards-count.md
+++ b/.changeset/serious-lizards-count.md
@@ -1,0 +1,5 @@
+---
+'@faustwp/core': patch
+---
+
+Trim any leading/ending backslashes in `NEXT_PUBLIC_WORDPRESS_URL`

--- a/packages/faustwp-core/src/lib/getWpUrl.ts
+++ b/packages/faustwp-core/src/lib/getWpUrl.ts
@@ -1,7 +1,8 @@
+import trim from 'lodash/trim.js';
 import { hooks } from '../hooks/index.js';
 
 export function getWpUrl(): string {
-  let wpUrl = process.env.NEXT_PUBLIC_WORDPRESS_URL;
+  let wpUrl = trim(process.env.NEXT_PUBLIC_WORDPRESS_URL, '/');
 
   wpUrl = hooks.applyFilters('wpUrl', wpUrl, {}) as string;
 


### PR DESCRIPTION
## Description

Trims leading/ending backslashes from `NEXT_PUBLIC_WORDPRESS_URL` to avoid breaking the GraphQL connection.