### PR TITLE
CLI: Check for `faust start` command

### DIFF
--- a/.changeset/chatty-planes-search.md
+++ b/.changeset/chatty-planes-search.md
@@ -1,0 +1,5 @@
+---
+'@faustwp/cli': patch
+---
+
+Fixed a bug where the `NODE_ENV` was not being set properly when `faust start` was ran. Additionally, fixed a bug that halted the `faust start` command from running in some CI/node environments.

--- a/packages/faustwp-cli/index.ts
+++ b/packages/faustwp-cli/index.ts
@@ -24,6 +24,9 @@ const config = new Configstore(CONFIG_STORE_NAME);
     case 'build':
       process.env.NODE_ENV = 'production';
       break;
+    case 'start':
+      process.env.NODE_ENV = 'production';
+      break;
     case 'test':
       process.env.NODE_ENV = 'test';
       break;
@@ -46,10 +49,10 @@ const config = new Configstore(CONFIG_STORE_NAME);
   ) {
     /**
      * Do not prompt for telemetry if preferences are not set and the command
-     * that is being ran is build. We do not want to halt the build of a
+     * that is being ran is build or start. We do not want to halt the build of a
      * production site that likely does not have preferences saved.
      */
-    if (arg1 !== 'build') {
+    if (arg1 !== 'build' && arg1 !== 'start') {
       await promptUserForTelemetryPref(true, config);
     }
   }


### PR DESCRIPTION
## Description

This PR fixes a bug when setting the improper `NODE_ENV` when `faust start` is ran. This PR also fixes a bug that halts CI/Node environments (when the env has no telemetry preferences set) like Atlas when running `faust start`