### PR TITLE
Add `FAUST_NO_INTERACTION` option to .env

### DIFF
--- a/.changeset/ten-steaks-roll.md
+++ b/.changeset/ten-steaks-roll.md
@@ -2,4 +2,4 @@
 '@faustwp/cli': minor
 ---
 
-Add support for new Faust .env variable, FAUST_NO_INTERACTION, intended for CI envirnments.
+Added new `.env` variable, FAUST_NO_INTERACTION, intended for CI environments.

--- a/.changeset/ten-steaks-roll.md
+++ b/.changeset/ten-steaks-roll.md
@@ -1,0 +1,5 @@
+---
+'@faustwp/cli': minor
+---
+
+Add support for new Faust .env variable, FAUST_NO_INTERACTION, intended for CI envirnments.

--- a/.changeset/ten-steaks-roll.md
+++ b/.changeset/ten-steaks-roll.md
@@ -1,5 +1,5 @@
 ---
-'@faustwp/cli': minor
+'@faustwp/cli': patch
 ---
 
 Added new `.env` variable, FAUST_NO_INTERACTION, intended for CI environments.

--- a/packages/faustwp-cli/index.ts
+++ b/packages/faustwp-cli/index.ts
@@ -53,11 +53,7 @@ const config = new Configstore(CONFIG_STORE_NAME);
      * that is being ran is build or start. We do not want to halt the build of a
      * production site that likely does not have preferences saved.
      */
-    if (
-      arg1 !== 'build' &&
-      arg1 !== 'start' &&
-      !disableCliInteraction()
-    ) {
+    if (arg1 !== 'build' && arg1 !== 'start' && !disableCliInteraction()) {
       await promptUserForTelemetryPref(true, config);
     }
   }

--- a/packages/faustwp-cli/index.ts
+++ b/packages/faustwp-cli/index.ts
@@ -4,13 +4,14 @@ import Configstore from 'configstore';
 import { spawn } from 'child_process';
 import dotenv from 'dotenv-flow';
 import {
-  marshallTelemetryData,
-  getCliArgs,
-  validateFaustEnvVars,
-  promptUserForTelemetryPref,
-  sendTelemetryData,
-  requestWPTelemetryData,
+  disableCliInteraction,
   generatePossibleTypes,
+  getCliArgs,
+  marshallTelemetryData,
+  promptUserForTelemetryPref,
+  requestWPTelemetryData,
+  sendTelemetryData,
+  validateFaustEnvVars,
 } from './utils/index.js';
 
 const CONFIG_STORE_NAME = 'faust';
@@ -52,7 +53,11 @@ const config = new Configstore(CONFIG_STORE_NAME);
      * that is being ran is build or start. We do not want to halt the build of a
      * production site that likely does not have preferences saved.
      */
-    if (arg1 !== 'build' && arg1 !== 'start') {
+    if (
+      arg1 !== 'build' &&
+      arg1 !== 'start' &&
+      !disableCliInteraction()
+    ) {
       await promptUserForTelemetryPref(true, config);
     }
   }

--- a/packages/faustwp-cli/package.json
+++ b/packages/faustwp-cli/package.json
@@ -25,10 +25,11 @@
     "uuid": "8.3.2"
   },
   "scripts": {
-    "test": "npm test",
     "build": "tsc -p tsconfig.json",
+    "clean": "rimraf dist",
     "dev": "tsc -p tsconfig.json --watch",
-    "clean": "rimraf dist"
+    "format": "prettier --write .",
+    "test": "npm test"
   },
   "repository": {
     "type": "git",

--- a/packages/faustwp-cli/utils/disableCliInteraction.ts
+++ b/packages/faustwp-cli/utils/disableCliInteraction.ts
@@ -8,4 +8,4 @@ export const disableCliInteraction = () => {
   }
 
   return false;
-}
+};

--- a/packages/faustwp-cli/utils/disableCliInteraction.ts
+++ b/packages/faustwp-cli/utils/disableCliInteraction.ts
@@ -1,0 +1,11 @@
+export const disableCliInteraction = () => {
+  if (
+    process.env.FAUST_NO_INTERACTION &&
+    process.env.FAUST_NO_INTERACTION !== '0' &&
+    process.env.FAUST_NO_INTERACTION?.toLowerCase() !== 'false'
+  ) {
+    return true;
+  }
+
+  return false;
+}

--- a/packages/faustwp-cli/utils/index.ts
+++ b/packages/faustwp-cli/utils/index.ts
@@ -1,3 +1,4 @@
+import { disableCliInteraction } from './disableCliInteraction.js';
 import { getCliArgs } from './getCliArgs.js';
 import { errorLog, infoLog } from './log.js';
 import { marshallTelemetryData } from './marshallTelemetryData.js';
@@ -5,18 +6,19 @@ import { promptUserForTelemetryPref } from './promptUserForTelemetryPref.js';
 import { requestWPTelemetryData } from './requestWPTelemetryData.js';
 import { sendTelemetryData } from './sendTelemetryData.js';
 import type { TelemetryData } from './marshallTelemetryData.js';
-import { validateFaustEnvVars } from './validateFaustEnvVars.js';
 import { generatePossibleTypes } from './generatePossibleTypes.js';
+import { validateFaustEnvVars } from './validateFaustEnvVars.js';
 
 export {
-  getCliArgs,
+  disableCliInteraction,
   errorLog,
+  generatePossibleTypes,
+  getCliArgs,
+  infoLog,
   marshallTelemetryData,
   promptUserForTelemetryPref,
-  sendTelemetryData,
   requestWPTelemetryData,
+  sendTelemetryData,
   TelemetryData,
-  infoLog,
   validateFaustEnvVars,
-  generatePossibleTypes,
 };

--- a/packages/faustwp-cli/utils/validateFaustEnvVars.ts
+++ b/packages/faustwp-cli/utils/validateFaustEnvVars.ts
@@ -16,11 +16,7 @@ export const validateFaustEnvVars = () => {
     warnLog('Some functionality may be limited.');
   }
 
-  console.log(process.env.FAUST_NO_INTERACTION)
-  console.log(typeof process.env.FAUST_NO_INTERACTION)
-
-
-  // if (disableCliInteraction()) {
-  //   infoLog('FAUST_NO_INTERACTION is set, specify `false`, `0`, or remove to disable.');
-  // }
+  if (disableCliInteraction()) {
+    infoLog('FAUST_NO_INTERACTION is set. Specify `false`, `0`, or remove to disable.');
+  }
 };

--- a/packages/faustwp-cli/utils/validateFaustEnvVars.ts
+++ b/packages/faustwp-cli/utils/validateFaustEnvVars.ts
@@ -17,6 +17,8 @@ export const validateFaustEnvVars = () => {
   }
 
   if (disableCliInteraction()) {
-    infoLog('FAUST_NO_INTERACTION is set. Specify `false`, `0`, or remove to disable.');
+    infoLog(
+      'FAUST_NO_INTERACTION is set. Specify `false`, `0`, or remove to disable.',
+    );
   }
 };

--- a/packages/faustwp-cli/utils/validateFaustEnvVars.ts
+++ b/packages/faustwp-cli/utils/validateFaustEnvVars.ts
@@ -1,4 +1,5 @@
-import { errorLog, warnLog } from './log.js';
+import { errorLog, warnLog, infoLog } from './log.js';
+import { disableCliInteraction } from './disableCliInteraction.js';
 
 /**
  * Validates that the appropriate Faust related environment variables are set.
@@ -14,4 +15,12 @@ export const validateFaustEnvVars = () => {
     warnLog('Could not find FAUSTWP_SECRET_KEY environment variable.');
     warnLog('Some functionality may be limited.');
   }
+
+  console.log(process.env.FAUST_NO_INTERACTION)
+  console.log(typeof process.env.FAUST_NO_INTERACTION)
+
+
+  // if (disableCliInteraction()) {
+  //   infoLog('FAUST_NO_INTERACTION is set, specify `false`, `0`, or remove to disable.');
+  // }
 };

--- a/packages/faustwp-core/DEVELOPMENT.md
+++ b/packages/faustwp-core/DEVELOPMENT.md
@@ -26,7 +26,7 @@ When switching git branch, run `npm run clean` from the root and then re-run `np
 
 ### 1. Setup
 
-1. Create the following `.env.local` in the `packages/faustwp-core` root and replace the ``NEXT_PUBLIC_GRAPHQL_ENDPOINT`` with your own.
+1. Create the following `.env.local` in the `packages/faustwp-core` root and replace the `NEXT_PUBLIC_GRAPHQL_ENDPOINT` with your own.
 
 ```
 # GraphQL Endpoint
@@ -81,11 +81,13 @@ When you are ready to release, you should first create the new package and plugi
 
 1. Go to [pull requests](https://github.com/wpengine/faustjs/pulls), and view the "Version Packages" PR.
 2. Review the PR:
-  - [ ] Changelog entries were created in all updated packages or plugins.
-  - [ ] Version numbers were appropriately bumped in the relevant package.json files.
-  - [ ] All `.changeset/*.md` files were removed.
-  - [ ] Version number updated in the main plugin file and readme.txt (Plugin versioning only)
-  - [ ] The plugin's readme.txt changelog has been updated with the latest 3 versions (Plugin versioning only)
+
+- [ ] Changelog entries were created in all updated packages or plugins.
+- [ ] Version numbers were appropriately bumped in the relevant package.json files.
+- [ ] All `.changeset/*.md` files were removed.
+- [ ] Version number updated in the main plugin file and readme.txt (Plugin versioning only)
+- [ ] The plugin's readme.txt changelog has been updated with the latest 3 versions (Plugin versioning only)
+
 3. Approve, then "Squash and merge" the "Version Packages" PR into `canary`.
 
 ### Publishing the @faustwp packages

--- a/packages/faustwp-core/package.json
+++ b/packages/faustwp-core/package.json
@@ -38,6 +38,7 @@
     "build": "npm run clean && npm run ts && npm run ts:cjs && npm run package",
     "clean": "rimraf dist",
     "dev": "npm run ts:watch",
+    "format": "prettier --write .",
     "package": "node ../../scripts/package.js",
     "prepublish": "npm run build",
     "test:coverage:ci": "jest --ci --json --coverage --testLocationInResults --outputFile=report.json",

--- a/packages/next/test/useCheckFaustContext.test.tsx
+++ b/packages/next/test/useCheckFaustContext.test.tsx
@@ -3,8 +3,8 @@
  */
 import React from 'react';
 import { render, cleanup } from '@testing-library/react';
-import { useCheckFaustContext } from "../src/gqty/hooks/useCheckFaustContext";
-import { FaustContextType } from "../src/gqty";
+import { useCheckFaustContext } from '../src/gqty/hooks/useCheckFaustContext';
+import { FaustContextType } from '../src/gqty';
 
 describe('useCheckFaustContext hook', () => {
   afterEach(() => {

--- a/packages/next/test/withFaust.test.ts
+++ b/packages/next/test/withFaust.test.ts
@@ -81,20 +81,18 @@ describe('withFaust', () => {
   });
 
   test('preview redirect respects trailingSlash config', async () => {
-    const config = withFaust(
-      {
-        trailingSlash: true,
-        async redirects() {
-          return [
-            {
-              source: '/about',
-              destination: '/',
-              permanent: true,
-            },
-          ];
-        },
-      }
-    );
+    const config = withFaust({
+      trailingSlash: true,
+      async redirects() {
+        return [
+          {
+            source: '/about',
+            destination: '/',
+            permanent: true,
+          },
+        ];
+      },
+    });
 
     const configRedirects = await (config as any).redirects();
 


### PR DESCRIPTION
Signed-off-by: Joe Fusco <joe.fusco@wpengine.com>

## Description

These changes add a new env variable, `FAUST_NO_INTERACTION`, intended for CI/CD environments.

## Testing

1. Checkout `MERL-642-telemetry-env-var`
2. Add `FAUST_NO_INTERACTION=1` to the faustwp example project .env. 
3. Delete any existing faust config: `rm -rf ~/.config/configstore/faust.json`
4. Build CLI: `npm run build:faust-cli`
5. Start Example Project: `npm run dev --workspace=@faustwp/getting-started-example`
6. Notice that project prompts (currently just telemetry) is disabled.

## Screenshots

<img width="1135" alt="Screen Shot 2022-11-18 at 3 51 47 PM" src="https://user-images.githubusercontent.com/6676674/202800240-b0d7d5e6-addc-436d-8792-f07fa122e18f.png">

