### PR TITLE
Add verbose mode to Faust

### DIFF
--- a/.changeset/curvy-cameras-grow.md
+++ b/.changeset/curvy-cameras-grow.md
@@ -1,0 +1,5 @@
+---
+'@faustwp/cli': patch
+---
+
+Fixed a bug where the CLI was overriding the NODE_ENV environment variable if it was predefined

--- a/.changeset/forty-stingrays-own.md
+++ b/.changeset/forty-stingrays-own.md
@@ -1,0 +1,5 @@
+---
+'@faustwp/core': patch
+---
+
+BREAKING: Removed the `disableLogging` option from the Faust config

--- a/.changeset/two-tigers-clap.md
+++ b/.changeset/two-tigers-clap.md
@@ -1,0 +1,6 @@
+---
+'@faustwp/cli': patch
+'@faustwp/core': patch
+---
+
+Added a verbose mode by setting the `FAUST_VERBOSE` environment variable to either `true` or `1`

--- a/package-lock.json
+++ b/package-lock.json
@@ -13271,7 +13271,7 @@
       "license": "MIT",
       "dependencies": {
         "@wordpress/hooks": "^3.14.0",
-        "chalk": "^5.2.0",
+        "chalk": "^4.1.2",
         "cookie": "^0.5.0",
         "deepmerge": "^4.2.2",
         "isomorphic-fetch": "^3.0.0",
@@ -13300,15 +13300,68 @@
         "react-dom": ">=17.0.2"
       }
     },
-    "packages/faustwp-core/node_modules/chalk": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.2.0.tgz",
-      "integrity": "sha512-ree3Gqw/nazQAPuJJEy+avdl7QfZMcUvmHIKgEZkGL+xOBzRvup5Hxo6LHuMceSxOabuJLJm5Yp/92R9eMmMvA==",
+    "packages/faustwp-core/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
       "engines": {
-        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "packages/faustwp-core/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "packages/faustwp-core/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "packages/faustwp-core/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "packages/faustwp-core/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "packages/faustwp-core/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "packages/next": {
@@ -14324,7 +14377,7 @@
         "@types/lodash": "^4.14.176",
         "@types/node": "^17.0.17",
         "@wordpress/hooks": "^3.14.0",
-        "chalk": "*",
+        "chalk": "^4.1.2",
         "cookie": "^0.5.0",
         "deepmerge": "^4.2.2",
         "fetch-mock": "9.11.0",
@@ -14337,10 +14390,48 @@
         "typescript": "^4.4.4"
       },
       "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
         "chalk": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.2.0.tgz",
-          "integrity": "sha512-ree3Gqw/nazQAPuJJEy+avdl7QfZMcUvmHIKgEZkGL+xOBzRvup5Hxo6LHuMceSxOabuJLJm5Yp/92R9eMmMvA=="
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -13119,10 +13119,10 @@
       }
     },
     "packages/blocks": {
+      "name": "@faustwp/blocks",
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
-        "@faustwp/core": "*",
         "lodash": "^4.17.21"
       },
       "devDependencies": {
@@ -13271,6 +13271,7 @@
       "license": "MIT",
       "dependencies": {
         "@wordpress/hooks": "^3.14.0",
+        "chalk": "^5.2.0",
         "cookie": "^0.5.0",
         "deepmerge": "^4.2.2",
         "isomorphic-fetch": "^3.0.0",
@@ -13297,6 +13298,17 @@
         "next": ">=12.1.6",
         "react": ">=17.0.2",
         "react-dom": ">=17.0.2"
+      }
+    },
+    "packages/faustwp-core/node_modules/chalk": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.2.0.tgz",
+      "integrity": "sha512-ree3Gqw/nazQAPuJJEy+avdl7QfZMcUvmHIKgEZkGL+xOBzRvup5Hxo6LHuMceSxOabuJLJm5Yp/92R9eMmMvA==",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "packages/next": {
@@ -14231,7 +14243,6 @@
     "@faustwp/blocks": {
       "version": "file:packages/blocks",
       "requires": {
-        "@faustwp/core": "*",
         "@testing-library/jest-dom": "^5.15.0",
         "@types/node": "^18.0.6",
         "@types/react": "^17.0.34",
@@ -14313,6 +14324,7 @@
         "@types/lodash": "^4.14.176",
         "@types/node": "^17.0.17",
         "@wordpress/hooks": "^3.14.0",
+        "chalk": "*",
         "cookie": "^0.5.0",
         "deepmerge": "^4.2.2",
         "fetch-mock": "9.11.0",
@@ -14323,6 +14335,13 @@
         "ts-jest": "^27.0.7",
         "ts-loader": "^9.2.6",
         "typescript": "^4.4.4"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.2.0.tgz",
+          "integrity": "sha512-ree3Gqw/nazQAPuJJEy+avdl7QfZMcUvmHIKgEZkGL+xOBzRvup5Hxo6LHuMceSxOabuJLJm5Yp/92R9eMmMvA=="
+        }
       }
     },
     "@faustwp/getting-started-example": {

--- a/packages/faustwp-cli/index.ts
+++ b/packages/faustwp-cli/index.ts
@@ -15,28 +15,38 @@ import {
   validateFaustEnvVars,
   userConfig,
   infoLog,
+  verboseLog,
+  isVerbose,
 } from './utils/index.js';
 
 // eslint-disable-next-line func-names, @typescript-eslint/no-floating-promises
 (async function () {
   const arg1 = getCliArgs()[0];
 
-  switch (arg1) {
-    case 'build':
-      process.env.NODE_ENV = 'production';
-      break;
-    case 'start':
-      process.env.NODE_ENV = 'production';
-      break;
-    case 'test':
-      process.env.NODE_ENV = 'test';
-      break;
-    case 'dev':
-    default:
-      process.env.NODE_ENV = 'development';
-      break;
-  }
   dotenv.config();
+
+  if (isVerbose()) {
+    verboseLog('Faust is running in verbose mode');
+  }
+
+  if (!process.env.NODE_ENV) {
+    switch (arg1) {
+      case 'build':
+        process.env.NODE_ENV = 'production';
+        break;
+      case 'start':
+        process.env.NODE_ENV = 'production';
+        break;
+      case 'test':
+        process.env.NODE_ENV = 'test';
+        break;
+      case 'dev':
+      default:
+        process.env.NODE_ENV = 'development';
+        break;
+    }
+  }
+
   validateFaustEnvVars();
 
   // Inform user of telemetry program.
@@ -79,7 +89,7 @@ import {
 
       const telemetryData = marshallTelemetryData(wpTelemetryData, arg1);
 
-      // infoLog('Telemetry event being sent', telemetryData);
+      verboseLog('Telemetry event: ', telemetryData);
 
       void sendTelemetryData(
         telemetryData,

--- a/packages/faustwp-cli/utils/index.ts
+++ b/packages/faustwp-cli/utils/index.ts
@@ -1,5 +1,5 @@
 import { getCliArgs } from './getCliArgs.js';
-import { errorLog, infoLog } from './log.js';
+import { errorLog, infoLog, verboseLog } from './log.js';
 import { marshallTelemetryData } from './marshallTelemetryData.js';
 import { handleTelemetrySubcommand } from './handleTelemetrySubcommand.js';
 import { requestWPTelemetryData } from './requestWPTelemetryData.js';
@@ -10,12 +10,14 @@ import { generatePossibleTypes } from './generatePossibleTypes.js';
 import { userConfig } from './userConfig.js';
 import { telemetryPrefsExist } from './doTelemetryPrefsExist.js';
 import { validateFaustEnvVars } from './validateFaustEnvVars.js';
+import { isVerbose } from './isVerbose.js';
 
 export {
   errorLog,
   generatePossibleTypes,
   getCliArgs,
   infoLog,
+  verboseLog,
   marshallTelemetryData,
   handleTelemetrySubcommand,
   requestWPTelemetryData,
@@ -25,4 +27,5 @@ export {
   telemetryPrefsExist,
   userConfig,
   validateFaustEnvVars,
+  isVerbose,
 };

--- a/packages/faustwp-cli/utils/isVerbose.ts
+++ b/packages/faustwp-cli/utils/isVerbose.ts
@@ -1,11 +1,7 @@
 export function isVerbose(): boolean {
   const isVerboseEnvVar = process.env.FAUST_VERBOSE;
 
-  if (isVerboseEnvVar === 'true') {
-    return true;
-  }
-
-  if (isVerboseEnvVar === '1') {
+  if (isVerboseEnvVar === 'true' || isVerboseEnvVar === '1') {
     return true;
   }
 

--- a/packages/faustwp-cli/utils/log.ts
+++ b/packages/faustwp-cli/utils/log.ts
@@ -1,7 +1,7 @@
 import { styles } from './styles.js';
 
 export const log = (
-  logLevel: 'info' | 'warn' | 'error',
+  logLevel: 'info' | 'warn' | 'error' | 'verbose',
   message: string,
   ...args: any
 ) => {
@@ -18,6 +18,10 @@ export const log = (
     }
     case 'error': {
       styledLogLevel = styles.error('error');
+      break;
+    }
+    case 'verbose': {
+      styledLogLevel = styles.verbose('verbose');
       break;
     }
     default: {
@@ -42,4 +46,9 @@ export const warnLog = (message: string, ...args: any) => {
 export const errorLog = (message: string, ...args: any) => {
   // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
   log('error', message, ...args);
+};
+
+export const verboseLog = (message: string, ...args: any) => {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+  log('verbose', message, ...args);
 };

--- a/packages/faustwp-cli/utils/log.ts
+++ b/packages/faustwp-cli/utils/log.ts
@@ -1,3 +1,4 @@
+import { isVerbose } from './isVerbose.js';
 import { styles } from './styles.js';
 
 export const log = (
@@ -49,6 +50,10 @@ export const errorLog = (message: string, ...args: any) => {
 };
 
 export const verboseLog = (message: string, ...args: any) => {
+  if (!isVerbose()) {
+    return;
+  }
+
   // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
   log('verbose', message, ...args);
 };

--- a/packages/faustwp-cli/utils/styles.ts
+++ b/packages/faustwp-cli/utils/styles.ts
@@ -6,4 +6,5 @@ export const styles = {
   warn: chalk.yellow,
   error: chalk.red,
   success: chalk.blueBright,
+  verbose: chalk.magenta.italic,
 };

--- a/packages/faustwp-core/package.json
+++ b/packages/faustwp-core/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@wordpress/hooks": "^3.14.0",
-    "chalk": "^5.2.0",
+    "chalk": "^4.1.2",
     "cookie": "^0.5.0",
     "deepmerge": "^4.2.2",
     "isomorphic-fetch": "^3.0.0",

--- a/packages/faustwp-core/package.json
+++ b/packages/faustwp-core/package.json
@@ -20,15 +20,16 @@
     "@types/jest": "^27.0.2",
     "@types/lodash": "^4.14.176",
     "@types/node": "^17.0.17",
+    "fetch-mock": "9.11.0",
     "jest": "^27.3.1",
     "rimraf": "^3.0.2",
     "ts-jest": "^27.0.7",
     "ts-loader": "^9.2.6",
-    "typescript": "^4.4.4",
-    "fetch-mock": "9.11.0"
+    "typescript": "^4.4.4"
   },
   "dependencies": {
     "@wordpress/hooks": "^3.14.0",
+    "chalk": "^5.2.0",
     "cookie": "^0.5.0",
     "deepmerge": "^4.2.2",
     "isomorphic-fetch": "^3.0.0",

--- a/packages/faustwp-core/src/getTemplate.ts
+++ b/packages/faustwp-core/src/getTemplate.ts
@@ -151,8 +151,6 @@ export function getTemplate(
   }
 
   const possibleTemplates = getPossibleTemplates(seedNode);
-  // eslint-disable-next-line no-console
-  console.log('possible templates: ', possibleTemplates);
 
   // eslint-disable-next-line no-plusplus
   for (let i = 0; i < possibleTemplates.length; i++) {

--- a/packages/faustwp-core/src/getWordPressProps.tsx
+++ b/packages/faustwp-core/src/getWordPressProps.tsx
@@ -1,10 +1,11 @@
 import { GetServerSidePropsContext, GetStaticPropsContext } from 'next';
 import type { DocumentNode } from 'graphql';
 import { SeedNode, SEED_QUERY } from './queries/seedQuery.js';
-import { getTemplate } from './getTemplate.js';
+import { getPossibleTemplates, getTemplate } from './getTemplate.js';
 import { addApolloState, getApolloClient } from './client.js';
 import { getConfig } from './config/index.js';
 import { hooks } from './hooks/index.js';
+import { infoLog, verboseLog } from './utils/log.js';
 
 export const DEFAULT_ISR_REVALIDATE = 60 * 15; // 15 minutes
 
@@ -69,11 +70,18 @@ export async function getWordPressProps(options: GetWordPressPropsConfig) {
 
   const seedNode = seedQueryRes?.data?.node as SeedNode;
 
+  verboseLog(`Seed Node for resolved url: "${resolvedUrl}": `, seedNode);
+
   if (!seedNode) {
     return {
       notFound: true,
     };
   }
+
+  infoLog(
+    `Possible templates for resolved url: "${resolvedUrl}":`,
+    getPossibleTemplates(seedNode),
+  );
 
   const template = getTemplate(seedNode, templates);
 

--- a/packages/faustwp-core/src/lib/isVerbose.ts
+++ b/packages/faustwp-core/src/lib/isVerbose.ts
@@ -1,0 +1,13 @@
+export function isVerbose(): boolean {
+  const isVerboseEnvVar = process.env.FAUST_VERBOSE;
+
+  if (isVerboseEnvVar === 'true') {
+    return true;
+  }
+
+  if (isVerboseEnvVar === '1') {
+    return true;
+  }
+
+  return false;
+}

--- a/packages/faustwp-core/src/lib/log.ts
+++ b/packages/faustwp-core/src/lib/log.ts
@@ -1,0 +1,53 @@
+import chalk from 'chalk';
+
+export const styles = {
+  brand: chalk.bold.whiteBright,
+  info: chalk.cyan,
+  warn: chalk.yellow,
+  error: chalk.red,
+  success: chalk.blueBright,
+};
+
+export const log = (
+  logLevel: 'info' | 'warn' | 'error',
+  message: string,
+  ...args: any
+) => {
+  let styledLogLevel = '';
+
+  switch (logLevel) {
+    case 'info': {
+      styledLogLevel = styles.info('info');
+      break;
+    }
+    case 'warn': {
+      styledLogLevel = styles.warn('warn');
+      break;
+    }
+    case 'error': {
+      styledLogLevel = styles.error('error');
+      break;
+    }
+    default: {
+      break;
+    }
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, no-console
+  console.log(`${styledLogLevel} - ${message}`, ...args);
+};
+
+export const infoLog = (message: string, ...args: any) => {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+  log('info', message, ...args);
+};
+
+export const warnLog = (message: string, ...args: any) => {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+  log('warn', message, ...args);
+};
+
+export const errorLog = (message: string, ...args: any) => {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+  log('error', message, ...args);
+};

--- a/packages/faustwp-core/src/server/auth/middleware.ts
+++ b/packages/faustwp-core/src/server/auth/middleware.ts
@@ -71,7 +71,7 @@ export async function authorizeHandler(
       res.end(JSON.stringify(result.result));
     }
   } catch (e) {
-    errorLog(e);
+    errorLog('Invalid response for authorize handler:', e);
 
     res.statusCode = 500;
     res.setHeader('Content-Type', 'application/json');

--- a/packages/faustwp-core/src/server/auth/middleware.ts
+++ b/packages/faustwp-core/src/server/auth/middleware.ts
@@ -1,6 +1,6 @@
 import 'isomorphic-fetch';
 import { IncomingMessage, ServerResponse } from 'http';
-import { getQueryParam, log } from '../../utils/index.js';
+import { errorLog, getQueryParam } from '../../utils/index.js';
 import { Cookies } from './cookie.js';
 import { OAuth } from './token.js';
 
@@ -71,7 +71,7 @@ export async function authorizeHandler(
       res.end(JSON.stringify(result.result));
     }
   } catch (e) {
-    log(e);
+    errorLog(e);
 
     res.statusCode = 500;
     res.setHeader('Content-Type', 'application/json');

--- a/packages/faustwp-core/src/server/auth/token.ts
+++ b/packages/faustwp-core/src/server/auth/token.ts
@@ -3,7 +3,7 @@ import isNil from 'lodash/isNil.js';
 import isString from 'lodash/isString.js';
 import isNumber from 'lodash/isNumber.js';
 import { Cookies } from './cookie.js';
-import { log } from '../../utils/index.js';
+import { warnLog } from '../../utils/index.js';
 import { getWpSecret } from '../../lib/getWpSecret.js';
 import { getWpUrl } from '../../lib/getWpUrl.js';
 
@@ -92,7 +92,7 @@ export class OAuth {
       });
 
       if (response.status !== 404) {
-        log(
+        warnLog(
           'Authentication and post previews will soon be incompatible with ' +
             'your version of the FaustWP plugin. Please update to the latest' +
             ' version.',

--- a/packages/faustwp-core/src/utils/isVerbose.ts
+++ b/packages/faustwp-core/src/utils/isVerbose.ts
@@ -1,0 +1,9 @@
+export function isVerbose(): boolean {
+  const isVerboseEnvVar = process.env.FAUST_VERBOSE;
+
+  if (isVerboseEnvVar === 'true' || isVerboseEnvVar === '1') {
+    return true;
+  }
+
+  return false;
+}

--- a/packages/faustwp-core/src/utils/log.ts
+++ b/packages/faustwp-core/src/utils/log.ts
@@ -1,4 +1,5 @@
 import chalk from 'chalk';
+import { isVerbose } from './isVerbose';
 
 export const styles = {
   brand: chalk.bold.whiteBright,
@@ -58,6 +59,10 @@ export const errorLog = (message: string, ...args: any) => {
 };
 
 export const verboseLog = (message: string, ...args: any) => {
+  if (!isVerbose()) {
+    return;
+  }
+
   // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
   log('verbose', message, ...args);
 };

--- a/packages/faustwp-core/src/utils/log.ts
+++ b/packages/faustwp-core/src/utils/log.ts
@@ -1,10 +1,63 @@
-import { getConfig } from '../config/index.js';
+import chalk from 'chalk';
 
-export const log: typeof console.log = (...args) => {
-  if (getConfig().disableLogging) {
-    return;
+export const styles = {
+  brand: chalk.bold.whiteBright,
+  info: chalk.cyan,
+  warn: chalk.yellow,
+  error: chalk.red,
+  success: chalk.blueBright,
+  verbose: chalk.magenta.italic,
+};
+
+export const log = (
+  logLevel: 'info' | 'warn' | 'error' | 'verbose',
+  message: string,
+  ...args: any
+) => {
+  let styledLogLevel = '';
+
+  switch (logLevel) {
+    case 'info': {
+      styledLogLevel = styles.info('info');
+      break;
+    }
+    case 'warn': {
+      styledLogLevel = styles.warn('warn');
+      break;
+    }
+    case 'error': {
+      styledLogLevel = styles.error('error');
+      break;
+    }
+    case 'verbose': {
+      styledLogLevel = styles.verbose('verbose');
+      break;
+    }
+    default: {
+      break;
+    }
   }
 
-  // eslint-disable-next-line no-console
-  console.log(...args);
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, no-console
+  console.log(`${styledLogLevel} - ${message}`, ...args);
+};
+
+export const infoLog = (message: string, ...args: any) => {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+  log('info', message, ...args);
+};
+
+export const warnLog = (message: string, ...args: any) => {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+  log('warn', message, ...args);
+};
+
+export const errorLog = (message: string, ...args: any) => {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+  log('error', message, ...args);
+};
+
+export const verboseLog = (message: string, ...args: any) => {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+  log('verbose', message, ...args);
 };


### PR DESCRIPTION
## Tasks

- [ x] I have signed a [Contributor License Agreement (CLA)](https://github.com/wpengine/faustjs#contributor-license-agreement) with WP Engine.

## Description

Adds a verbose mode to Faust by specifying the `FAUST_VERBOSE` environment variable.

* Removed the `disableLogging` option from the @faustwp/core logger. This was a reminant of old Faust and hasn't been explicitly documented in new Faust so it's not a breaking change.
* Faust now only sets the `NODE_ENV` if it wasn't already set. That way if users wanted custom `NODE_ENV`s we are not overriding their preferences.

Currently there is a logger in both @faustwp/core and @faustwp/cli, making the code not as DRY as it could be. However, since we may be researching how we can built the CLI into core I figure we could address this at a later time. I didn't want to create exports in the CLI just for logger utils for core to use.

<!--
Include a summary of the change and some contextual information.
-->

## Related Issue(s):

<!--
Provide the GitHub issue(s) number for issue tracking purposes, use the following syntax:

- #1234
-->

## Testing

<!--
Describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Also list any relevant details for your test configuration such as how to test the changes locally or in staging.
-->

## Screenshots

<img width="1563" alt="Screenshot 2023-01-17 at 3 28 03 PM" src="https://user-images.githubusercontent.com/5946219/213016054-7499ab54-927d-44b9-960d-ee09a2516f23.png">

Much cleaner...

## Documentation Changes

<!--
List corresponding changes to the documentation.
-->

## Dependant PRs

<!--
List any dependent PR's that are awaiting review. Use the following syntax:

- #1234
-->
