### PR TITLE
Fix: Captures CLI process exit code

### DIFF
--- a/.changeset/dirty-beds-cover.md
+++ b/.changeset/dirty-beds-cover.md
@@ -1,0 +1,5 @@
+---
+'@faustwp/cli': patch
+---
+
+Fixes: CLI does not return non zero exit code on unsuccessful build

--- a/packages/faustwp-cli/index.ts
+++ b/packages/faustwp-cli/index.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import Configstore from 'configstore';
-import { spawn } from 'child_process';
+import { spawnSync } from 'child_process';
 import dotenv from 'dotenv-flow';
 import {
   disableCliInteraction,
@@ -107,5 +107,8 @@ const config = new Configstore(CONFIG_STORE_NAME);
    * Spawn a child process using the args captured in argv and continue the
    * standard i/o for the Next.js CLI.
    */
-  spawn('next', getCliArgs(), { stdio: 'inherit' });
+  process.exit(
+    spawnSync('next', getCliArgs(), { stdio: 'inherit', encoding: 'utf8' })
+      ?.status as number | undefined,
+  );
 })();


### PR DESCRIPTION
## Tasks

- [ ] I've filled out the WP Engine Contributor License Agreement (CLA)

## Description

Fixes issue when Faust CLI does not return non zero exit code on unsuccessful build.

## Related Issue(s):

<!--
Provide the GitHub issue(s) number for issue tracking purposes, use the following syntax:

- #1234
-->
https://wpengine.atlassian.net/browse/MERL-656

## Testing

<!--
Describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Also list any relevant details for your test configuration such as how to test the changes locally or in staging.
-->

* Try to build a site that has build errors and echo the exit code. It should be `!= 0` when there is a build error:

**Before:**
```
> @faustwp/getting-started-example@0.1.0 build
> faust build

> Build error occurred
Error: Export encountered errors on following paths:
        /: /en
        /example: /en/example
    at /Users/theo.despoudis/Workspace/faustjs/node_modules/next/dist/export/index.js:394:19
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async Span.traceAsyncFn (/Users/theo.despoudis/Workspace/faustjs/node_modules/next/dist/trace/trace.js:79:20)
    at async /Users/theo.despoudis/Workspace/faustjs/node_modules/next/dist/build/index.js:1168:21
    at async Span.traceAsyncFn (/Users/theo.despoudis/Workspace/faustjs/node_modules/next/dist/trace/trace.js:79:20)
    at async /Users/theo.despoudis/Workspace/faustjs/node_modules/next/dist/build/index.js:1044:17
    at async Span.traceAsyncFn (/Users/theo.despoudis/Workspace/faustjs/node_modules/next/dist/trace/trace.js:79:20)
    at async Object.build [as default] (/Users/theo.despoudis/Workspace/faustjs/node_modules/next/dist/build/index.js:65:29)
npm ERR! Lifecycle script `build` failed with error: 
npm ERR! Error: command failed 
npm ERR!   in workspace: @faustwp/getting-started-example@0.1.0 
npm ERR!   at location: /Users/theo.despoudis/Workspace/faustjs/examples/next/faustwp-getting-started 

```

```
❯ echo $?
0
```

**After**
```
> @faustwp/getting-started-example@0.1.0 build
> faust build

> Build error occurred
Error: Export encountered errors on following paths:
        /: /en
        /example: /en/example
    at /Users/theo.despoudis/Workspace/faustjs/node_modules/next/dist/export/index.js:394:19
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async Span.traceAsyncFn (/Users/theo.despoudis/Workspace/faustjs/node_modules/next/dist/trace/trace.js:79:20)
    at async /Users/theo.despoudis/Workspace/faustjs/node_modules/next/dist/build/index.js:1168:21
    at async Span.traceAsyncFn (/Users/theo.despoudis/Workspace/faustjs/node_modules/next/dist/trace/trace.js:79:20)
    at async /Users/theo.despoudis/Workspace/faustjs/node_modules/next/dist/build/index.js:1044:17
    at async Span.traceAsyncFn (/Users/theo.despoudis/Workspace/faustjs/node_modules/next/dist/trace/trace.js:79:20)
    at async Object.build [as default] (/Users/theo.despoudis/Workspace/faustjs/node_modules/next/dist/build/index.js:65:29)
npm ERR! Lifecycle script `build` failed with error: 
npm ERR! Error: command failed 
npm ERR!   in workspace: @faustwp/getting-started-example@0.1.0 
npm ERR!   at location: /Users/theo.despoudis/Workspace/faustjs/examples/next/faustwp-getting-started 

```

```
❯ echo $?
1
```
## Screenshots

<!--
If this is a visual change include relevant screenshots about the behavior of the application before and after this change.
-->

## Documentation Changes

<!--
List corresponding changes to the documentation.
-->

## Dependant PRs

<!--
List any dependent PR's that are awaiting review. Use the following syntax:

- #1234
-->
