### PR TITLE
Support props/revalidate in getWordPressProps

### DIFF
--- a/.changeset/fresh-pandas-pull.md
+++ b/.changeset/fresh-pandas-pull.md
@@ -1,0 +1,5 @@
+---
+'@faustwp/core': patch
+---
+
+Added: Template variables are now being returned to the client via the `__TEMPLATE_VARIABLES__` prop.

--- a/.changeset/grumpy-windows-provide.md
+++ b/.changeset/grumpy-windows-provide.md
@@ -2,5 +2,4 @@
 '@faustwp/core': patch
 ---
 
-- Added: `FaustTemplateProps<TemplateDataType, AdditionalProps>` TypeScript type so you can type your incoming props from Faust Templates
-- Added: Template variables are now being returned to the client via the `__TEMPLATE_VARIABLES__` prop.
+Added: `FaustTemplateProps<TemplateDataType, AdditionalProps>` TypeScript type so you can type your incoming props from Faust Templates

--- a/.changeset/modern-bulldogs-clap.md
+++ b/.changeset/modern-bulldogs-clap.md
@@ -1,0 +1,5 @@
+---
+'@faustwp/core': patch
+---
+
+`getWordPressProps` now sets a smart default `revalidate` of `900` (15 minutes) when using `getStaticProps`

--- a/.changeset/new-birds-brush.md
+++ b/.changeset/new-birds-brush.md
@@ -1,0 +1,5 @@
+---
+'@faustwp/core': patch
+---
+
+`getWordPressProps()` now accepts `props` and `revalidate` as apart of its `options` object parameter.

--- a/packages/faustwp-core/src/client.ts
+++ b/packages/faustwp-core/src/client.ts
@@ -98,9 +98,11 @@ export function addApolloState(
   client: ApolloClient<NormalizedCacheObject>,
   pageProps: AppProps<{
     props: { [key: string]: any };
+    revalidate?: number | boolean;
   }>['pageProps'],
 ): AppProps<{
   props: { [key: string]: any };
+  revalidate?: number | boolean;
 }>['pageProps'] {
   if (pageProps?.props) {
     // eslint-disable-next-line no-param-reassign


### PR DESCRIPTION
## Tasks

- [x] I've filled out the WP Engine Contributor License Agreement (CLA)

## Description

This PR introduces `props` and `revalidate` to the `getWordPressProps` options config object. It also sets a default `revalidate` to `900` (15 minutes) when using `getStaticProps`.

Also cleaned up the PRs to have each change have it's own changeset so it's reflected properly in the changelog.md

## Related Issue(s):

<!--
Provide the GitHub issue(s) number for issue tracking purposes, use the following syntax:

- #1234
-->

## Testing

1. Pull in the PR
2. Update `[...wordpressNode].js` with the following content:
    ```js
    import { getWordPressProps, WordPressTemplate } from '@faustwp/core';
    
    export default function Page(props) {
      return <WordPressTemplate {...props} />;
    }
    
    export async function getStaticProps(ctx) {
      const appProps = await getWordPressProps({
        ctx,
        props: {
          myProp: 'testing',
        },
      });
    
      console.log(appProps);
    
      return appProps;
    }
    
    export async function getStaticPaths() {
      return {
        paths: [],
        fallback: 'blocking',
      };
    }
    ```
3. `npm run dev`
4. Go to a page and notice the `appProps` being console logged. You should see both the `myProp` and a default `revalidate` of `900` **(NOTE: `revalidate` does not live in the `props` object, it lives outside of it in the `appProps` object.)**
5. Now set a custom `revalidate`:
    ```js
    import { getWordPressProps, WordPressTemplate } from '@faustwp/core';
    
    export default function Page(props) {
      return <WordPressTemplate {...props} />;
    }
    
    export async function getStaticProps(ctx) {
      const appProps = await getWordPressProps({
        ctx,
        props: {
          myProp: 'testing',
        },
        revalidate: 5
      });
    
      console.log(appProps);
    
      return appProps;
    }
    
    export async function getStaticPaths() {
      return {
        paths: [],
        fallback: 'blocking',
      };
    }
    ```
6. Refresh the page and notice the `appProps` being console logged. You should see both the `myProp` and a custom `revalidate` of `5`

<!--
Describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Also list any relevant details for your test configuration such as how to test the changes locally or in staging.
-->

## Screenshots

<!--
If this is a visual change include relevant screenshots about the behavior of the application before and after this change.
-->

## Documentation Changes

<!--
List corresponding changes to the documentation.
-->

## Dependant PRs

<!--
List any dependent PR's that are awaiting review. Use the following syntax:

- #1234
-->
