### PR TITLE
feat[faustwp-core]: (1228) add locale to the context sent down to the component variables in template

### DIFF
--- a/.changeset/dry-melons-talk.md
+++ b/.changeset/dry-melons-talk.md
@@ -1,0 +1,5 @@
+---
+'@faustwp/core': minor
+---
+
+Add locale to context that is passed to template variables

--- a/internal/faustjs.org/docs/templates.mdx
+++ b/internal/faustjs.org/docs/templates.mdx
@@ -144,6 +144,7 @@ The `context` of `Component.variables` has the following properties:
 ```ts
 interface {
   asPreview?: boolean
+  locale?: string
 }
 ```
 

--- a/packages/faustwp-core/src/getWordPressProps.tsx
+++ b/packages/faustwp-core/src/getWordPressProps.tsx
@@ -18,7 +18,7 @@ export type WordPressTemplate = React.FC & {
   query?: DocumentNode;
   variables?: (
     seedNode: SeedNode,
-    context?: { asPreview?: boolean },
+    context?: { asPreview?: boolean; locale?: string },
   ) => { [key: string]: any };
 };
 
@@ -85,7 +85,7 @@ export async function getWordPressProps(options: GetWordPressPropsConfig) {
 
   let templateQueryRes;
   const templateVariables = template?.variables
-    ? template?.variables(seedNode, { asPreview: false })
+    ? template?.variables(seedNode, { asPreview: false, locale: ctx.locale })
     : undefined;
 
   if (template.query) {


### PR DESCRIPTION
## Tasks

- [x] I have signed a [Contributor License Agreement (CLA)](https://github.com/wpengine/faustjs#contributor-license-agreement) with WP Engine.

## Description

This adds locale to the context for templates. more information can be found on the linked issue.

## Related Issue(s):

- #1228

## Testing

I did not create any tests for this change, I tried to look for tests that would cover this code but I didn't see any and thus, I didn't create any since its such a small change.

## Screenshots

No visual change

## Documentation Changes

With adding locale to the context, I have updated the document located at https://faustjs.org/docs/templates to correct the interface for the Component.variables.

## Dependant PRs

None

## Other notes

I did not create a changeset as I didn't know if it was required for my change. Please let me know if its required (I couldnt tell from [this](https://github.com/wpengine/faustjs/blob/canary/DEVELOPMENT.md#code-changesfeature-workflow) doc).
