### PR TITLE
Remove the command constraint from the telemetry event being sent

### DIFF
--- a/.changeset/itchy-ways-applaud.md
+++ b/.changeset/itchy-ways-applaud.md
@@ -1,0 +1,5 @@
+---
+'@faustwp/cli': patch
+---
+
+Telemetry events will now be send for any Faust command. Previously, telemetry events were only being sent for the `faust dev` and `faust build` commands.

--- a/packages/faustwp-cli/utils/shouldFireTelemetryEvent.ts
+++ b/packages/faustwp-cli/utils/shouldFireTelemetryEvent.ts
@@ -1,20 +1,11 @@
-import { getCliArgs } from './getCliArgs.js';
 import { userConfig } from './userConfig.js';
 
 export function shouldFireTelemetryEvent(): boolean {
-  const args = getCliArgs();
-  const arg1 = args[0];
-
   const hasSecretKey = process.env.FAUSTWP_SECRET_KEY;
   const hasAnonymousId = userConfig.get('telemetry.anonymousId');
   const hasTelemetryEnabled = userConfig.get('telemetry.enabled') === true;
-  const runningUsingProperCommands = arg1 === 'dev' || arg1 === 'build';
 
-  const shouldFireEvent =
-    hasSecretKey &&
-    hasAnonymousId &&
-    hasTelemetryEnabled &&
-    runningUsingProperCommands;
+  const shouldFireEvent = hasSecretKey && hasAnonymousId && hasTelemetryEnabled;
 
   return shouldFireEvent as boolean;
 }


### PR DESCRIPTION
## Tasks

- [x] I have signed a [Contributor License Agreement (CLA)](https://github.com/wpengine/faustjs#contributor-license-agreement) with WP Engine.

## Description

This PR removes the command constraint (that the command either needs to be `dev` or `build`) to sent a telemetry request.

The idea of only allowing telemetry events on `faust dev` or `faust build` was to ensure that the interactive prompt did not interfer with user's CI/CD pipelines. Now that we have done away with the interactive prompt and instead have a simple console message describing how users can enable/disable telemetry, this is no longer a concern.

Additionally, we have made it clear in our docs that we collect the command, so no changes are needed to what we collect docs:
https://faustjs.org/docs/telemetry#node-environment

<!--
Include a summary of the change and some contextual information.
-->

## Related Issue(s):

<!--
Provide the GitHub issue(s) number for issue tracking purposes, use the following syntax:

- #1234
-->

## Testing

<!--
Describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Also list any relevant details for your test configuration such as how to test the changes locally or in staging.
-->

## Screenshots

<img width="1463" alt="Screenshot 2023-01-18 at 2 50 29 PM" src="https://user-images.githubusercontent.com/5946219/213291758-ff9b1b83-47d5-42f2-8202-ea6f49e46cdf.png">

A user running `npm start` with no telemetry preferences saved. As you can see the telemetry message is called, but obviously is non blocking. You could image this being a CI environment.

## Documentation Changes

<!--
List corresponding changes to the documentation.
-->

## Dependant PRs

<!--
List any dependent PR's that are awaiting review. Use the following syntax:

- #1234
-->
