### PR TITLE
Codegen utils

### DIFF
--- a/packages/faustwp-core/src/components/WordPressTemplate.tsx
+++ b/packages/faustwp-core/src/components/WordPressTemplate.tsx
@@ -17,8 +17,8 @@ export type FaustTemplateWithProps<Data, Props> = Props & {
   data?: Data;
   loading?: boolean;
   __SEED_NODE__?: SeedNode | null;
-  __TEMPLATE_QUERY_DATA__: any | null;
-  __TEMPLATE_VARIABLES__: { [key: string]: any };
+  __TEMPLATE_QUERY_DATA__?: any | null;
+  __TEMPLATE_VARIABLES__?: { [key: string]: any };
 };
 
 function cleanTemplate(

--- a/packages/faustwp-core/src/components/WordPressTemplate.tsx
+++ b/packages/faustwp-core/src/components/WordPressTemplate.tsx
@@ -13,10 +13,7 @@ export type WordPressTemplateProps = PropsWithChildren<{
   __TEMPLATE_QUERY_DATA__: any | null;
 }>;
 
-export type FaustTemplateWithProps<
-  Data,
-  Props = Record<string, never>,
-> = Props & {
+export type FaustTemplateProps<Data, Props = Record<string, never>> = Props & {
   data?: Data;
   loading?: boolean;
   __SEED_NODE__?: SeedNode | null;

--- a/packages/faustwp-core/src/components/WordPressTemplate.tsx
+++ b/packages/faustwp-core/src/components/WordPressTemplate.tsx
@@ -13,6 +13,14 @@ export type WordPressTemplateProps = PropsWithChildren<{
   __TEMPLATE_QUERY_DATA__: any | null;
 }>;
 
+export type FaustTemplateWithProps<Data, Props> = Props & {
+  data?: Data;
+  loading?: boolean;
+  __SEED_NODE__?: SeedNode | null;
+  __TEMPLATE_QUERY_DATA__: any | null;
+  __TEMPLATE_VARIABLES__: { [key: string]: any };
+};
+
 function cleanTemplate(
   template: WordPressTemplateType,
 ): React.FC<{ [key: string]: any }> {

--- a/packages/faustwp-core/src/components/WordPressTemplate.tsx
+++ b/packages/faustwp-core/src/components/WordPressTemplate.tsx
@@ -13,7 +13,10 @@ export type WordPressTemplateProps = PropsWithChildren<{
   __TEMPLATE_QUERY_DATA__: any | null;
 }>;
 
-export type FaustTemplateWithProps<Data, Props> = Props & {
+export type FaustTemplateWithProps<
+  Data,
+  Props = Record<string, never>,
+> = Props & {
   data?: Data;
   loading?: boolean;
   __SEED_NODE__?: SeedNode | null;

--- a/packages/faustwp-core/src/getWordPressProps.tsx
+++ b/packages/faustwp-core/src/getWordPressProps.tsx
@@ -80,12 +80,13 @@ export async function getWordPressProps(options: GetWordPressPropsConfig) {
   }
 
   let templateQueryRes;
+  const templateVariables = template?.variables
+    ? template?.variables(seedNode, { asPreview: false })
+    : undefined;
   if (template.query) {
     templateQueryRes = await client.query({
       query: template.query,
-      variables: template?.variables
-        ? template?.variables(seedNode, { asPreview: false })
-        : undefined,
+      variables: templateVariables,
     });
   }
 
@@ -98,6 +99,7 @@ export async function getWordPressProps(options: GetWordPressPropsConfig) {
        */
       __SEED_NODE__: seedNode ?? null,
       __TEMPLATE_QUERY_DATA__: templateQueryRes?.data ?? null,
+      __TEMPLATE_VARIABLES__: templateVariables ?? null,
     },
   });
 }

--- a/packages/faustwp-core/src/index.ts
+++ b/packages/faustwp-core/src/index.ts
@@ -1,7 +1,7 @@
 import { FaustProvider } from './components/FaustProvider.js';
 import {
   WordPressTemplate,
-  FaustTemplateWithProps,
+  FaustTemplateProps,
 } from './components/WordPressTemplate.js';
 import { getWordPressProps } from './getWordPressProps.js';
 import { getNextStaticProps } from './getProps.js';
@@ -17,7 +17,7 @@ import { getApolloClient, addApolloState } from './client.js';
 export {
   FaustProvider,
   WordPressTemplate,
-  FaustTemplateWithProps,
+  FaustTemplateProps,
   getWordPressProps,
   getNextStaticProps,
   getConfig,

--- a/packages/faustwp-core/src/index.ts
+++ b/packages/faustwp-core/src/index.ts
@@ -1,5 +1,8 @@
 import { FaustProvider } from './components/FaustProvider.js';
-import { WordPressTemplate } from './components/WordPressTemplate.js';
+import {
+  WordPressTemplate,
+  FaustTemplateWithProps,
+} from './components/WordPressTemplate.js';
 import { getWordPressProps } from './getWordPressProps.js';
 import { getNextStaticProps } from './getProps.js';
 import { getConfig, setConfig, FaustConfig } from './config/index.js';
@@ -14,6 +17,7 @@ import { getApolloClient, addApolloState } from './client.js';
 export {
   FaustProvider,
   WordPressTemplate,
+  FaustTemplateWithProps,
   getWordPressProps,
   getNextStaticProps,
   getConfig,


### PR DESCRIPTION
## Tasks

- [ ] I've filled out the WP Engine Contributor License Agreement (CLA)

## Description

This PR introduces some utils/features for TypeScript:
* `FaustTemplateProps` which can be used to type the incoming props from a Faust Template, in addition to the shape of the `data`
* Returns the Template variables object as a prop called `props.__TEMPLATE_VARIABLES__`. This follows the same convention for the `__TEMPLATE_QUERY_DATA__` and `__SEED_NODE__`.
  * Ideally, we should build some hooks with React Context to return these as apart of our API so we can safely rename these in the future if needed. Think `useSeedNode()`, `useTemplateVariables()`, etc. But that is for a future discussion.

## Related Issue(s):

<!--
Provide the GitHub issue(s) number for issue tracking purposes, use the following syntax:

- #1234
-->

## Testing

1. Check out this PR and build the faustwp packages
2. `cd examples/next/faustwp-getting-started`
3. `touch tsconfig.json`
4. Rename `wp-templates/page.js` -> `wp-templates/page.tsx`
5. `npm run dev`
6. Replace the page.tsx file with the following code:
```tsx
import { gql } from '@apollo/client';
import { FaustTemplateProps } from '@faustwp/core';

// Just for testing. This will be generated by Apollo/CodeGen
interface GetPageQuery {
  page: {
    title: string;
    content: string;
  };
}

export default function Component(props: FaustTemplateProps<GetPageQuery>) {
  // Loading state for previews
  if (props.loading) {
    return <>Loading...</>;
  }

  console.log(props.__TEMPLATE_VARIABLES__);

  console.log(props.data);
  console.log(props.data.page.title); // string
  console.log(props.data.page.content); // string

  return <>Check the console</>;
}

Component.variables = ({ databaseId }, ctx) => {
  return {
    databaseId,
    asPreview: ctx?.asPreview,
  };
};

Component.query = gql`
  query GetPageData($databaseId: ID!, $asPreview: Boolean = false) {
    page(id: $databaseId, idType: DATABASE_ID, asPreview: $asPreview) {
      title
      content
    }
  }
`;
```
7. Check the console

## Screenshots

<!--
If this is a visual change include relevant screenshots about the behavior of the application before and after this change.
-->

## Documentation Changes

<!--
List corresponding changes to the documentation.
-->

## Dependant PRs

<!--
List any dependent PR's that are awaiting review. Use the following syntax:

- #1234
-->
