### PR TITLE
Generate changeset for latest plugin updates

### DIFF
--- a/.changeset/light-donkeys-admire.md
+++ b/.changeset/light-donkeys-admire.md
@@ -1,0 +1,5 @@
+---
+'@faustwp/wordpress-plugin': patch
+---
+
+Update changelog plugin title


### PR DESCRIPTION
Signed-off-by: Joe Fusco <joe.fusco@wpengine.com>

## Tasks

- [X] I've filled out the WP Engine Contributor License Agreement (CLA)

## Description

This changeset was generated for https://github.com/wpengine/faustjs/pull/1120 in order to include these changes with the next release of our [WordPress plugin](https://wordpress.org/plugins/faustwp/).

Props to @TeresaGobble for calling this out!