### PR TITLE
Fix telemetry data

### DIFF
--- a/.changeset/olive-nails-argue.md
+++ b/.changeset/olive-nails-argue.md
@@ -1,0 +1,5 @@
+---
+'@faustwp/cli': patch
+---
+
+Fixed an issue where telemetry data could be incomplete. Now, if the request to get telemetry data from WordPress fails, we will not continue on with the telemetry request.

--- a/packages/faustwp-cli/index.ts
+++ b/packages/faustwp-cli/index.ts
@@ -85,7 +85,7 @@ import {
 
       const telemetryData = marshallTelemetryData(wpTelemetryData, arg1);
 
-      infoLog('Telemetry event being sent', telemetryData);
+      // infoLog('Telemetry event being sent', telemetryData);
 
       void sendTelemetryData(
         telemetryData,

--- a/packages/faustwp-cli/index.ts
+++ b/packages/faustwp-cli/index.ts
@@ -77,9 +77,15 @@ import {
         process.env.FAUSTWP_SECRET_KEY!,
       );
 
+      if (!wpTelemetryData) {
+        throw new Error(
+          'There was a problem retrieving telemetry data from the WordPress instance',
+        );
+      }
+
       const telemetryData = marshallTelemetryData(wpTelemetryData, arg1);
 
-      // infoLog('Telemetry event being sent', telemetryData);
+      infoLog('Telemetry event being sent', telemetryData);
 
       void sendTelemetryData(
         telemetryData,

--- a/packages/faustwp-cli/utils/marshallTelemetryData.ts
+++ b/packages/faustwp-cli/utils/marshallTelemetryData.ts
@@ -55,7 +55,7 @@ const sanitizePackageJsonVersion = (_version: string | undefined) => {
  * @param wpTelemetryData
  */
 export const marshallTelemetryData = (
-  wpTelemetryData: WPTelemetryResponseData | undefined,
+  wpTelemetryData: WPTelemetryResponseData,
   command: string,
 ): TelemetryData => {
   const packageJson = JSON.parse(fs.readFileSync('package.json', 'utf8'));


### PR DESCRIPTION
## Tasks

- [x] I have signed a [Contributor License Agreement (CLA)](https://github.com/wpengine/faustjs#contributor-license-agreement) with WP Engine.

## Description

This PR fixes occurances where we are sending incomplete telemetry data to Google Analytics.

If the request to get telemetry data from WordPress fails, we throw an error and do not make a request to Google Analytics.

<!--
Include a summary of the change and some contextual information.
-->

## Related Issue(s):

<!--
Provide the GitHub issue(s) number for issue tracking purposes, use the following syntax:

- #1234
-->

## Testing

1. Check out the branch
2. Uncomment the `console.log` on line 95 of `faustwp-cli/index.ts`
3. Uncomment the telemetry log on line 88 of `faustwp-cli/index.ts`
4. Change your `FAUST_SECRET_KEY` to something invalid
5. Ensure you have opted in for Faust telemetry
6. Run `npm run dev` in the example, and notice the Error "There was a problem retrieving telemetry data from the WordPress instance"
7. Add the proper `FAUST_SECRET_KEY`
8. Re-run `npm run dev` and notice the proper telemetry event with all properties filled out

<!--
Describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Also list any relevant details for your test configuration such as how to test the changes locally or in staging.
-->

## Screenshots

<!--
If this is a visual change include relevant screenshots about the behavior of the application before and after this change.
-->

## Documentation Changes

<!--
List corresponding changes to the documentation.
-->

## Dependant PRs

<!--
List any dependent PR's that are awaiting review. Use the following syntax:

- #1234
-->
