### PR TITLE
Plugin System TypeScript helpers and Docs

### DIFF
--- a/.changeset/tasty-ads-grin.md
+++ b/.changeset/tasty-ads-grin.md
@@ -1,0 +1,13 @@
+---
+'@faustwp/core': patch
+---
+
+Created two new TypeScript types (`FaustPlugin` and `FaustHooks`) which can be used to type check Faust plugins:
+
+```tsx
+import { FaustHooks, FaustPlugin } from '@faustwp/core';
+
+export class MyPlugin implements FaustPlugin {
+  apply(hooks: FaustHooks) {}
+}
+```

--- a/internal/faustjs.org/docs/plugin-system/creating-a-plugin.mdx
+++ b/internal/faustjs.org/docs/plugin-system/creating-a-plugin.mdx
@@ -1,0 +1,53 @@
+---
+slug: /plugin-system/creating-a-plugin
+title: Creating a Plugin
+description: How to create a plugin in the Faust Plugin System
+---
+
+In it's very basic form, a Faust Plugin is a JavaScript class with an `apply` method. This `apply` method has a parameter called `hooks`, which is passed from [`@wordpress/hooks`](https://www.npmjs.com/package/@wordpress/hooks). Here is an implementation in TypeScript:
+
+```tsx title="MyPlugin.tsx"
+import { FaustHooks, FaustPlugin } from '@faustwp/core';
+
+export class MyPlugin implements FaustPlugin {
+  apply(hooks: FaustHooks) {}
+}
+```
+
+The `hooks` parameter is an object which contains the functions `addFilter` and `addAction`, [amongst others](https://www.npmjs.com/package/@wordpress/hooks). You can then use these functions to call the respective [actions and filters](/docs/plugin-system/filters) to tap into Faust:
+
+```tsx title="MyPlugin.tsx"
+import { FaustHooks, FaustPlugin } from '@faustwp/core';
+
+export class MyPlugin implements FaustPlugin {
+  apply(hooks: FaustHooks) {
+    const { addAction, addFilter } = hooks;
+
+    addFilter(
+      'possibleTemplatesList',
+      'my-namespace',
+      (possibleTemplates, context) => {
+        // Filter logic goes here.
+      },
+    );
+  }
+}
+```
+
+You or the end user can then implement the plugin by adding it to the `experimentalPlugins` property in the App's `faust.config.js` file:
+
+```js
+import { setConfig } from '@faustwp/core';
+import templates from './wp-templates';
+import possibleTypes from './possibleTypes.json';
+import { MyPlugin } from './MyPlugin.tsx';
+
+/**
+ * @type {import('@faustwp/core').FaustConfig}
+ **/
+export default setConfig({
+  templates,
+  experimentalPlugins: [new MyPlugin()],
+  possibleTypes,
+});
+```

--- a/internal/faustjs.org/docs/plugin-system/creating-a-plugin.mdx
+++ b/internal/faustjs.org/docs/plugin-system/creating-a-plugin.mdx
@@ -4,7 +4,7 @@ title: Creating a Plugin
 description: How to create a plugin in the Faust Plugin System
 ---
 
-In it's very basic form, a Faust Plugin is a JavaScript class with an `apply` method. This `apply` method has a parameter called `hooks`, which is passed from [`@wordpress/hooks`](https://www.npmjs.com/package/@wordpress/hooks). Here is an implementation in TypeScript:
+In its very basic form, a Faust Plugin is a JavaScript class with an `apply` method. This `apply` method has a parameter called `hooks`, which is passed from [`@wordpress/hooks`](https://www.npmjs.com/package/@wordpress/hooks). Here is an implementation in TypeScript:
 
 ```tsx title="MyPlugin.tsx"
 import { FaustHooks, FaustPlugin } from '@faustwp/core';

--- a/internal/faustjs.org/docs/plugin-system/filters.mdx
+++ b/internal/faustjs.org/docs/plugin-system/filters.mdx
@@ -4,7 +4,7 @@ title: Filters
 description: Faust plugin system filters available to you
 ---
 
-Below are the different types of filters available to you in the Faust Plugin System. Each Filter callback contains two parameters, the first parameter is the filtered data. For instance the first parameter in the `possibleTemplatesList` filter is `possibleTemplates`, a string array of templates. The second parameter of every filter is a `context` object. This object may contain information needed to make modifications to the filtered data.
+Below are the different types of filters available to you in the Faust Plugin System. Each filter callback contains two parameters, the first parameter is the filtered data. For instance the first parameter in the `possibleTemplatesList` filter is `possibleTemplates`, a string array of templates. The second parameter of every filter is a `context` object. This object may contain information needed to make modifications to the filtered data.
 
 ## apolloClientInMemoryCacheOptions
 

--- a/internal/faustjs.org/docs/plugin-system/filters.mdx
+++ b/internal/faustjs.org/docs/plugin-system/filters.mdx
@@ -1,0 +1,153 @@
+---
+slug: /plugin-system/filters
+title: Filters
+description: Faust plugin system filters available to you
+---
+
+Below are the different types of filters available to you in the Faust Plugin System. Each Filter callback contains two parameters, the first parameter is the filtered data. For instance the first parameter in the `possibleTemplatesList` filter is `possibleTemplates`, a string array of templates. The second parameter of every filter is a `context` object. This object may contain information needed to make modifications to the filtered data.
+
+## apolloClientInMemoryCacheOptions
+
+Allows you to modify the [Apollo Client's `InMemoryCache` config](https://www.apollographql.com/docs/react/api/cache/InMemoryCache).
+
+### Signature
+
+```tsx
+import {
+  InMemoryCacheConfig,
+} from '@apollo/client';
+
+addFilter(
+    hookName: 'apolloClientInMemoryCacheOptions',
+    namespace: string,
+    callback: (
+      inMemoryCacheObject: InMemoryCacheConfig,
+      context: Record<string, never>,
+    ) => InMemoryCacheConfig,
+    priority?: number | undefined,
+  ): void;
+```
+
+## apolloClientOptions
+
+Allows you to modify the [Apollo Client's options](https://www.apollographql.com/docs/react/api/core/ApolloClient/).
+
+### Signature
+
+```tsx
+import {
+  ApolloClientOptions,
+  NormalizedCacheObject,
+} from '@apollo/client';
+
+addFilter(
+    hookName: 'apolloClientOptions',
+    namespace: string,
+    callback: (
+      apolloClientOptions: ApolloClientOptions<NormalizedCacheObject>,
+      context: Record<string, never>,
+    ) => ApolloClientOptions<NormalizedCacheObject>,
+    priority?: number | undefined,
+  ): void;
+```
+
+## possibleTemplatesList
+
+Allows you to modify the templates that are returned for a given URI.
+
+### Context Object
+
+- `seedNode: SeedNode`: The seed node requested from the seed query
+
+### Signature
+
+```tsx
+  addFilter(
+    hookName: 'possibleTemplatesList',
+    namespace: string,
+    callback: (
+      possibleTemplates: string[],
+      context: { seedNode: SeedNode },
+    ) => string[],
+    priority?: number | undefined,
+  ): void;
+```
+
+## seedQueryDocumentNode
+
+Allows you to override the Seed Query.
+
+### Context Object
+
+- `resolvedUrl: string`: The resolved URL for the given route.
+
+### Signature
+
+```tsx
+addFilter(
+    hookName: 'seedQueryDocumentNode',
+    namespace: string,
+    callback: (
+      seedQuery: DocumentNode,
+      context: { resolvedUrl: string },
+    ) => DocumentNode,
+    priority?: number | undefined,
+  ): void;
+```
+
+## graphqlEndpoint
+
+Allows you to override the GraphQL Endpoint.
+
+### Context Object
+
+- `wpUrl: string`: The URL to the WordPress site
+
+### Signature
+
+```tsx
+  addFilter(
+    hookName: 'graphqlEndpoint',
+    namespace: string,
+    callback: (graphqlEndpoint: string, context: { wpUrl: string }) => string,
+    priority?: number | undefined,
+  ): void;
+```
+
+## wpHostname
+
+Allows you to override the WordPress site URLs `hostname`.
+
+### Context Object
+
+- `wpUrl: string`: The URL to the WordPress site
+
+### Signature
+
+```tsx
+  addFilter(
+    hookName: 'wpHostname',
+    namespace: string,
+    callback: (wpHostname: string, context: { wpUrl: string }) => string,
+    priority?: number | undefined,
+  ): void;
+```
+
+## wpUrl
+
+Allows you to override the WordPress site URL.
+
+### Context Object
+
+- `wpUrl: string`: The URL to the WordPress site
+
+### Signature
+
+```tsx
+addFilter(
+    hookName: 'wpUrl',
+    namespace: string,
+    callback: (wpUrl: string, context: Record<string, never>) => string,
+    priority?: number | undefined,
+  ): void;
+```

--- a/internal/faustjs.org/sidebars.js
+++ b/internal/faustjs.org/sidebars.js
@@ -95,6 +95,22 @@ module.exports = {
       ],
     },
     {
+      type: 'category',
+      label: 'Faust Plugin System',
+      items: [
+        {
+          type: 'doc',
+          label: 'Creating a Plugin',
+          id: 'plugin-system/creating-a-plugin',
+        },
+        {
+          type: 'doc',
+          label: 'Filters',
+          id: 'plugin-system/filters',
+        },
+      ],
+    },
+    {
       type: 'doc',
       label: 'Telemetry',
       id: 'telemetry',

--- a/internal/faustjs.org/src/components/Features/HomepageFeatures.js
+++ b/internal/faustjs.org/src/components/Features/HomepageFeatures.js
@@ -18,8 +18,8 @@ const FeatureList = [
     title: 'Previews',
     description: (
       <>
-        Preview posts and pages before publishing and rewrite WordPress
-        preview URLs to your frontend.
+        Preview posts and pages before publishing and rewrite WordPress preview
+        URLs to your frontend.
       </>
     ),
     link: '/docs/next/guides/post-page-previews',
@@ -32,20 +32,21 @@ const FeatureList = [
     link: '/docs/templates',
   },
   {
-    title: 'Seed Query',
+    title: 'Plugin System',
     description: (
       <>
-        Use a seed query to obtain a list of possible templates for any given
-        route.
+        Faust has a robust, built-in, plugin system that allows practically
+        every part of the framework to be configurable.
       </>
     ),
-    link: '/docs/faustwp/seed-query',
+    link: '/docs/plugin-system/creating-a-plugin',
   },
   {
     title: 'Next.js',
     description: (
       <>
-        Build a static site with WordPress data outside the template hierarchy with Next.js file based pages.
+        Build a static site with WordPress data outside the template hierarchy
+        with Next.js file based pages.
       </>
     ),
     link: '/docs/next/reference/getNextStaticProps',

--- a/packages/faustwp-core/src/config/index.ts
+++ b/packages/faustwp-core/src/config/index.ts
@@ -4,13 +4,13 @@ import extend from 'lodash/extend.js';
 import isString from 'lodash/isString.js';
 import once from 'lodash/once.js';
 import { WordPressTemplate } from '../getWordPressProps.js';
-import { hooks, Plugin } from '../hooks/index.js';
+import { hooks, FaustPlugin } from '../hooks/index.js';
 
 export interface FaustConfig {
   templates: { [key: string]: WordPressTemplate };
   disableLogging: boolean;
   loginPagePath?: string;
-  experimentalPlugins: Plugin[];
+  experimentalPlugins: FaustPlugin[];
   possibleTypes: PossibleTypesMap;
 }
 

--- a/packages/faustwp-core/src/hooks/index.ts
+++ b/packages/faustwp-core/src/hooks/index.ts
@@ -1,9 +1,8 @@
 import { createHooks } from '@wordpress/hooks';
-// eslint-disable-next-line import/extensions
-import { _Hooks } from '@wordpress/hooks/build-types/createHooks';
+import { FaustHooks } from './overloads.js';
 
-export interface Plugin {
-  apply?: (hooks: _Hooks) => void;
-}
+export type FaustPlugin = {
+  apply: (hooks: FaustHooks) => void;
+};
 
 export const hooks = createHooks();

--- a/packages/faustwp-core/src/hooks/overloads.ts
+++ b/packages/faustwp-core/src/hooks/overloads.ts
@@ -1,0 +1,80 @@
+import {
+  ApolloClientOptions,
+  DocumentNode,
+  InMemoryCacheConfig,
+  NormalizedCacheObject,
+} from '@apollo/client';
+import { _Hooks } from '@wordpress/hooks/build-types/createHooks.js';
+import { SeedNode } from '../queries/seedQuery.js';
+
+type FaustCoreFilters = {
+  addFilter(
+    hookName: 'apolloClientInMemoryCacheOptions',
+    namespace: string,
+    callback: (
+      inMemoryCacheObject: InMemoryCacheConfig,
+      context: Record<string, never>,
+    ) => InMemoryCacheConfig,
+    priority?: number | undefined,
+  ): void;
+
+  addFilter(
+    hookName: 'apolloClientOptions',
+    namespace: string,
+    callback: (
+      apolloClientOptions: ApolloClientOptions<NormalizedCacheObject>,
+      context: Record<string, never>,
+    ) => ApolloClientOptions<NormalizedCacheObject>,
+    priority?: number | undefined,
+  ): void;
+
+  addFilter(
+    hookName: 'possibleTemplatesList',
+    namespace: string,
+    callback: (
+      possibleTemplates: string[],
+      context: { seedNode: SeedNode },
+    ) => string[],
+    priority?: number | undefined,
+  ): void;
+
+  addFilter(
+    hookName: 'seedQueryDocumentNode',
+    namespace: string,
+    callback: (
+      seedQuery: DocumentNode,
+      context: { resolvedUrl: string },
+    ) => DocumentNode,
+    priority?: number | undefined,
+  ): void;
+
+  addFilter(
+    hookName: 'graphqlEndpoint',
+    namespace: string,
+    callback: (graphqlEndpoint: string, context: { wpUrl: string }) => string,
+    priority?: number | undefined,
+  ): void;
+
+  addFilter(
+    hookName: 'wpHostname',
+    namespace: string,
+    callback: (wpHostname: string, context: { wpUrl: string }) => string,
+    priority?: number | undefined,
+  ): void;
+
+  addFilter(
+    hookName: 'wpHostname',
+    namespace: string,
+    callback: (wpHostname: string, context: { wpUrl: string }) => string,
+    priority?: number | undefined,
+  ): void;
+
+  addFilter(
+    hookName: 'wpUrl',
+    namespace: string,
+    callback: (wpUrl: string, context: Record<string, never>) => string,
+    priority?: number | undefined,
+  ): void;
+};
+
+export type FaustHooks = _Hooks & FaustCoreFilters;

--- a/packages/faustwp-core/src/hooks/overloads.ts
+++ b/packages/faustwp-core/src/hooks/overloads.ts
@@ -63,13 +63,6 @@ type FaustCoreFilters = {
   ): void;
 
   addFilter(
-    hookName: 'wpHostname',
-    namespace: string,
-    callback: (wpHostname: string, context: { wpUrl: string }) => string,
-    priority?: number | undefined,
-  ): void;
-
-  addFilter(
     hookName: 'wpUrl',
     namespace: string,
     callback: (wpUrl: string, context: Record<string, never>) => string,

--- a/packages/faustwp-core/src/index.ts
+++ b/packages/faustwp-core/src/index.ts
@@ -13,6 +13,8 @@ import { getWpUrl } from './lib/getWpUrl.js';
 import { getGraphqlEndpoint } from './lib/getGraphqlEndpoint.js';
 import { getWpHostname } from './lib/getWpHostname.js';
 import { getApolloClient, addApolloState } from './client.js';
+import { FaustPlugin } from './hooks/index.js';
+import { FaustHooks } from './hooks/overloads.js';
 
 export {
   FaustProvider,
@@ -33,4 +35,6 @@ export {
   getGraphqlEndpoint,
   getApolloClient,
   addApolloState,
+  FaustPlugin,
+  FaustHooks,
 };

--- a/packages/faustwp-core/tests/config/index.test.ts
+++ b/packages/faustwp-core/tests/config/index.test.ts
@@ -1,4 +1,5 @@
 import { Hooks } from '@wordpress/hooks/build-types';
+import { FaustPlugin } from '../../src';
 import { setConfig } from '../../src/config/index';
 
 class HelloWorldTestPlugin {
@@ -36,7 +37,10 @@ describe('config', () => {
       setConfig({
         // @ts-ignore
         templates: [],
-        experimentalPlugins: [new HelloWorldTestPlugin(), new InvalidPlugin()],
+        experimentalPlugins: [
+          new HelloWorldTestPlugin(),
+          new InvalidPlugin() as FaustPlugin,
+        ],
       }),
     ).not.toThrowError();
   });


### PR DESCRIPTION
## Tasks

- [x] I've filled out the WP Engine Contributor License Agreement (CLA)

## Description

Created two new TypeScript types for type checking Faust Plugins: `FaustPlugin` and `FaustHooks`, which work like:

```tsx
import { FaustHooks, FaustPlugin } from '@faustwp/core';

export class MyPlugin implements FaustPlugin {
  apply(hooks: FaustHooks) {}
}
```

This allows for intellisense to pick up the different types of filters that are available and their signatures:

<img width="1003" alt="Screenshot 2023-01-04 at 2 44 10 PM" src="https://user-images.githubusercontent.com/5946219/210646531-0f9adf90-a4a2-4b81-b449-90306b9d4f14.png">


Added docs that describe the filters and their context objects and signatures. Additionally added a short doc describing how to create a Faust plugin.

## Related Issue(s):

<!--
Provide the GitHub issue(s) number for issue tracking purposes, use the following syntax:

- #1234
-->

## Testing

<!--
Describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Also list any relevant details for your test configuration such as how to test the changes locally or in staging.
-->

## Screenshots

<!--
If this is a visual change include relevant screenshots about the behavior of the application before and after this change.
-->

## Documentation Changes

<!--
List corresponding changes to the documentation.
-->

## Dependant PRs

<!--
List any dependent PR's that are awaiting review. Use the following syntax:

- #1234
-->
