### PR TITLE
Docs Site: Add "no index" feature

### DIFF
--- a/internal/faustjs.org/docusaurus.config.js
+++ b/internal/faustjs.org/docusaurus.config.js
@@ -16,6 +16,7 @@ module.exports = {
   favicon: 'img/favicon.ico',
   organizationName: 'wpengine', // Usually your GitHub org/user name.
   projectName: 'faustjs', // Usually your repo name.
+  noIndex: process.env.SITE_NO_INDEX ?? false,
   themeConfig: {
     algolia: {
       // If Algolia did not provide you any appId, use 'BH4D9OD16A'

--- a/internal/legacy.faustjs.org/docusaurus.config.js
+++ b/internal/legacy.faustjs.org/docusaurus.config.js
@@ -16,6 +16,7 @@ module.exports = {
   favicon: 'img/favicon.ico',
   organizationName: 'wpengine', // Usually your GitHub org/user name.
   projectName: 'faustjs', // Usually your repo name.
+  noIndex: process.env.SITE_NO_INDEX ?? false,
   themeConfig: {
     algolia: {
       // If Algolia did not provide you any appId, use 'BH4D9OD16A'


### PR DESCRIPTION
## Description

This PR makes Docusaurus look for the `SITE_NO_INDEX` env var to determine if the site should be indexed or not on search engines. We can use this when deploying dev/unreleased docs sites. Defaults to `false` when the env var is not configured