### PR TITLE
Remove telemetry prompt in favor of CLI message

### DIFF
--- a/packages/faustwp-cli/utils/doTelemetryPrefsExist.ts
+++ b/packages/faustwp-cli/utils/doTelemetryPrefsExist.ts
@@ -1,0 +1,9 @@
+import { ConfigStoreType } from '../index.js';
+
+export function TelemetryPrefsExist(config: ConfigStoreType): boolean {
+  return (
+    config.all.telemetry !== undefined &&
+    config.all.telemetry.anonymousId !== undefined &&
+    config.all.telemetry.enabled !== undefined
+  );
+}


### PR DESCRIPTION
## Tasks

- [x] I've filled out the WP Engine Contributor License Agreement (CLA)

## Description

This PR removes the telemetry prompt when running CLI commands (except for `npx faust faust-telemetry`) in favor of a CLI message:

> Faust has completely anonymous, opt-in Telemetry! You can enable it by running "npx faust faust-telemetry"

## Related Issue(s):

<!--
Provide the GitHub issue(s) number for issue tracking purposes, use the following syntax:

- #1234
-->

## Context:
It has proven difficult to determine all of the scenerios in which the telemetry prompt should not be run (re: non-interactive modes, CI/CD, etc). Rather than trying to catch every edge case possible, and risking timing out production builds, using a CLI message instead will avoid this, and will return the CLI to a non-interactive CLI by default.

## Testing

1. Check out this PR
2. `npm run build -w @faustwp/cli`
3. `mv ~/.config/configstore/faust.json ~/.config/configstore/faust-backup.json`
4. `npm run dev -w @faustwp/getting-started-example`
5. Notice the Telemetry message
6. `mv ~/.config/configstore/faust-backup.json ~/.config/configstore/faust.json`
7. `npm run dev -w @faustwp/getting-started-example`
8. Notice no telemetry message since preferences exist

## Screenshots

No preferences saved:
<img width="1386" alt="Screenshot 2022-12-05 at 9 17 16 PM" src="https://user-images.githubusercontent.com/5946219/205804622-14cf6d00-eca5-4c2d-9130-87b98e4b925b.png">

With preferences saved:
<img width="1243" alt="Screenshot 2022-12-05 at 9 18 01 PM" src="https://user-images.githubusercontent.com/5946219/205804651-d3b396d6-944b-4834-9ead-44761608c0c8.png">


<!--
If this is a visual change include relevant screenshots about the behavior of the application before and after this change.
-->

## Documentation Changes

<!--
List corresponding changes to the documentation.
-->

## Dependant PRs

<!--
List any dependent PR's that are awaiting review. Use the following syntax:

- #1234
-->
