### PR TITLE
fix: (1235) remove unneeded argument in function call

### DIFF
--- a/examples/next/faustwp-getting-started/components/NavigationMenu/NavigationMenu.js
+++ b/examples/next/faustwp-getting-started/components/NavigationMenu/NavigationMenu.js
@@ -30,7 +30,7 @@ export default function NavigationMenu({ menuItems, className }) {
           return (
             <li key={id} className={cxFromWp(cssClasses)}>
               <Link href={path ?? ''}>{label ?? ''}</Link>
-              {children.length ? renderMenu(children, true) : null}
+              {children.length ? renderMenu(children) : null}
             </li>
           );
         })}


### PR DESCRIPTION
## Tasks

- [x] I have signed a [Contributor License Agreement (CLA)](https://github.com/wpengine/faustjs#contributor-license-agreement) with WP Engine.

## Description
Remove an extra argument when renderMenu is called recursively in the example NavigationMenu component. 

## Related Issue(s):
#1235 

## Testing
Removed the extra argument in my own repo and no errors were observed.


