### PR TITLE
Add Legacy Docs link in header

### DIFF
--- a/internal/faustjs.org/docusaurus.config.js
+++ b/internal/faustjs.org/docusaurus.config.js
@@ -46,6 +46,11 @@ module.exports = {
           position: 'left',
         },
         {
+          href: 'https://legacy.faustjs.org',
+          label: 'Legacy Docs',
+          position: 'left',
+        },
+        {
           href: 'https://github.com/wpengine/faustjs?ref=faustjs',
           label: 'GitHub',
           position: 'right',


### PR DESCRIPTION
## Description

Add a link to the legacy docs in the header for those coming to faustjs.org looking for the legacy docs.