### PR TITLE
Removed dark lines in code snippets

### DIFF
--- a/internal/faustjs.org/docs/next/guides/post-page-previews.mdx
+++ b/internal/faustjs.org/docs/next/guides/post-page-previews.mdx
@@ -37,7 +37,7 @@ Like the [`next/getting-started`](https://github.com/wpengine/faustjs/tree/main/
 
 You'll need to import it at the top of your `_app.js` file to ensure the `config` is set, and your Faust app initializes appropriately.
 
-```js title=pages/_app.js {1}
+```js title=pages/_app.js 
 import '../faust.config';
 import React from 'react';
 import { useRouter } from 'next/router';
@@ -88,7 +88,7 @@ Now in the `wp-template` pages, Faust will propagate a special boolean property 
 
 Here is an example taken from the [`next/getting-started`](https://github.com/wpengine/faustjs/tree/main/examples/next/faustwp-getting-started) Faust example of what you should do in your template hierarchy components if you wish to render previews:
 
-```js title=wp-templates/single.js {20}
+```js title=wp-templates/single.js 
 export default function Component(props) {
   // Loading state for previews
   if (props.loading) {


### PR DESCRIPTION
## Description

The page previews [here](https://faustjs.org/docs/next/guides/post-page-previews) have a glitch in two code snippets in light mode, where they have a dark bar over the code.

Code snippets had what appears to be an unnecessary line count at the top of the two code snippets in the page previews. After deleting the count the glitch is gone from each snippet.

Screenshots of fixed snippets:

![image](https://user-images.githubusercontent.com/50935135/200475645-d14ba37b-fc63-42b3-b335-1b5132b6bf99.png)

![image](https://user-images.githubusercontent.com/50935135/200475774-9d7fc992-2be8-4891-bb24-db6f2fca9433.png)

