### PR TITLE
Automate WP Plugin Tag and Release

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -6,6 +6,10 @@
     ["@faustjs/core", "@faustjs/next", "@faustjs/react"],
     ["@faustwp/core", "@faustwp/cli"]
   ],
+  "privatePackages": {
+    "version": true,
+    "tag": true
+  },
   "access": "public",
   "baseBranch": "canary",
   "updateInternalDependencies": "patch",

--- a/.github/actions/release-plugin/deploy.sh
+++ b/.github/actions/release-plugin/deploy.sh
@@ -36,7 +36,7 @@ echo "ℹ︎ SLUG is $SLUG"
 # Does it even make sense for VERSION to be editable in a workflow definition?
 if [[ -z "$VERSION" ]]; then
 	VERSION="${GITHUB_REF#refs/tags/}"
-	VERSION="${VERSION#plugin/faustwp/v}" # Strip the plugin/faustwp/v prefix from the version
+	VERSION="${VERSION#@faustwp/wordpress-plugin@}" # Strip the @faustwp/wordpress-plugin@ prefix from the version
 fi
 echo "ℹ︎ VERSION is $VERSION"
 

--- a/.github/workflows/release-plugin.yml
+++ b/.github/workflows/release-plugin.yml
@@ -2,7 +2,7 @@ name: Deploy to WordPress.org
 on:
   push:
     tags:
-    - "plugin/faustwp/*"
+    - "@faustwp/wordpress-plugin@*"
 jobs:
   release_plugin:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description

This PR automates the release of the WordPress plugin by instructing Changesets to create tags for private packages.

https://github.com/changesets/changesets/blob/main/docs/versioning-apps.md

This will result in a tag being created for the WordPress plugin (`@faustwp/wordpress-plugin@x.x.x`) when we merge in the "Version Packages" PR with plugin changes.