### PR TITLE
Update CLA docs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 ## Tasks
 
-- [ ] I've filled out the WP Engine Contributor License Agreement (CLA)
+- [ ] I have signed a [Contributor License Agreement (CLA)](https://github.com/wpengine/faustjs#contributor-license-agreement) with WP Engine.
 
 ## Description
 

--- a/README.md
+++ b/README.md
@@ -68,4 +68,4 @@ All external contributors to WP Engine products must have a signed Contributor L
 2. 📝 Sign the CLA emailed to you
 3. 📥 Receive copy of signed CLA
 
-❤️ Thank you for helping us fufill our legal obligations in order to continue empowering builders through headless WordPress.
+❤️ Thank you for helping us fulfill our legal obligations in order to continue empowering builders through headless WordPress.

--- a/README.md
+++ b/README.md
@@ -60,8 +60,12 @@ There are many ways to [contribute](/CONTRIBUTING.md) to this project.
 - Review and discuss the [source code changes](https://github.com/wpengine/faustjs/pulls).
 - [Contribute bug fixes](/CONTRIBUTING.md)
 
-### Pull Request Notice
+### Contributor License Agreement
 
-All contributions from non-WP Engine employees require that you sign our Contributor License Agreement (CLA).
+All external contributors to WP Engine products must have a signed Contributor License Agreement (CLA) in place before the contribution may be accepted into any WP Engine codebase.
 
-https://wpeng.in/cla/
+1. [Submit your name and email](https://wpeng.in/cla/)
+2. 📝 Sign the CLA emailed to you
+3. 📥 Receive copy of signed CLA
+
+❤️ Thank you for helping us fufill our legal obligations in order to continue empowering builders through headless WordPress.


### PR DESCRIPTION
Signed-off-by: Joe Fusco <joe.fusco@wpengine.com>

## Tasks

- [x] I've filled out the WP Engine Contributor License Agreement (CLA)

## Description

These changes provide more details regarding the current CLA process.

## Screenshots

<img width="1407" alt="Screen Shot 2023-01-04 at 4 47 05 PM" src="https://user-images.githubusercontent.com/6676674/210656165-ccd68f9d-5687-48e5-a681-e17d18ffafcb.png">
