### PR TITLE
Merl 655 add analytics to faustjs org

### DIFF
--- a/internal/faustjs.org/docusaurus.config.js
+++ b/internal/faustjs.org/docusaurus.config.js
@@ -167,6 +167,10 @@ module.exports = {
         theme: {
           customCss: require.resolve('./src/css/custom.css'),
         },
+        gtag: {
+          trackingID: 'G-J8K2JTXB1B',
+          anonymizeIP: true,
+        },
       },
     ],
   ],

--- a/internal/faustjs.org/package-lock.json
+++ b/internal/faustjs.org/package-lock.json
@@ -9,6 +9,7 @@
       "dependencies": {
         "@docusaurus/core": "^2.1.0",
         "@docusaurus/plugin-client-redirects": "^2.1.0",
+        "@docusaurus/plugin-google-gtag": "^2.2.0",
         "@docusaurus/preset-classic": "^2.1.0",
         "@mdx-js/react": "^1.6.22",
         "@svgr/webpack": "^6.4.0",
@@ -2300,13 +2301,13 @@
       }
     },
     "node_modules/@docusaurus/plugin-google-gtag": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-2.1.0.tgz",
-      "integrity": "sha512-/3aDlv2dMoCeiX2e+DTGvvrdTA+v3cKQV3DbmfsF4ENhvc5nKV23nth04Z3Vq0Ci1ui6Sn80TkhGk/tiCMW2AA==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-2.2.0.tgz",
+      "integrity": "sha512-6SOgczP/dYdkqUMGTRqgxAS1eTp6MnJDAQMy8VCF1QKbWZmlkx4agHDexihqmYyCujTYHqDAhm1hV26EET54NQ==",
       "dependencies": {
-        "@docusaurus/core": "2.1.0",
-        "@docusaurus/types": "2.1.0",
-        "@docusaurus/utils-validation": "2.1.0",
+        "@docusaurus/core": "2.2.0",
+        "@docusaurus/types": "2.2.0",
+        "@docusaurus/utils-validation": "2.2.0",
         "tslib": "^2.4.0"
       },
       "engines": {
@@ -2315,6 +2316,237 @@
       "peerDependencies": {
         "react": "^16.8.4 || ^17.0.0",
         "react-dom": "^16.8.4 || ^17.0.0"
+      }
+    },
+    "node_modules/@docusaurus/plugin-google-gtag/node_modules/@docusaurus/core": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-2.2.0.tgz",
+      "integrity": "sha512-Vd6XOluKQqzG12fEs9prJgDtyn6DPok9vmUWDR2E6/nV5Fl9SVkhEQOBxwObjk3kQh7OY7vguFaLh0jqdApWsA==",
+      "dependencies": {
+        "@babel/core": "^7.18.6",
+        "@babel/generator": "^7.18.7",
+        "@babel/plugin-syntax-dynamic-import": "^7.8.3",
+        "@babel/plugin-transform-runtime": "^7.18.6",
+        "@babel/preset-env": "^7.18.6",
+        "@babel/preset-react": "^7.18.6",
+        "@babel/preset-typescript": "^7.18.6",
+        "@babel/runtime": "^7.18.6",
+        "@babel/runtime-corejs3": "^7.18.6",
+        "@babel/traverse": "^7.18.8",
+        "@docusaurus/cssnano-preset": "2.2.0",
+        "@docusaurus/logger": "2.2.0",
+        "@docusaurus/mdx-loader": "2.2.0",
+        "@docusaurus/react-loadable": "5.5.2",
+        "@docusaurus/utils": "2.2.0",
+        "@docusaurus/utils-common": "2.2.0",
+        "@docusaurus/utils-validation": "2.2.0",
+        "@slorber/static-site-generator-webpack-plugin": "^4.0.7",
+        "@svgr/webpack": "^6.2.1",
+        "autoprefixer": "^10.4.7",
+        "babel-loader": "^8.2.5",
+        "babel-plugin-dynamic-import-node": "^2.3.3",
+        "boxen": "^6.2.1",
+        "chalk": "^4.1.2",
+        "chokidar": "^3.5.3",
+        "clean-css": "^5.3.0",
+        "cli-table3": "^0.6.2",
+        "combine-promises": "^1.1.0",
+        "commander": "^5.1.0",
+        "copy-webpack-plugin": "^11.0.0",
+        "core-js": "^3.23.3",
+        "css-loader": "^6.7.1",
+        "css-minimizer-webpack-plugin": "^4.0.0",
+        "cssnano": "^5.1.12",
+        "del": "^6.1.1",
+        "detect-port": "^1.3.0",
+        "escape-html": "^1.0.3",
+        "eta": "^1.12.3",
+        "file-loader": "^6.2.0",
+        "fs-extra": "^10.1.0",
+        "html-minifier-terser": "^6.1.0",
+        "html-tags": "^3.2.0",
+        "html-webpack-plugin": "^5.5.0",
+        "import-fresh": "^3.3.0",
+        "leven": "^3.1.0",
+        "lodash": "^4.17.21",
+        "mini-css-extract-plugin": "^2.6.1",
+        "postcss": "^8.4.14",
+        "postcss-loader": "^7.0.0",
+        "prompts": "^2.4.2",
+        "react-dev-utils": "^12.0.1",
+        "react-helmet-async": "^1.3.0",
+        "react-loadable": "npm:@docusaurus/react-loadable@5.5.2",
+        "react-loadable-ssr-addon-v5-slorber": "^1.0.1",
+        "react-router": "^5.3.3",
+        "react-router-config": "^5.1.1",
+        "react-router-dom": "^5.3.3",
+        "rtl-detect": "^1.0.4",
+        "semver": "^7.3.7",
+        "serve-handler": "^6.1.3",
+        "shelljs": "^0.8.5",
+        "terser-webpack-plugin": "^5.3.3",
+        "tslib": "^2.4.0",
+        "update-notifier": "^5.1.0",
+        "url-loader": "^4.1.1",
+        "wait-on": "^6.0.1",
+        "webpack": "^5.73.0",
+        "webpack-bundle-analyzer": "^4.5.0",
+        "webpack-dev-server": "^4.9.3",
+        "webpack-merge": "^5.8.0",
+        "webpackbar": "^5.0.2"
+      },
+      "bin": {
+        "docusaurus": "bin/docusaurus.mjs"
+      },
+      "engines": {
+        "node": ">=16.14"
+      },
+      "peerDependencies": {
+        "react": "^16.8.4 || ^17.0.0",
+        "react-dom": "^16.8.4 || ^17.0.0"
+      }
+    },
+    "node_modules/@docusaurus/plugin-google-gtag/node_modules/@docusaurus/cssnano-preset": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-2.2.0.tgz",
+      "integrity": "sha512-mAAwCo4n66TMWBH1kXnHVZsakW9VAXJzTO4yZukuL3ro4F+JtkMwKfh42EG75K/J/YIFQG5I/Bzy0UH/hFxaTg==",
+      "dependencies": {
+        "cssnano-preset-advanced": "^5.3.8",
+        "postcss": "^8.4.14",
+        "postcss-sort-media-queries": "^4.2.1",
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=16.14"
+      }
+    },
+    "node_modules/@docusaurus/plugin-google-gtag/node_modules/@docusaurus/logger": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-2.2.0.tgz",
+      "integrity": "sha512-DF3j1cA5y2nNsu/vk8AG7xwpZu6f5MKkPPMaaIbgXLnWGfm6+wkOeW7kNrxnM95YOhKUkJUophX69nGUnLsm0A==",
+      "dependencies": {
+        "chalk": "^4.1.2",
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=16.14"
+      }
+    },
+    "node_modules/@docusaurus/plugin-google-gtag/node_modules/@docusaurus/mdx-loader": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-2.2.0.tgz",
+      "integrity": "sha512-X2bzo3T0jW0VhUU+XdQofcEeozXOTmKQMvc8tUnWRdTnCvj4XEcBVdC3g+/jftceluiwSTNRAX4VBOJdNt18jA==",
+      "dependencies": {
+        "@babel/parser": "^7.18.8",
+        "@babel/traverse": "^7.18.8",
+        "@docusaurus/logger": "2.2.0",
+        "@docusaurus/utils": "2.2.0",
+        "@mdx-js/mdx": "^1.6.22",
+        "escape-html": "^1.0.3",
+        "file-loader": "^6.2.0",
+        "fs-extra": "^10.1.0",
+        "image-size": "^1.0.1",
+        "mdast-util-to-string": "^2.0.0",
+        "remark-emoji": "^2.2.0",
+        "stringify-object": "^3.3.0",
+        "tslib": "^2.4.0",
+        "unified": "^9.2.2",
+        "unist-util-visit": "^2.0.3",
+        "url-loader": "^4.1.1",
+        "webpack": "^5.73.0"
+      },
+      "engines": {
+        "node": ">=16.14"
+      },
+      "peerDependencies": {
+        "react": "^16.8.4 || ^17.0.0",
+        "react-dom": "^16.8.4 || ^17.0.0"
+      }
+    },
+    "node_modules/@docusaurus/plugin-google-gtag/node_modules/@docusaurus/types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-2.2.0.tgz",
+      "integrity": "sha512-b6xxyoexfbRNRI8gjblzVOnLr4peCJhGbYGPpJ3LFqpi5nsFfoK4mmDLvWdeah0B7gmJeXabN7nQkFoqeSdmOw==",
+      "dependencies": {
+        "@types/history": "^4.7.11",
+        "@types/react": "*",
+        "commander": "^5.1.0",
+        "joi": "^17.6.0",
+        "react-helmet-async": "^1.3.0",
+        "utility-types": "^3.10.0",
+        "webpack": "^5.73.0",
+        "webpack-merge": "^5.8.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.4 || ^17.0.0",
+        "react-dom": "^16.8.4 || ^17.0.0"
+      }
+    },
+    "node_modules/@docusaurus/plugin-google-gtag/node_modules/@docusaurus/utils": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-2.2.0.tgz",
+      "integrity": "sha512-oNk3cjvx7Tt1Lgh/aeZAmFpGV2pDr5nHKrBVx6hTkzGhrnMuQqLt6UPlQjdYQ3QHXwyF/ZtZMO1D5Pfi0lu7SA==",
+      "dependencies": {
+        "@docusaurus/logger": "2.2.0",
+        "@svgr/webpack": "^6.2.1",
+        "file-loader": "^6.2.0",
+        "fs-extra": "^10.1.0",
+        "github-slugger": "^1.4.0",
+        "globby": "^11.1.0",
+        "gray-matter": "^4.0.3",
+        "js-yaml": "^4.1.0",
+        "lodash": "^4.17.21",
+        "micromatch": "^4.0.5",
+        "resolve-pathname": "^3.0.0",
+        "shelljs": "^0.8.5",
+        "tslib": "^2.4.0",
+        "url-loader": "^4.1.1",
+        "webpack": "^5.73.0"
+      },
+      "engines": {
+        "node": ">=16.14"
+      },
+      "peerDependencies": {
+        "@docusaurus/types": "*"
+      },
+      "peerDependenciesMeta": {
+        "@docusaurus/types": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@docusaurus/plugin-google-gtag/node_modules/@docusaurus/utils-common": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-2.2.0.tgz",
+      "integrity": "sha512-qebnerHp+cyovdUseDQyYFvMW1n1nv61zGe5JJfoNQUnjKuApch3IVsz+/lZ9a38pId8kqehC1Ao2bW/s0ntDA==",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=16.14"
+      },
+      "peerDependencies": {
+        "@docusaurus/types": "*"
+      },
+      "peerDependenciesMeta": {
+        "@docusaurus/types": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@docusaurus/plugin-google-gtag/node_modules/@docusaurus/utils-validation": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-2.2.0.tgz",
+      "integrity": "sha512-I1hcsG3yoCkasOL5qQAYAfnmVoLei7apugT6m4crQjmDGxq+UkiRrq55UqmDDyZlac/6ax/JC0p+usZ6W4nVyg==",
+      "dependencies": {
+        "@docusaurus/logger": "2.2.0",
+        "@docusaurus/utils": "2.2.0",
+        "joi": "^17.6.0",
+        "js-yaml": "^4.1.0",
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=16.14"
       }
     },
     "node_modules/@docusaurus/plugin-sitemap": {
@@ -2357,6 +2589,24 @@
         "@docusaurus/theme-common": "2.1.0",
         "@docusaurus/theme-search-algolia": "2.1.0",
         "@docusaurus/types": "2.1.0"
+      },
+      "engines": {
+        "node": ">=16.14"
+      },
+      "peerDependencies": {
+        "react": "^16.8.4 || ^17.0.0",
+        "react-dom": "^16.8.4 || ^17.0.0"
+      }
+    },
+    "node_modules/@docusaurus/preset-classic/node_modules/@docusaurus/plugin-google-gtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-2.1.0.tgz",
+      "integrity": "sha512-/3aDlv2dMoCeiX2e+DTGvvrdTA+v3cKQV3DbmfsF4ENhvc5nKV23nth04Z3Vq0Ci1ui6Sn80TkhGk/tiCMW2AA==",
+      "dependencies": {
+        "@docusaurus/core": "2.1.0",
+        "@docusaurus/types": "2.1.0",
+        "@docusaurus/utils-validation": "2.1.0",
+        "tslib": "^2.4.0"
       },
       "engines": {
         "node": ">=16.14"
@@ -14099,14 +14349,195 @@
       }
     },
     "@docusaurus/plugin-google-gtag": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-2.1.0.tgz",
-      "integrity": "sha512-/3aDlv2dMoCeiX2e+DTGvvrdTA+v3cKQV3DbmfsF4ENhvc5nKV23nth04Z3Vq0Ci1ui6Sn80TkhGk/tiCMW2AA==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-2.2.0.tgz",
+      "integrity": "sha512-6SOgczP/dYdkqUMGTRqgxAS1eTp6MnJDAQMy8VCF1QKbWZmlkx4agHDexihqmYyCujTYHqDAhm1hV26EET54NQ==",
       "requires": {
-        "@docusaurus/core": "2.1.0",
-        "@docusaurus/types": "2.1.0",
-        "@docusaurus/utils-validation": "2.1.0",
+        "@docusaurus/core": "2.2.0",
+        "@docusaurus/types": "2.2.0",
+        "@docusaurus/utils-validation": "2.2.0",
         "tslib": "^2.4.0"
+      },
+      "dependencies": {
+        "@docusaurus/core": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-2.2.0.tgz",
+          "integrity": "sha512-Vd6XOluKQqzG12fEs9prJgDtyn6DPok9vmUWDR2E6/nV5Fl9SVkhEQOBxwObjk3kQh7OY7vguFaLh0jqdApWsA==",
+          "requires": {
+            "@babel/core": "^7.18.6",
+            "@babel/generator": "^7.18.7",
+            "@babel/plugin-syntax-dynamic-import": "^7.8.3",
+            "@babel/plugin-transform-runtime": "^7.18.6",
+            "@babel/preset-env": "^7.18.6",
+            "@babel/preset-react": "^7.18.6",
+            "@babel/preset-typescript": "^7.18.6",
+            "@babel/runtime": "^7.18.6",
+            "@babel/runtime-corejs3": "^7.18.6",
+            "@babel/traverse": "^7.18.8",
+            "@docusaurus/cssnano-preset": "2.2.0",
+            "@docusaurus/logger": "2.2.0",
+            "@docusaurus/mdx-loader": "2.2.0",
+            "@docusaurus/react-loadable": "5.5.2",
+            "@docusaurus/utils": "2.2.0",
+            "@docusaurus/utils-common": "2.2.0",
+            "@docusaurus/utils-validation": "2.2.0",
+            "@slorber/static-site-generator-webpack-plugin": "^4.0.7",
+            "@svgr/webpack": "^6.2.1",
+            "autoprefixer": "^10.4.7",
+            "babel-loader": "^8.2.5",
+            "babel-plugin-dynamic-import-node": "^2.3.3",
+            "boxen": "^6.2.1",
+            "chalk": "^4.1.2",
+            "chokidar": "^3.5.3",
+            "clean-css": "^5.3.0",
+            "cli-table3": "^0.6.2",
+            "combine-promises": "^1.1.0",
+            "commander": "^5.1.0",
+            "copy-webpack-plugin": "^11.0.0",
+            "core-js": "^3.23.3",
+            "css-loader": "^6.7.1",
+            "css-minimizer-webpack-plugin": "^4.0.0",
+            "cssnano": "^5.1.12",
+            "del": "^6.1.1",
+            "detect-port": "^1.3.0",
+            "escape-html": "^1.0.3",
+            "eta": "^1.12.3",
+            "file-loader": "^6.2.0",
+            "fs-extra": "^10.1.0",
+            "html-minifier-terser": "^6.1.0",
+            "html-tags": "^3.2.0",
+            "html-webpack-plugin": "^5.5.0",
+            "import-fresh": "^3.3.0",
+            "leven": "^3.1.0",
+            "lodash": "^4.17.21",
+            "mini-css-extract-plugin": "^2.6.1",
+            "postcss": "^8.4.14",
+            "postcss-loader": "^7.0.0",
+            "prompts": "^2.4.2",
+            "react-dev-utils": "^12.0.1",
+            "react-helmet-async": "^1.3.0",
+            "react-loadable": "npm:@docusaurus/react-loadable@5.5.2",
+            "react-loadable-ssr-addon-v5-slorber": "^1.0.1",
+            "react-router": "^5.3.3",
+            "react-router-config": "^5.1.1",
+            "react-router-dom": "^5.3.3",
+            "rtl-detect": "^1.0.4",
+            "semver": "^7.3.7",
+            "serve-handler": "^6.1.3",
+            "shelljs": "^0.8.5",
+            "terser-webpack-plugin": "^5.3.3",
+            "tslib": "^2.4.0",
+            "update-notifier": "^5.1.0",
+            "url-loader": "^4.1.1",
+            "wait-on": "^6.0.1",
+            "webpack": "^5.73.0",
+            "webpack-bundle-analyzer": "^4.5.0",
+            "webpack-dev-server": "^4.9.3",
+            "webpack-merge": "^5.8.0",
+            "webpackbar": "^5.0.2"
+          }
+        },
+        "@docusaurus/cssnano-preset": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-2.2.0.tgz",
+          "integrity": "sha512-mAAwCo4n66TMWBH1kXnHVZsakW9VAXJzTO4yZukuL3ro4F+JtkMwKfh42EG75K/J/YIFQG5I/Bzy0UH/hFxaTg==",
+          "requires": {
+            "cssnano-preset-advanced": "^5.3.8",
+            "postcss": "^8.4.14",
+            "postcss-sort-media-queries": "^4.2.1",
+            "tslib": "^2.4.0"
+          }
+        },
+        "@docusaurus/logger": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-2.2.0.tgz",
+          "integrity": "sha512-DF3j1cA5y2nNsu/vk8AG7xwpZu6f5MKkPPMaaIbgXLnWGfm6+wkOeW7kNrxnM95YOhKUkJUophX69nGUnLsm0A==",
+          "requires": {
+            "chalk": "^4.1.2",
+            "tslib": "^2.4.0"
+          }
+        },
+        "@docusaurus/mdx-loader": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-2.2.0.tgz",
+          "integrity": "sha512-X2bzo3T0jW0VhUU+XdQofcEeozXOTmKQMvc8tUnWRdTnCvj4XEcBVdC3g+/jftceluiwSTNRAX4VBOJdNt18jA==",
+          "requires": {
+            "@babel/parser": "^7.18.8",
+            "@babel/traverse": "^7.18.8",
+            "@docusaurus/logger": "2.2.0",
+            "@docusaurus/utils": "2.2.0",
+            "@mdx-js/mdx": "^1.6.22",
+            "escape-html": "^1.0.3",
+            "file-loader": "^6.2.0",
+            "fs-extra": "^10.1.0",
+            "image-size": "^1.0.1",
+            "mdast-util-to-string": "^2.0.0",
+            "remark-emoji": "^2.2.0",
+            "stringify-object": "^3.3.0",
+            "tslib": "^2.4.0",
+            "unified": "^9.2.2",
+            "unist-util-visit": "^2.0.3",
+            "url-loader": "^4.1.1",
+            "webpack": "^5.73.0"
+          }
+        },
+        "@docusaurus/types": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-2.2.0.tgz",
+          "integrity": "sha512-b6xxyoexfbRNRI8gjblzVOnLr4peCJhGbYGPpJ3LFqpi5nsFfoK4mmDLvWdeah0B7gmJeXabN7nQkFoqeSdmOw==",
+          "requires": {
+            "@types/history": "^4.7.11",
+            "@types/react": "*",
+            "commander": "^5.1.0",
+            "joi": "^17.6.0",
+            "react-helmet-async": "^1.3.0",
+            "utility-types": "^3.10.0",
+            "webpack": "^5.73.0",
+            "webpack-merge": "^5.8.0"
+          }
+        },
+        "@docusaurus/utils": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-2.2.0.tgz",
+          "integrity": "sha512-oNk3cjvx7Tt1Lgh/aeZAmFpGV2pDr5nHKrBVx6hTkzGhrnMuQqLt6UPlQjdYQ3QHXwyF/ZtZMO1D5Pfi0lu7SA==",
+          "requires": {
+            "@docusaurus/logger": "2.2.0",
+            "@svgr/webpack": "^6.2.1",
+            "file-loader": "^6.2.0",
+            "fs-extra": "^10.1.0",
+            "github-slugger": "^1.4.0",
+            "globby": "^11.1.0",
+            "gray-matter": "^4.0.3",
+            "js-yaml": "^4.1.0",
+            "lodash": "^4.17.21",
+            "micromatch": "^4.0.5",
+            "resolve-pathname": "^3.0.0",
+            "shelljs": "^0.8.5",
+            "tslib": "^2.4.0",
+            "url-loader": "^4.1.1",
+            "webpack": "^5.73.0"
+          }
+        },
+        "@docusaurus/utils-common": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-2.2.0.tgz",
+          "integrity": "sha512-qebnerHp+cyovdUseDQyYFvMW1n1nv61zGe5JJfoNQUnjKuApch3IVsz+/lZ9a38pId8kqehC1Ao2bW/s0ntDA==",
+          "requires": {
+            "tslib": "^2.4.0"
+          }
+        },
+        "@docusaurus/utils-validation": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-2.2.0.tgz",
+          "integrity": "sha512-I1hcsG3yoCkasOL5qQAYAfnmVoLei7apugT6m4crQjmDGxq+UkiRrq55UqmDDyZlac/6ax/JC0p+usZ6W4nVyg==",
+          "requires": {
+            "@docusaurus/logger": "2.2.0",
+            "@docusaurus/utils": "2.2.0",
+            "joi": "^17.6.0",
+            "js-yaml": "^4.1.0",
+            "tslib": "^2.4.0"
+          }
+        }
       }
     },
     "@docusaurus/plugin-sitemap": {
@@ -14142,6 +14573,19 @@
         "@docusaurus/theme-common": "2.1.0",
         "@docusaurus/theme-search-algolia": "2.1.0",
         "@docusaurus/types": "2.1.0"
+      },
+      "dependencies": {
+        "@docusaurus/plugin-google-gtag": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-2.1.0.tgz",
+          "integrity": "sha512-/3aDlv2dMoCeiX2e+DTGvvrdTA+v3cKQV3DbmfsF4ENhvc5nKV23nth04Z3Vq0Ci1ui6Sn80TkhGk/tiCMW2AA==",
+          "requires": {
+            "@docusaurus/core": "2.1.0",
+            "@docusaurus/types": "2.1.0",
+            "@docusaurus/utils-validation": "2.1.0",
+            "tslib": "^2.4.0"
+          }
+        }
       }
     },
     "@docusaurus/react-loadable": {

--- a/internal/faustjs.org/package.json
+++ b/internal/faustjs.org/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "@docusaurus/core": "^2.1.0",
     "@docusaurus/plugin-client-redirects": "^2.1.0",
+    "@docusaurus/plugin-google-gtag": "^2.2.0",
     "@docusaurus/preset-classic": "^2.1.0",
     "@mdx-js/react": "^1.6.22",
     "@svgr/webpack": "^6.4.0",


### PR DESCRIPTION

## Description

This PR adds[ GA's tracking utility ](https://developers.google.com/tag-platform/gtagjs/install)to the faustjs.org website. It uses[ docusaurus' plugin](https://docusaurus.io/docs/api/plugins/@docusaurus/plugin-google-gtag#anonymizeIP) to do so, with the `gtag` sourced from a new GA account for faustjs.org. 

## Testing

Test changes locally by checking for the `gtag` in the production site's html in the browser (remember to cd into faustjs.org, and then build and run the production branch [`npm run build`, and then `npm run start`]). It should be located in the `<head>` section of every site page's html and looks like this:

![image](https://user-images.githubusercontent.com/50935135/206044852-7fc8950c-ca1a-4468-9c77-e7e2545c7d16.png)

**Note:** full testing of the GA data collection cannot happen until a push to production has occurred on the live site, since docusaurus' GA plugin only works in production.
