### PR TITLE
Limit Sonarqube scans to main branch pull requests

### DIFF
--- a/.github/workflows/sonarqube-scan.yml
+++ b/.github/workflows/sonarqube-scan.yml
@@ -4,7 +4,7 @@ on:
       - canary
   pull_request:
     branches:
-      - canary
+      - main
     paths-ignore:
       - '**/*.md'
 


### PR DESCRIPTION
Signed-off-by: Joe Fusco <joe.fusco@wpengine.com>

## Tasks

- [X] I have signed a [Contributor License Agreement (CLA)](https://github.com/wpengine/faustjs#contributor-license-agreement) with WP Engine.

## Description

These changes remove Sonarqube scans for pull requests into `canary` in order to prevent failed builds for outside contributors.

Sonarqube scans will continue to run against all new code for pull requests into `main`.