### PR TITLE
Create a debug/verbose flag

### DIFF
--- a/.changeset/nine-cooks-cross.md
+++ b/.changeset/nine-cooks-cross.md
@@ -1,0 +1,5 @@
+---
+'@faustwp/cli': patch
+---
+
+Created a debug mode which will show detailed debug/verbose messages from the CLI. You can enable it by adding `FAUST_DEBUG=1` as an environment variable.

--- a/packages/faustwp-cli/index.ts
+++ b/packages/faustwp-cli/index.ts
@@ -16,6 +16,7 @@ import {
   userConfig,
   infoLog,
 } from './utils/index.js';
+import { debugLog } from './utils/log.js';
 
 // eslint-disable-next-line func-names, @typescript-eslint/no-floating-promises
 (async function () {
@@ -79,14 +80,16 @@ import {
 
       const telemetryData = marshallTelemetryData(wpTelemetryData, arg1);
 
-      // infoLog('Telemetry event being sent', telemetryData);
+      debugLog(
+        'Telemetry is enabled. Sending the following telemetry event:',
+        telemetryData,
+      );
 
       void sendTelemetryData(
         telemetryData,
         userConfig.get('telemetry.anonymousId') as string,
       );
     } catch (err) {
-      // console.log(err);
       // Fail silently
     }
   }

--- a/packages/faustwp-cli/utils/isDebug.ts
+++ b/packages/faustwp-cli/utils/isDebug.ts
@@ -1,0 +1,3 @@
+export function isDebug() {
+  return process.env.FAUST_DEBUG === '1' || process.env.FAUST_DEBUG === 'true';
+}

--- a/packages/faustwp-cli/utils/log.ts
+++ b/packages/faustwp-cli/utils/log.ts
@@ -1,7 +1,8 @@
+import { isDebug } from './isDebug.js';
 import { styles } from './styles.js';
 
 export const log = (
-  logLevel: 'info' | 'warn' | 'error',
+  logLevel: 'info' | 'warn' | 'error' | 'debug',
   message: string,
   ...args: any
 ) => {
@@ -18,6 +19,10 @@ export const log = (
     }
     case 'error': {
       styledLogLevel = styles.error('error');
+      break;
+    }
+    case 'debug': {
+      styledLogLevel = styles.debug('debug');
       break;
     }
     default: {
@@ -42,4 +47,12 @@ export const warnLog = (message: string, ...args: any) => {
 export const errorLog = (message: string, ...args: any) => {
   // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
   log('error', message, ...args);
+};
+
+export const debugLog = (message: string, ...args: any) => {
+  if (!isDebug()) {
+    return;
+  }
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+  log('debug', message, ...args);
 };

--- a/packages/faustwp-cli/utils/styles.ts
+++ b/packages/faustwp-cli/utils/styles.ts
@@ -5,5 +5,6 @@ export const styles = {
   info: chalk.cyan,
   warn: chalk.yellow,
   error: chalk.red,
+  debug: chalk.magenta,
   success: chalk.blueBright,
 };


### PR DESCRIPTION
## Tasks

- [x] I've filled out the WP Engine Contributor License Agreement (CLA)

## Description

This PR introduces a debug mode for the Faust CLI. It can be enabled by adding `FAUST_DEBUG=1` as an environment variable.

## Why not a CLI flag?

Originally, we were discussing adding a flag to the CLI, like `--debug`. However, since we pass these args to the Next.js CLI spawned process, it could create unintenteded consequences. For instance, `next build --debug` is supported, while `next dev --debug` is not, which results in an error in the CLI.

## Related Issue(s):

<!--
Provide the GitHub issue(s) number for issue tracking purposes, use the following syntax:

- #1234
-->

## Testing

1. Checkout the PR
2. Add `FAUST_DEBUG=1` to your `.env.local`
3. Enable telemetry
4. Run `npm run dev`
5. Notice the telemetry event gets logged with the `debug` log type
<img width="1230" alt="Screenshot 2022-12-15 at 3 40 52 PM" src="https://user-images.githubusercontent.com/5946219/207973032-f2ab023d-8d35-45f2-9ac8-92ec8c766237.png">


<!--
Describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Also list any relevant details for your test configuration such as how to test the changes locally or in staging.
-->

## Screenshots

<!--
If this is a visual change include relevant screenshots about the behavior of the application before and after this change.
-->

## Documentation Changes

<!--
List corresponding changes to the documentation.
-->

## Dependant PRs

<!--
List any dependent PR's that are awaiting review. Use the following syntax:

- #1234
-->
