### PR TITLE
Feat: Initial Bootstrap of @faustwp/blocks package

### DIFF
--- a/.changeset/flat-rivers-enjoy.md
+++ b/.changeset/flat-rivers-enjoy.md
@@ -1,0 +1,5 @@
+---
+'@faustwp/blocks': patch
+---
+
+Initial Blocks package

--- a/.changeset/flat-rivers-enjoy.md
+++ b/.changeset/flat-rivers-enjoy.md
@@ -1,5 +1,5 @@
 ---
-'@faustwp/blocks': patch
+'@faustwp/blocks': minor
 ---
 
 Initial Blocks package

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
           "packages/core",
           "packages/react",
           "packages/next",
+          "packages/blocks",
           "packages/faustwp-cli",
           "packages/faustwp-core",
           "examples/next/getting-started",
@@ -45,8 +46,8 @@
       "version": "0.1.0",
       "dependencies": {
         "@apollo/client": "^3.6.6",
-        "@faustwp/cli": "0.1.6",
-        "@faustwp/core": "0.1.5",
+        "@faustwp/cli": "0.2.0",
+        "@faustwp/core": "0.2.0",
         "@wordpress/base-styles": "^4.7.0",
         "@wordpress/block-library": "^7.13.0",
         "classnames": "^2.3.1",
@@ -1156,6 +1157,10 @@
     },
     "node_modules/@faustjs/react": {
       "resolved": "packages/react",
+      "link": true
+    },
+    "node_modules/@faustwp/blocks": {
+      "resolved": "packages/blocks",
       "link": true
     },
     "node_modules/@faustwp/cli": {
@@ -13110,6 +13115,31 @@
         "zen-observable": "0.8.15"
       }
     },
+    "packages/blocks": {
+      "version": "0.0.1",
+      "license": "MIT",
+      "dependencies": {
+        "@faustwp/core": "*",
+        "lodash": "^4.17.21"
+      },
+      "devDependencies": {
+        "@testing-library/jest-dom": "^5.15.0",
+        "@types/node": "^18.0.6",
+        "@types/react": "^17.0.34",
+        "react": "^17.0.2",
+        "react-dom": "^17.0.2"
+      },
+      "peerDependencies": {
+        "react": ">=17.0.2",
+        "react-dom": ">=17.0.2"
+      }
+    },
+    "packages/blocks/node_modules/@types/node": {
+      "version": "18.11.18",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.18.tgz",
+      "integrity": "sha512-DHQpWGjyQKSHj3ebjFI/wRKcqQcdR+MoFBygntYOZytCqNfkd2ZC4ARDJ2DQqhjH5p85Nnd3jhUJIXrszFX/JA==",
+      "dev": true
+    },
     "packages/core": {
       "name": "@faustjs/core",
       "version": "0.15.7",
@@ -13148,7 +13178,7 @@
     },
     "packages/faustwp-cli": {
       "name": "@faustwp/cli",
-      "version": "0.1.6",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.1.2",
@@ -13234,7 +13264,7 @@
     },
     "packages/faustwp-core": {
       "name": "@faustwp/core",
-      "version": "0.1.5",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "@wordpress/hooks": "^3.14.0",
@@ -13342,7 +13372,7 @@
     },
     "plugins/faustwp": {
       "name": "@faustwp/wordpress-plugin",
-      "version": "0.8.0"
+      "version": "0.8.1"
     }
   },
   "dependencies": {
@@ -14195,6 +14225,26 @@
         "typescript": "^4.4.4"
       }
     },
+    "@faustwp/blocks": {
+      "version": "file:packages/blocks",
+      "requires": {
+        "@faustwp/core": "*",
+        "@testing-library/jest-dom": "^5.15.0",
+        "@types/node": "^18.0.6",
+        "@types/react": "^17.0.34",
+        "lodash": "^4.17.21",
+        "react": "^17.0.2",
+        "react-dom": "^17.0.2"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "18.11.18",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.18.tgz",
+          "integrity": "sha512-DHQpWGjyQKSHj3ebjFI/wRKcqQcdR+MoFBygntYOZytCqNfkd2ZC4ARDJ2DQqhjH5p85Nnd3jhUJIXrszFX/JA==",
+          "dev": true
+        }
+      }
+    },
     "@faustwp/cli": {
       "version": "file:packages/faustwp-cli",
       "requires": {
@@ -14276,8 +14326,8 @@
       "version": "file:examples/next/faustwp-getting-started",
       "requires": {
         "@apollo/client": "^3.6.6",
-        "@faustwp/cli": "0.1.6",
-        "@faustwp/core": "0.1.5",
+        "@faustwp/cli": "0.2.0",
+        "@faustwp/core": "0.2.0",
         "@wordpress/base-styles": "^4.7.0",
         "@wordpress/block-library": "^7.13.0",
         "classnames": "^2.3.1",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
       "packages/core",
       "packages/react",
       "packages/next",
+      "packages/blocks",
       "packages/faustwp-cli",
       "packages/faustwp-core",
       "examples/next/getting-started",
@@ -18,12 +19,13 @@
     ]
   },
   "scripts": {
-    "build": "npm run build --workspace=@faustjs/core --workspace=@faustjs/react --workspace=@faustjs/next --workspace=@faustwp/cli --workspace=@faustwp/core",
+    "build": "npm run build --workspace=@faustjs/core --workspace=@faustjs/react --workspace=@faustjs/next --workspace=@faustwp/cli --workspace=@faustwp/core --workspace=@faustwp/blocks",
     "build:core": "npm run build --workspace=@faustjs/core",
     "build:next": "npm run build --workspace=@faustjs/next",
     "build:react": "npm run build --workspace=@faustjs/react",
     "build:faust-cli": "npm run build --workspace=@faustwp/cli",
     "build:faust-core": "npm run build --workspace=@faustwp/core",
+    "build:faust-blocks": "npm run build --workspace=@faustwp/blocks",
     "clean": "npm run clean --workspace=@faustjs/core --workspace=@faustjs/react --workspace=@faustjs/next --workspace=@faustwp/cli --workspace=@faustwp/core",
     "clean:examples": "rimraf examples/**/node_modules",
     "format": "npm run format --workspace=@faustjs/core --workspace=@faustjs/react --workspace=@faustjs/next --workspace=@faustwp/cli --workspace=@faustwp/core",

--- a/packages/blocks/.eslintignore
+++ b/packages/blocks/.eslintignore
@@ -1,0 +1,5 @@
+dist
+node_modules
+/*.js
+/*.ts
+/*.d.ts

--- a/packages/blocks/.npmignore
+++ b/packages/blocks/.npmignore
@@ -1,0 +1,9 @@
+src/**/*
+tests/**/*
+.gitignore
+.eslintignore
+jest.config.js
+jest.setup.ts
+tsconfig-cjs.json
+tsconfig.json
+coverage

--- a/packages/blocks/CHANGELOG.md
+++ b/packages/blocks/CHANGELOG.md
@@ -1,0 +1,1 @@
+# @faustwp/blocks

--- a/packages/blocks/LICENSE
+++ b/packages/blocks/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2022 WP Engine
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/blocks/README.md
+++ b/packages/blocks/README.md
@@ -11,10 +11,10 @@
 </p>
 
 <p align="center">
-  <a aria-label="Faust.js Next Downloads Per Month" href="https://www.npmjs.com/package/@faustwp/blocks">
+  <a aria-label="Faust.js Blocks Downloads Per Month" href="https://www.npmjs.com/package/@faustwp/blocks">
     <img alt="" src="https://img.shields.io/npm/dm/@faustwp/blocks?color=7e5cef&style=for-the-badge&label=@faustwp/blocks">
   </a>
-  <a aria-label="Faust.js Next Downloads Per Week" href="https://www.npmjs.com/package/@faustwp/blocks">
+  <a aria-label="Faust.js Blocks Downloads Per Week" href="https://www.npmjs.com/package/@faustwp/blocks">
     <img alt="" src="https://img.shields.io/npm/dw/@faustwp/blocks?color=7e5cef&style=for-the-badge&label=@faustwp/blocks">
   </a>
 </p>

--- a/packages/blocks/README.md
+++ b/packages/blocks/README.md
@@ -1,0 +1,24 @@
+# @faustwp/blocks
+
+<p align="center">
+  <a aria-label="NPM version" href="https://www.npmjs.com/package/@faustwp/blocks">
+    <img alt="" src="https://img.shields.io/npm/v/@faustwp/blocks?color=7e5cef&style=for-the-badge">
+  </a>
+
+  <a aria-label="License" href="https://github.com/wpengine/faustjs/blob/canary/LICENSE">
+    <img alt="" src="https://img.shields.io/npm/l/@faustwp/blocks?color=7e5cef&style=for-the-badge">
+  </a>
+</p>
+
+<p align="center">
+  <a aria-label="Faust.js Next Downloads Per Month" href="https://www.npmjs.com/package/@faustwp/blocks">
+    <img alt="" src="https://img.shields.io/npm/dm/@faustwp/blocks?color=7e5cef&style=for-the-badge&label=@faustwp/blocks">
+  </a>
+  <a aria-label="Faust.js Next Downloads Per Week" href="https://www.npmjs.com/package/@faustwp/blocks">
+    <img alt="" src="https://img.shields.io/npm/dw/@faustwp/blocks?color=7e5cef&style=for-the-badge&label=@faustwp/blocks">
+  </a>
+</p>
+
+🚧 Please note this is prerelease software and breaking changes may occur.
+
+`@faustwp/blocks` provides conventional connector components for rendering WordPress blocks.

--- a/packages/blocks/jest.config.js
+++ b/packages/blocks/jest.config.js
@@ -1,0 +1,30 @@
+module.exports = {
+  roots: ['<rootDir>/tests'],
+
+  // Adds Jest support for TypeScript using ts-jest.
+  transform: {
+    '^.+\\.tsx?$': 'ts-jest',
+  },
+
+  // Run code before each file in the suite is tested.
+  setupFilesAfterEnv: ['./jest.setup.ts'],
+
+  testRegex: '(/__tests__/.*|(\\.|/)(test|spec))\\.tsx?$',
+
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
+
+  // ESM Support
+  // @link https://kulshekhar.github.io/ts-jest/docs/guides/esm-support/
+  extensionsToTreatAsEsm: ['.ts'],
+  globals: {
+    'ts-jest': {
+      useESM: true,
+    },
+  },
+  moduleNameMapper: {
+    '^(\\.{1,2}/.*)\\.js$': '$1',
+  },
+  collectCoverage: true,
+  coverageReporters: ['json', 'html'],
+  passWithNoTests: true,
+};

--- a/packages/blocks/jest.setup.ts
+++ b/packages/blocks/jest.setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom'; // For custom matchers. See https://github.com/testing-library/jest-dom#custom-matchers.

--- a/packages/blocks/package.json
+++ b/packages/blocks/package.json
@@ -18,7 +18,6 @@
     "react-dom": "^17.0.2"
   },
   "dependencies": {
-    "@faustwp/core": "*",
     "lodash": "^4.17.21"
   },
   "scripts": {

--- a/packages/blocks/package.json
+++ b/packages/blocks/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "@faustwp/blocks",
+  "version": "0.0.1",
+  "private": true,
+  "description": "Faust Blocks",
+  "main": "dist/cjs/index.js",
+  "module": "dist/mjs/index.js",
+  "types": "dist/cjs/index.d.ts",
+  "peerDependencies": {
+    "react": ">=17.0.2",
+    "react-dom": ">=17.0.2"
+  },
+  "devDependencies": {
+    "@types/node": "^18.0.6",
+    "@types/react": "^17.0.34",
+    "@testing-library/jest-dom": "^5.15.0",
+    "react": "^17.0.2",
+    "react-dom": "^17.0.2"
+  },
+  "dependencies": {
+    "@faustwp/core": "*",
+    "lodash": "^4.17.21"
+  },
+  "scripts": {
+    "test": "npm test",
+    "build": "tsc -p tsconfig.json",
+    "dev": "tsc -p tsconfig.json --watch"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/wpengine/faustjs.git"
+  },
+  "author": "Faust.js Team",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/wpengine/faustjs/issues"
+  },
+  "homepage": "https://github.com/wpengine/faustjs#readme"
+}

--- a/packages/blocks/package.json
+++ b/packages/blocks/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@faustwp/blocks",
   "version": "0.0.1",
-  "private": true,
   "description": "Faust Blocks",
   "main": "dist/cjs/index.js",
   "module": "dist/mjs/index.js",

--- a/packages/blocks/src/components/DefaultBlock.tsx
+++ b/packages/blocks/src/components/DefaultBlock.tsx
@@ -1,13 +1,13 @@
 /* eslint-disable prettier/prettier */
 import React from 'react';
-import { EditorBlock } from './WordPressBlocksViewer.js';
+import { ContentBlock } from './WordPressBlocksViewer.js';
 
 /**
  * DefaultBlock is an instance of WordPressBlock that is used in case no matching component is found when rendering the list of blocks.
  * @param param0
  * @returns JSX.Element
  */
-export default function DefaultBlock({ renderedHtml }: EditorBlock) {
+export default function DefaultBlock({ renderedHtml }: ContentBlock) {
   // eslint-disable-next-line react/no-danger
   return <span dangerouslySetInnerHTML={{ __html: renderedHtml ?? '' }} />;
 }

--- a/packages/blocks/src/components/DefaultBlock.tsx
+++ b/packages/blocks/src/components/DefaultBlock.tsx
@@ -1,0 +1,15 @@
+/* eslint-disable prettier/prettier */
+import React from 'react';
+import { EditorBlock } from './WordPressBlocksViewer.js';
+
+/**
+ * DefaultBlock is an instance of WordPressBlock that is used in case no matching component is found when rendering the list of blocks.
+ * @param param0
+ * @returns JSX.Element
+ */
+export default function DefaultBlock({ renderedHtml }: EditorBlock) {
+  // eslint-disable-next-line react/no-danger
+  return <span dangerouslySetInnerHTML={{ __html: renderedHtml ?? '' }} />;
+}
+
+DefaultBlock.displayName = 'DefaultBlock';

--- a/packages/blocks/src/components/WordPressBlocksProvider.tsx
+++ b/packages/blocks/src/components/WordPressBlocksProvider.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+
+/**
+ * WordPressBlock is a React component that contains some optional properties that we are
+ * used to match it with equivalent block data from the API
+ */
+export type WordPressBlock = React.FC & {
+  displayName?: string;
+  name?: string;
+  config?: {
+    name: string;
+  };
+};
+export const WordPressBlocksContext =
+  React.createContext<WordPressBlocksContextType>({});
+
+export interface WordPressBlocksContextType {
+  blocks?: WordPressBlock[];
+}
+
+/**
+ * WordPressBlocksProvider is used as a central store for the available list of WordPressBlock types.
+ * @param props
+ * @returns
+ */
+export function WordPressBlocksProvider(props: {
+  children: React.ReactNode;
+  config: WordPressBlocksContextType;
+}) {
+  const { children, config } = props;
+
+  return (
+    <WordPressBlocksContext.Provider value={config}>
+      {children}
+    </WordPressBlocksContext.Provider>
+  );
+}

--- a/packages/blocks/src/components/WordPressBlocksViewer.tsx
+++ b/packages/blocks/src/components/WordPressBlocksViewer.tsx
@@ -53,7 +53,7 @@ export function WordPressBlocksViewer(props: WordpressBlocksViewerProps) {
     return (
       // eslint-disable-next-line react/no-array-index-key
       <BlockDataProvider data={blockProps} key={idx}>
-        <>{React.createElement(BlockTemplate as any, { ...blockProps })}</>
+        <>{React.createElement<EditorBlock>(BlockTemplate, { ...blockProps })}</>
       </BlockDataProvider>
     );
   });

--- a/packages/blocks/src/components/WordPressBlocksViewer.tsx
+++ b/packages/blocks/src/components/WordPressBlocksViewer.tsx
@@ -37,7 +37,7 @@ export interface ContentBlock {
   renderedHtml?: string;
 }
 /**
- * WordPressBlocksViewer is the main component that renders blocks taken from WordPress as a list of EditorBlock[] data.
+ * WordPressBlocksViewer is the main component that renders blocks taken from WordPress as a list of ContentBlock[] data.
  * @param props WordpressBlocksViewerProps
  * @returns JSX.Component that renders the block tree.
  */

--- a/packages/blocks/src/components/WordPressBlocksViewer.tsx
+++ b/packages/blocks/src/components/WordPressBlocksViewer.tsx
@@ -1,7 +1,6 @@
 /* eslint-disable prettier/prettier */
 /* eslint-disable react/jsx-props-no-spreading */
 import React from 'react';
-import { hooks } from '@faustwp/core';
 import resolveBlockTemplate from '../resolveBlockTemplate.js';
 import { WordPressBlocksContext } from './WordPressBlocksProvider.js';
 
@@ -49,16 +48,11 @@ export function WordPressBlocksViewer(props: WordpressBlocksViewerProps) {
   }
 
   const { contentBlocks } = props;
-  const renderedBlocks = contentBlocks.map((block, idx) => {
-    const BlockTemplate = resolveBlockTemplate(block, blocks);
-    const blockProps = hooks.applyFilters(
-      `resolve_block_${BlockTemplate.name}`,
-      block,
-      {},
-    ) as EditorBlock;
+  const renderedBlocks = contentBlocks.map((blockProps, idx) => {
+    const BlockTemplate = resolveBlockTemplate(blockProps, blocks);
     return (
       // eslint-disable-next-line react/no-array-index-key
-      <BlockDataProvider data={block} key={idx}>
+      <BlockDataProvider data={blockProps} key={idx}>
         <>{React.createElement(BlockTemplate as any, { ...blockProps })}</>
       </BlockDataProvider>
     );

--- a/packages/blocks/src/components/WordPressBlocksViewer.tsx
+++ b/packages/blocks/src/components/WordPressBlocksViewer.tsx
@@ -56,7 +56,6 @@ export function WordPressBlocksViewer(props: WordpressBlocksViewerProps) {
       block,
       {},
     ) as EditorBlock;
-    console.debug(blockProps);
     return (
       // eslint-disable-next-line react/no-array-index-key
       <BlockDataProvider data={block} key={idx}>

--- a/packages/blocks/src/components/WordPressBlocksViewer.tsx
+++ b/packages/blocks/src/components/WordPressBlocksViewer.tsx
@@ -24,14 +24,14 @@ export function BlockDataProvider(
 }
 
 export interface WordpressBlocksViewerProps {
-  contentBlocks: EditorBlock[];
+  contentBlocks: ContentBlock[];
 }
 
-export interface EditorBlock {
+export interface ContentBlock {
   __typename?: string;
   apiVersion?: number;
   cssClassNames?: string;
-  innerBlocks?: EditorBlock[];
+  innerBlocks?: ContentBlock[];
   isDynamic?: boolean;
   name?: string;
   renderedHtml?: string;
@@ -53,7 +53,7 @@ export function WordPressBlocksViewer(props: WordpressBlocksViewerProps) {
     return (
       // eslint-disable-next-line react/no-array-index-key
       <BlockDataProvider data={blockProps} key={idx}>
-        <>{React.createElement<EditorBlock>(BlockTemplate, { ...blockProps })}</>
+        <>{React.createElement<ContentBlock>(BlockTemplate, { ...blockProps })}</>
       </BlockDataProvider>
     );
   });

--- a/packages/blocks/src/components/WordPressBlocksViewer.tsx
+++ b/packages/blocks/src/components/WordPressBlocksViewer.tsx
@@ -1,0 +1,69 @@
+/* eslint-disable prettier/prettier */
+/* eslint-disable react/jsx-props-no-spreading */
+import React from 'react';
+import { hooks } from '@faustwp/core';
+import resolveBlockTemplate from '../resolveBlockTemplate.js';
+import { WordPressBlocksContext } from './WordPressBlocksProvider.js';
+
+const Context = React.createContext<{ [key: string]: any } | null>(null);
+
+export const useBlockData = (): { [key: string]: any } | null => {
+  const contextState = React.useContext(Context);
+  if (contextState === null) {
+    throw new Error('useBlockData must be used within a BlockDataProvider tag');
+  }
+  return contextState;
+};
+
+export function BlockDataProvider(
+  props: React.PropsWithChildren<{ data: Record<string, any> | null }>,
+) {
+  const { children, data } = props;
+  const ref = React.useRef(data);
+
+  return <Context.Provider value={ref.current}>{children}</Context.Provider>;
+}
+
+export interface WordpressBlocksViewerProps {
+  contentBlocks: EditorBlock[];
+}
+
+export interface EditorBlock {
+  __typename?: string;
+  apiVersion?: number;
+  cssClassNames?: string;
+  innerBlocks?: EditorBlock[];
+  isDynamic?: boolean;
+  name?: string;
+  renderedHtml?: string;
+}
+/**
+ * WordPressBlocksViewer is the main component that renders blocks taken from WordPress as a list of EditorBlock[] data.
+ * @param props WordpressBlocksViewerProps
+ * @returns JSX.Component that renders the block tree.
+ */
+export function WordPressBlocksViewer(props: WordpressBlocksViewerProps) {
+  const { blocks } = React.useContext(WordPressBlocksContext);
+  if (!blocks) {
+    throw new Error('Blocks are required. Please add them to your config.');
+  }
+
+  const { contentBlocks } = props;
+  const renderedBlocks = contentBlocks.map((block, idx) => {
+    const BlockTemplate = resolveBlockTemplate(block, blocks);
+    const blockProps = hooks.applyFilters(
+      `resolve_block_${BlockTemplate.name}`,
+      block,
+      {},
+    ) as EditorBlock;
+    console.debug(blockProps);
+    return (
+      // eslint-disable-next-line react/no-array-index-key
+      <BlockDataProvider data={block} key={idx}>
+        <>{React.createElement(BlockTemplate as any, { ...blockProps })}</>
+      </BlockDataProvider>
+    );
+  });
+
+  return renderedBlocks;
+}

--- a/packages/blocks/src/index.ts
+++ b/packages/blocks/src/index.ts
@@ -1,0 +1,19 @@
+import {
+  WordPressBlocksContext,
+  WordPressBlock,
+  WordPressBlocksProvider,
+} from './components/WordPressBlocksProvider.js';
+import {
+  useBlockData,
+  WordpressBlocksViewerProps,
+  WordPressBlocksViewer,
+} from './components/WordPressBlocksViewer.js';
+
+export {
+  WordPressBlocksContext,
+  WordPressBlock,
+  WordPressBlocksProvider,
+  useBlockData,
+  WordpressBlocksViewerProps,
+  WordPressBlocksViewer,
+};

--- a/packages/blocks/src/resolveBlockTemplate.ts
+++ b/packages/blocks/src/resolveBlockTemplate.ts
@@ -1,5 +1,5 @@
 import find from 'lodash/find.js';
-import { EditorBlock } from './components/WordPressBlocksViewer.js';
+import { ContentBlock } from './components/WordPressBlocksViewer.js';
 import { WordPressBlock } from './components/WordPressBlocksProvider.js';
 import DefaultBlock from './components/DefaultBlock.js';
 
@@ -7,16 +7,16 @@ import DefaultBlock from './components/DefaultBlock.js';
  * This function contains the main resolve logic for matching a provided editorBlock instance with the list of
  * available WordPressBlock components.
  *
- * @param editorBlock An instance of a block as retrieved from the API
+ * @param contentBlock An instance of a block as retrieved from the API
  * @param blocks A list of available WordPressBlock components to match with the provided editorBlock
  * @returns An instance of the WordPressBlock component that matches the the provided editorBlock or a DefaultBlock if no such match exists.
  */
 export default function resolveBlockTemplate(
-  editorBlock: EditorBlock,
+  contentBlock: ContentBlock,
   blocks: WordPressBlock[],
 ): WordPressBlock {
   // eslint-disable-next-line no-underscore-dangle
-  const namesToCheck = [editorBlock?.name, editorBlock?.__typename].filter(
+  const namesToCheck = [contentBlock?.name, contentBlock?.__typename].filter(
     Boolean,
   ) as string[];
   const block = find(blocks, (item) => {

--- a/packages/blocks/src/resolveBlockTemplate.ts
+++ b/packages/blocks/src/resolveBlockTemplate.ts
@@ -4,12 +4,12 @@ import { WordPressBlock } from './components/WordPressBlocksProvider.js';
 import DefaultBlock from './components/DefaultBlock.js';
 
 /**
- * This function contains the main resolve logic for matching a provided editorBlock instance with the list of
+ * This function contains the main resolve logic for matching a provided contentBlock instance with the list of
  * available WordPressBlock components.
  *
  * @param contentBlock An instance of a block as retrieved from the API
- * @param blocks A list of available WordPressBlock components to match with the provided editorBlock
- * @returns An instance of the WordPressBlock component that matches the the provided editorBlock or a DefaultBlock if no such match exists.
+ * @param blocks A list of available WordPressBlock components to match with the provided contentBlock
+ * @returns An instance of the WordPressBlock component that matches the the provided contentBlock or a DefaultBlock if no such match exists.
  */
 export default function resolveBlockTemplate(
   contentBlock: ContentBlock,

--- a/packages/blocks/src/resolveBlockTemplate.ts
+++ b/packages/blocks/src/resolveBlockTemplate.ts
@@ -1,0 +1,40 @@
+import find from 'lodash/find.js';
+import { EditorBlock } from './components/WordPressBlocksViewer.js';
+import { WordPressBlock } from './components/WordPressBlocksProvider.js';
+import DefaultBlock from './components/DefaultBlock.js';
+
+/**
+ * This function contains the main resolve logic for matching a provided editorBlock instance with the list of
+ * available WordPressBlock components.
+ *
+ * @param editorBlock An instance of a block as retrieved from the API
+ * @param blocks A list of available WordPressBlock components to match with the provided editorBlock
+ * @returns An instance of the WordPressBlock component that matches the the provided editorBlock or a DefaultBlock if no such match exists.
+ */
+export default function resolveBlockTemplate(
+  editorBlock: EditorBlock,
+  blocks: WordPressBlock[],
+): WordPressBlock {
+  // eslint-disable-next-line no-underscore-dangle
+  const namesToCheck = [editorBlock?.name, editorBlock?.__typename].filter(
+    Boolean,
+  ) as string[];
+  const block = find(blocks, (item) => {
+    for (let i = 0; i < namesToCheck.length; i += 1) {
+      if (item?.displayName === namesToCheck[i]) {
+        return true;
+      }
+      if (item?.config?.name === namesToCheck[i]) {
+        return true;
+      }
+      if (item?.name === namesToCheck[i]) {
+        return true;
+      }
+    }
+    return false;
+  });
+  if (block) {
+    return block;
+  }
+  return DefaultBlock as WordPressBlock;
+}

--- a/packages/blocks/tsconfig.cjs.json
+++ b/packages/blocks/tsconfig.cjs.json
@@ -1,0 +1,9 @@
+{
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+	  "module": "commonjs",
+	  "outDir": "dist/cjs",
+	  "target": "es2017",
+	  "rootDir": "src"
+	}
+  }

--- a/packages/blocks/tsconfig.json
+++ b/packages/blocks/tsconfig.json
@@ -1,0 +1,12 @@
+{
+	"extends": "../../tsconfig.json",
+	"compilerOptions": {
+	  "module": "esnext",
+	  "outDir": "dist/mjs",
+	  "target": "es2017",
+	  "rootDir": "src",
+	  "jsx": "react"
+	},
+	"exclude": ["node_modules", "dist"],
+	"include": ["src"]
+  }


### PR DESCRIPTION
## Tasks

- [x] I've filled out the WP Engine Contributor License Agreement (CLA)

## Description

<!--
Include a summary of the change and some contextual information.
-->

Adds a new package named `@faustwp/blocks` with its main implementation.

## Related Issue(s):

<!--
Provide the GitHub issue(s) number for issue tracking purposes, use the following syntax:

- #1234
-->

## Testing

You may want to see this [example repo](https://github.com/wpengine/faustjs/tree/MERL-538/examples/next/faustwp-getting-started) on how to use it.

1. Make sure you install the wp-content-blocks-plugin on your site. Specifically use the [MERL-542](https://github.com/wpengine/wp-graphql-content-blocks/tree/MERL-542) Branch as it contains a few bug fixes.
1. Use the [WordPressBlocksProvider](https://github.com/wpengine/faustjs/blob/MERL-538/examples/next/faustwp-getting-started/pages/_app.js#L14-L19) passing on the list of block components.
2. On your WordPressTemplate, import the [WordPressBlocksViewer](https://github.com/wpengine/faustjs/blob/MERL-538/examples/next/faustwp-getting-started/wp-templates/single.js#L3) component and pass on the list of [contentBlocks](https://github.com/wpengine/faustjs/blob/MERL-538/examples/next/faustwp-getting-started/wp-templates/single.js#L29-L31) from the API. Sample blocks are provided in the  [example repo](https://github.com/wpengine/faustjs/tree/MERL-538/examples/next/faustwp-getting-started/wp-blocks)
3. Make sure you pass on the [query fragments](https://github.com/wpengine/faustjs/blob/MERL-538/examples/next/faustwp-getting-started/wp-templates/single.js#L86-L115) as well.
4. If all goes well you should be able to check the blocks render correctly.

<!--
Describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Also list any relevant details for your test configuration such as how to test the changes locally or in staging.
-->

## Screenshots

<!--
If this is a visual change include relevant screenshots about the behavior of the application before and after this change.
-->

## Documentation Changes

<!--
List corresponding changes to the documentation.
-->

## Dependant PRs

<!--
List any dependent PR's that are awaiting review. Use the following syntax:

- #1234
-->


[MERL-538]: https://wpengine.atlassian.net/browse/MERL-538?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MERL-538]: https://wpengine.atlassian.net/browse/MERL-538?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MERL-538]: https://wpengine.atlassian.net/browse/MERL-538?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MERL-538]: https://wpengine.atlassian.net/browse/MERL-538?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[MERL-542]: https://wpengine.atlassian.net/browse/MERL-542?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ