### PR TITLE
Merl 253 provide text description for videos on docs website

### DIFF
--- a/internal/faustjs.org/docs/getting-started.mdx
+++ b/internal/faustjs.org/docs/getting-started.mdx
@@ -32,7 +32,7 @@ You can now visit [http://localhost:3000](http://localhost:3000) to see your new
 
 <p align="center">
   <video
-    aira-hidden="true"
+    aria-hidden="true"
     src="/docs/video/next/getting-started-next-example.mp4"
     muted
     autoPlay

--- a/internal/faustjs.org/docs/getting-started.mdx
+++ b/internal/faustjs.org/docs/getting-started.mdx
@@ -32,6 +32,7 @@ You can now visit [http://localhost:3000](http://localhost:3000) to see your new
 
 <p align="center">
   <video
+    aira-hidden="true"
     src="/docs/video/next/getting-started-next-example.mp4"
     muted
     autoPlay

--- a/internal/faustjs.org/src/components/GetStarted/HomepageGetStarted.js
+++ b/internal/faustjs.org/src/components/GetStarted/HomepageGetStarted.js
@@ -18,6 +18,7 @@ export default function HomepageGetStarted() {
         <div className={clsx('row', styles.getStartedRow)}>
           <p>
             <video
+              aira-hidden="true"
               src="/docs/video/next/getting-started-next-example.mp4"
               muted
               autoPlay

--- a/internal/faustjs.org/src/components/GetStarted/HomepageGetStarted.js
+++ b/internal/faustjs.org/src/components/GetStarted/HomepageGetStarted.js
@@ -18,7 +18,7 @@ export default function HomepageGetStarted() {
         <div className={clsx('row', styles.getStartedRow)}>
           <p>
             <video
-              aira-hidden="true"
+              aria-hidden="true"
               src="/docs/video/next/getting-started-next-example.mp4"
               muted
               autoPlay

--- a/internal/legacy.faustjs.org/docs/next/getting-started.mdx
+++ b/internal/legacy.faustjs.org/docs/next/getting-started.mdx
@@ -48,6 +48,7 @@ You can now visit [http://localhost:3000](http://localhost:3000) to see the exam
 
 <p align="center">
   <video
+    aira-hidden="true"
     src="/docs/video/next/getting-started-next-example.mp4"
     muted
     autoPlay

--- a/internal/legacy.faustjs.org/docs/next/getting-started.mdx
+++ b/internal/legacy.faustjs.org/docs/next/getting-started.mdx
@@ -48,7 +48,7 @@ You can now visit [http://localhost:3000](http://localhost:3000) to see the exam
 
 <p align="center">
   <video
-    aira-hidden="true"
+    aria-hidden="true"
     src="/docs/video/next/getting-started-next-example.mp4"
     muted
     autoPlay

--- a/internal/legacy.faustjs.org/docs/next/guides/authentication.mdx
+++ b/internal/legacy.faustjs.org/docs/next/guides/authentication.mdx
@@ -197,6 +197,7 @@ The `useLogout` hook exports an object with the following properties:
 <video
   width="100%"
   src="/docs/video/next/local-auth-flow-previews.mp4"
+  alt="The user clicks on the 'Preview' button in the top right-hand corner of the WordPress site editor. They then select ‘Preview in new tab,’ from a dropdown menu, which takes them to an admin login and password prompt. After entering the login and password, the user can now see a preview of any site edits."
   muted
   autoPlay
   playsInline

--- a/internal/legacy.faustjs.org/docs/next/guides/authentication.mdx
+++ b/internal/legacy.faustjs.org/docs/next/guides/authentication.mdx
@@ -194,16 +194,20 @@ The `useLogout` hook exports an object with the following properties:
 - `isLoading`: a boolean that indicates whether the logout request is in progress.
 - `isLoggedOut`: a boolean that indicates whether the logout request was successful.
 
-<video
-  width="100%"
-  src="/docs/video/next/local-auth-flow-previews.mp4"
-  alt="The user clicks on the 'Preview' button in the top right-hand corner of the WordPress site editor. They then select ‘Preview in new tab,’ from a dropdown menu, which takes them to an admin login and password prompt. After entering the login and password, the user can now see a preview of any site edits."
-  muted
-  autoPlay
-  playsInline
-  controls
-  loop
-/>
+<div aria-describedby="auth-flow-clip-desc">
+  <video
+    width="100%"
+    src="/docs/video/next/local-auth-flow-previews.mp4"
+    muted
+    autoPlay
+    playsInline
+    controls
+    loop
+  />
+  <p id="auth-flow-clip-desc">
+    In this clip, the user clicks on the 'Preview' button in the top right-hand corner of the WordPress site editor. They then select ‘Preview in new tab,’ from a dropdown menu, which takes them to an admin login and password prompt. After entering the login and password, the user can now see a preview of any site edits.
+  </p>
+</div>
 
 ## Making Authenticated Requests
 

--- a/internal/legacy.faustjs.org/src/components/GetStarted/HomepageGetStarted.js
+++ b/internal/legacy.faustjs.org/src/components/GetStarted/HomepageGetStarted.js
@@ -18,6 +18,7 @@ export default function HomepageGetStarted() {
         <div className={clsx('row', styles.getStartedRow)}>
           <p>
             <video
+              aira-hidden="true"
               src="/docs/video/next/getting-started-next-example.mp4"
               muted
               autoPlay

--- a/internal/legacy.faustjs.org/src/components/GetStarted/HomepageGetStarted.js
+++ b/internal/legacy.faustjs.org/src/components/GetStarted/HomepageGetStarted.js
@@ -18,7 +18,7 @@ export default function HomepageGetStarted() {
         <div className={clsx('row', styles.getStartedRow)}>
           <p>
             <video
-              aira-hidden="true"
+              aria-hidden="true"
               src="/docs/video/next/getting-started-next-example.mp4"
               muted
               autoPlay


### PR DESCRIPTION
## Description

There are two videos across three pages:

[Authentication](https://legacy.faustjs.org/docs/next/guides/auth) (informational; not in faustjs, but in legacy site)

[Getting Started with Faust](https://faustjs.org/docs/next/getting-started) (decorative; in both faustjs and legacy site)

[Main Page](https://faustjs.org/) (decorative; in both faustjs and legacy site)


This PR adds an `aria-hidden="true"` to the Getting Started and Main Page videos (they are the same decorative video). The `aria-hidden="true"` is added here as the videos are decorative in nature, so that the screen reader will skip over them without pause.

An additional paragraph has been added to the authentication video, using `aria-describedby`, which will skip the video and provide a text description below it.

## Testing

All sections are tested using the VoiceOver mac accessibility tool, which demonstrated a skip for each video. 

Elements used: 
`aria-describedby`: [link](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-describedby)
`area-hidden`: [link](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-hidden)