### PR TITLE
Merl 616 implement devrel feedback on new faust site

### DIFF
--- a/internal/faustjs.org/docs/authentication.mdx
+++ b/internal/faustjs.org/docs/authentication.mdx
@@ -1,0 +1,7 @@
+---
+slug: auth
+title: Authentication
+description: Use Faust.js' built-in authentication strategies to authenticate users from your WordPress backend
+---
+
+### This document is in progress. Check back soon for content!

--- a/internal/faustjs.org/docs/faq.mdx
+++ b/internal/faustjs.org/docs/faq.mdx
@@ -1,0 +1,23 @@
+---
+slug: faq
+title: FAQ
+description: Frequently Asked Questions
+---
+
+# Frequently Asked Questions 
+
+## If I need more support, where should I ask questions?
+
+Use one of the channels below to contact the Faust team for support.
+
+[GitHub](https://github.com/wpengine/faustjs) - Faust GitHub documentation and codebase.
+
+[Discord](https://discord.gg/J2khkF9XYK) - Interactive chat support on Discord.
+
+## Where can I find more information about development and future features for the WordPress plugin?
+
+Great question! The development team posts weekly summaries of sprints related to Faust, [here](https://faustjs.org/blog). 
+
+## Why the name “Faust”?
+
+Johann Faust was a German printer and was instrumental in the invention of the printing press, along with his partner Johann Gutenberg. In the same way the printing press democratized the spread of information, the mission of Faust.js is to support and further the vision of WordPress to democratize publishing on the web. 

--- a/internal/faustjs.org/docs/faq.mdx
+++ b/internal/faustjs.org/docs/faq.mdx
@@ -4,9 +4,9 @@ title: FAQ
 description: Frequently Asked Questions
 ---
 
-# Frequently Asked Questions 
+## Frequently Asked Questions 
 
-## If I need more support, where should I ask questions?
+### If I need more support, where should I ask questions?
 
 Use one of the channels below to contact the Faust team for support.
 
@@ -14,10 +14,10 @@ Use one of the channels below to contact the Faust team for support.
 
 [Discord](https://discord.gg/J2khkF9XYK) - Interactive chat support on Discord.
 
-## Where can I find more information about development and future features for the WordPress plugin?
+### Where can I find more information about development and future features for the WordPress plugin?
 
 Great question! The development team posts weekly summaries of sprints related to Faust, [here](https://faustjs.org/blog). 
 
-## Why the name “Faust”?
+### Why the name “Faust”?
 
 Johann Faust was a German printer and was instrumental in the invention of the printing press, along with his partner Johann Gutenberg. In the same way the printing press democratized the spread of information, the mission of Faust.js is to support and further the vision of WordPress to democratize publishing on the web. 

--- a/internal/faustjs.org/docs/faustwp/seed-query.mdx
+++ b/internal/faustjs.org/docs/faustwp/seed-query.mdx
@@ -6,7 +6,7 @@ description: This section describes the FaustWP Seed Query.
 
 The Seed Query is a request that is fired when a user is trying to visit a URL which requests data from WP for the given URL. With this data we are able to get a list of possible templates for the given route.
 
-### What is it used for?
+### What Is It Used For?
 
 The Seed Query is used for resolving templates in the Faust template hierarchy.
 

--- a/internal/faustjs.org/docs/faustwp/settings.mdx
+++ b/internal/faustjs.org/docs/faustwp/settings.mdx
@@ -12,7 +12,7 @@ allows you to customize the behavior of the plugin by configuring certain featur
 
 The following options are available to enable/disabled based on your requirements:
 
-### Disabling WordPress theme admin pages
+### Disabling WordPress Theme Admin Pages
 
 This option is controlled by the `Disable WordPress theme admin pages` checkbox.
 When enabled it removes certain wp-admin menu items that aren't supported in a headless environment.
@@ -28,7 +28,7 @@ It will also remove any features that require the `Customizer` which means that 
 
 If you still want to have access to those pages then, you can disable this setting.
 
-### Enabling Post and Category URL rewrites
+### Enabling Post and Category URL Rewrites
 
 This option is controlled by the `Enable Post and Category URL rewrites` checkbox. When enabled it will
 perform domain replacement of all terms, post, preview, category links from your `WordPress URL` into your headless `Front-end site URL` by using
@@ -44,7 +44,7 @@ will prevent the original content links from pointing to the headless url.
 
 > **NOTE:** It is recommended to keep this setting enabled so that all links will be properly served by the headless site.
 
-### Enabling public route redirects
+### Enabling Public Route Redirects
 
 This option is controlled by the `Enable public route redirects` checkbox. When enabled it will
 redirect any public API requests to your `WordPress URL` into your headless `Front-end site URL` by using
@@ -58,7 +58,7 @@ then if you visit any page on your `WordPress URL` will be redirected to the hea
 If you don't want this redirect to happen then you can disable this option which allows you to access the original WP site.
 
 
-### Using the WordPress domain for media URLs in post content
+### Using the WordPress Domain for Media URLs in Post Content
 
 This option is controlled by the `Use the WordPress domain for media URLs in post content` checkbox and is disabled by default.
 When enabled it will perform a `src` and `srcset` replacement of all media urls of the sites post/page content using

--- a/internal/faustjs.org/docs/getting-started.mdx
+++ b/internal/faustjs.org/docs/getting-started.mdx
@@ -43,7 +43,7 @@ You can now visit [http://localhost:3000](http://localhost:3000) to see your new
 
 Currently, the posts and pages you see are coming from our WordPress site at [https://faustexample.wpengine.com](https://faustexample.wpengine.com). In the next step, we'll show you how to hook up your own WordPress site.
 
-## Connecting your WordPress site
+## Connecting Your WordPress Site
 
 The example app above loads WordPress content from the demo site at [https://faustexample.wpengine.com](https://faustexample.wpengine.com).
 

--- a/internal/faustjs.org/docs/next/guides/post-page-previews.mdx
+++ b/internal/faustjs.org/docs/next/guides/post-page-previews.mdx
@@ -12,7 +12,7 @@ Your headless secret is a value that authenticates requests to WordPress. This s
 
 ### Copy your Headless Secret
 
-Find your Headless Secret in **WP-Admin -> Settings -> Faust**. Copy this value:
+Find your Headless Secret in `WP-Admin` -> `Settings` -> `Faust`. Copy this value:
 
 <img
   src="/docs/img/headless-admin-secret.png"
@@ -135,16 +135,16 @@ If you wish to disable post/page previews for a particular template hierarchy pa
 
 Start by logging into your WordPress Admin. For this example, we'll create a new post.
 
-So far, I've added a title and a simple line of text for the content. To view this post as a preview on your front end, click the **Preview** link (1). From there, click, **Preview in new tab** (2):
+So far, I've added a title and a simple line of text for the content. To view this post as a preview on your front end, click the `Preview` link (1). From there, click, `Preview in new tab` (2):
 
 <img
   src="/docs/img/post-preview.png"
   alt="WordPress post page using the Gutenberg editor with a red arrow to the preview and preview in new tab dropdowns"
 />
 
-Notice the **Publish** button is also visible, meaning that you still need to publish the post. Therefore you can now view the post on the frontend without being authenticated.
+Notice the `Publish` button is also visible, meaning that you still need to publish the post. Therefore you can now view the post on the frontend without being authenticated.
 
-Clicking on **Preview in new tab** should take you to your post preview page with the current preview content:
+Clicking on `Preview in new tab` should take you to your post preview page with the current preview content:
 
 <img
   src="/docs/img/post-preview-frontend.png"

--- a/internal/faustjs.org/docs/next/guides/post-page-previews.mdx
+++ b/internal/faustjs.org/docs/next/guides/post-page-previews.mdx
@@ -19,7 +19,7 @@ Find your Headless Secret in **WP-Admin -> Settings -> Faust**. Copy this value:
   alt="The Faust plugin admin interface with a red rectangle around the Secret Key field"
 />
 
-### Add your Headless Secret to your `.env.local` File
+### Add Your Headless Secret to Your `.env.local` File
 
 Add the `FAUSTWP_SECRET_KEY` key to your `.env.local` file with the headless secret as the value. Your `.env.local` file should already have a value for `NEXT_PUBLIC_WORDPRESS_URL`. The file should look something like this:
 
@@ -31,7 +31,7 @@ NEXT_PUBLIC_WORDPRESS_URL=http://localhost:8080
 FAUSTWP_SECRET_KEY=xxxx
 ```
 
-### Ensure you've created your `faust.config.js` file and are importing it in your `_app.js`
+### Create Your `faust.config.js` File Import It In `_app.js`
 
 Like the [`next/getting-started`](https://github.com/wpengine/faustjs/tree/main/examples/next/faustwp-getting-started) Faust example, your [`faust.config.js`](https://github.com/wpengine/faustjs/blob/main/examples/next/faustwp-getting-started/faust.config.js) file.
 
@@ -66,7 +66,7 @@ import { apiRouter } from '@faustwp/core';
 export default apiRouter;
 ```
 
-## Create your Preview Page
+## Create Your Preview Page
 
 With your headless secret set and the `authorizeHandler` ready to handle requests, you can now create a Next.js [page](https://nextjs.org/docs/basic-features/pages) for previews. Create a file at `pages/preview.js` with the following:
 
@@ -127,7 +127,7 @@ if (props.loading) {
 
 If you don't handle the loading state you may find that the post/page data will be undefined.
 
-### What happens if you don't use on the `asPreview` property?
+### Is the `asPreview` Property Necessary?
 
 If you wish to disable post/page previews for a particular template hierarchy page you can simply ignore the `asPreview` parameter.
 

--- a/internal/faustjs.org/docs/next/guides/project-walkthrough.mdx
+++ b/internal/faustjs.org/docs/next/guides/project-walkthrough.mdx
@@ -4,18 +4,18 @@ title: Understanding the Example project
 description: Understand how the Example project is structured so that you can augment it according to your project’s needs
 ---
 
-# Understanding the Example project
+# Understanding the Example Project
 
 The example project contains a site demonstrating the use of Faust features like WordPress template hierarchy and the plugin system.
 You can use this project for basing your future projects and as a good reference site.
 
-## How to get the example working locally
+## How to Get the Example Working Locally
 
 If you followed the [Getting started guide](/docs/next/getting-started), you will have to create a new app using the template and connect your WordPress site.
 
 Then you can navigate to the `my-app` folder and inspect the code.
 
-## The file structure rationale
+## The File Structure Rationale
 
 The example project follows the typical conventions of the [Next.js file based routing](https://nextjs.org/docs/routing/introduction).
 Here is the output of the `tree` command on this folder:
@@ -93,24 +93,24 @@ They are highly re-usable and for purely presentational purposes.
 
 Now that you have an good picture of the folder structure, let's take a look at which files you should be changing if you wish to customize this theme.
 
-## The areas of example files where you should make changes
+## Changing Example Files
 
 Instead of telling you what you should change, you can follow the below how-to sections that will help you customize the theme for your needs.
 
-### How to change the styling of the site?
+### How do I change the styling of the site?
 
 To change the styling of each `component` you can navigate to the `components` folder and change the CSS styles in the `.module.scss` file. As
 If you want to change the global styling of the site or the style of the pages, you can navigate to the `styles` folder and make your changes there.
 Each `scss` module contains documentation strings for your convenience.
 
-### How to change the pages layout?
+### How do I change the pages layout?
 
 To change each pages layout, you will need to review the `wp-templates` folder and make your changes there.
 For each type of page that correspond to the WordPress template hierarchy, there are different layouts and queries.
 For example the `page.js` represents the ["page type"](https://developer.wordpress.org/themes/basics/template-hierarchy/#single-page) and the `single.js` represents the ["single post type"](https://developer.wordpress.org/themes/basics/template-hierarchy/#single-post).
 You can reuse the existing components or create new ones that fit your requirements.
 
-### How to change the GraphQL queries?
+### How do I change the GraphQL queries?
 
 Most of the queries are located within each `wp-templates` component. If you look after the definitions of each component there is a `query` and `variables` properties:
 

--- a/internal/faustjs.org/docs/next/reference/getNextServerSideProps.mdx
+++ b/internal/faustjs.org/docs/next/reference/getNextServerSideProps.mdx
@@ -22,11 +22,11 @@ Faust uses `MyPage` passed via `getNextServerSideProps` to fetch the data using 
 
 This is merely a convenient way to fetch the page data while reusing the logic between components. If you are interested on how this is done you can review the [source code here.](https://github.com/wpengine/faustjs/blob/canary/packages/faustwp-core/src/getProps.ts#L71)
 
-## Context parameter
+## Context Parameter
 
 This is the same object that Next.js provides in the `getServerSideProps`. You can read the [list of parameters here](https://nextjs.org/docs/api-reference/data-fetching/get-server-side-props#context-parameter).
 
-## GetNextServerSidePropsConfig parameter
+## GetNextServerSidePropsConfig Parameter
 
 The second argument of `getNextServerSideProps` is of type `GetNextServerSidePropsConfig` and accepts the following parameters:
 
@@ -35,6 +35,6 @@ The second argument of `getNextServerSideProps` is of type `GetNextServerSidePro
 * `redirect`: The `redirect` object allows redirecting to internal and external resources. It should match the shape of `{ destination: string, permanent: boolean }`.
 * `props`: The `props` object is any other key value pairs of properties where each value is received by the `Page` component.
 
-## getNextServerSideProps return values
+## getNextServerSideProps Return Values
 
 The `getNextServerSideProps` function returns an object that is required by the `getServerSideProps` function.

--- a/internal/faustjs.org/docs/next/reference/getNextStaticProps.mdx
+++ b/internal/faustjs.org/docs/next/reference/getNextStaticProps.mdx
@@ -21,11 +21,11 @@ Faust uses `MyPage` passed via `getNextStaticProps` to fetch the data using the 
 
 This is merely a convenient way to fetch the page data while reusing the logic between components. If you are interested on how this is done you can review the [source code here.](https://github.com/wpengine/faustjs/blob/canary/packages/faustwp-core/src/getProps.ts#L35)
 
-## Context parameter
+## Context Parameter
 
 This is the same object that Next.js provides in `getStaticProps`. You can read the [list of parameters here](https://nextjs.org/docs/api-reference/data-fetching/get-static-props#context-parameter).
 
-## GetNextServerSidePropsConfig parameter
+## GetNextServerSidePropsConfig Parameter
 
 The second argument of `getNextStaticProps` is of type `GetNextStaticPropsConfig` and accepts the following parameters:
 
@@ -35,6 +35,6 @@ The second argument of `getNextStaticProps` is of type `GetNextStaticPropsConfig
 
 Because the `GetNextStaticPropsConfig` type extends `GetNextServerSidePropsConfig`, it can also accept any other properties of the [getNextServerSideProps](/docs/next/reference/getNextServerSideProps).
 
-## getNextServerSideProps return values
+## getNextServerSideProps Return Values
 
 The `getNextStaticProps` function returns an object that is required by the `getStaticProps` function.

--- a/internal/faustjs.org/docs/sitemaps.mdx
+++ b/internal/faustjs.org/docs/sitemaps.mdx
@@ -1,0 +1,7 @@
+---
+slug: sitemaps
+title: Sitemaps
+description: Generate sitemaps for your Faust.js site
+---
+
+### This document is in progress. Check back soon for content!

--- a/internal/faustjs.org/sidebars.js
+++ b/internal/faustjs.org/sidebars.js
@@ -30,6 +30,16 @@ module.exports = {
           label: 'Previews',
           id: 'next/guides/post-page-previews',
         },
+        {
+          type: 'doc',
+          label: 'Authentication',
+          id: 'authentication',
+        },
+        {
+          type: 'doc',
+          label: 'Sitemaps',
+          id: 'sitemaps',
+        },
       ],
     },
     {

--- a/internal/faustjs.org/sidebars.js
+++ b/internal/faustjs.org/sidebars.js
@@ -94,5 +94,10 @@ module.exports = {
       label: 'Migration from old Faust',
       id: 'migrationPath/overview',
     },
+    {
+      type: 'doc',
+      label: 'FAQ',
+      id: 'faq',
+    },
   ],
 };


### PR DESCRIPTION
## Description

After meeting with devrel to conduct a site audit, the following feedback was provided on readability: 

- Placeholders for Auth and Sitemaps docs added (similar to migration doc placeholder)

- Copy over FAQs page from plugin and add to docs sidebar

- Create uniform headers for all docs (title casing)

- Change bold use for feature highlighting in doc text to code snippets instead to match Atlas docs

This PR addresses the above feedback items.



## Testing

Use the Atlas preview link below to review the site. Alternatively, you can review locally by:

`cd` into the `internal/faustjs.org/` file
`npm run build`
`npm run dev`

Please check to ensure documents are corrected and sidebar is up to date. 
