### PR TITLE
[Merl 738] Bug Fix: Propagate `revalidate` in getNextStaticProps`

### DIFF
--- a/.changeset/perfect-gorillas-march.md
+++ b/.changeset/perfect-gorillas-march.md
@@ -1,0 +1,5 @@
+---
+'@faustwp/core': patch
+---
+
+Bug Fix: Propagate `revalidate` property in getNextStaticProps.

--- a/packages/faustwp-core/src/getProps.ts
+++ b/packages/faustwp-core/src/getProps.ts
@@ -7,6 +7,7 @@ import {
 import type { DocumentNode } from 'graphql';
 import isBoolean from 'lodash/isBoolean.js';
 import isObject from 'lodash/isObject.js';
+import { DEFAULT_ISR_REVALIDATE } from './getWordPressProps.js';
 import { addApolloState, getApolloClient } from './client.js';
 
 export interface GetNextServerSidePropsConfig<Props = Record<string, unknown>> {
@@ -36,9 +37,8 @@ export async function getNextStaticProps<Props>(
   context: GetStaticPropsContext,
   cfg: GetNextStaticPropsConfig<Props>,
 ) {
-  const { notFound, redirect, Page, props } = cfg;
+  const { notFound, redirect, Page, revalidate, props } = cfg;
   const apolloClient = getApolloClient();
-
   if (isBoolean(notFound) && notFound === true) {
     return {
       notFound,
@@ -58,8 +58,9 @@ export async function getNextStaticProps<Props>(
     });
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-  return addApolloState(apolloClient, { props: { ...props } });
+  const pageProps = addApolloState(apolloClient, { props: { ...props } });
+  pageProps.revalidate = revalidate ?? DEFAULT_ISR_REVALIDATE;
+  return pageProps;
 }
 
 /**

--- a/packages/faustwp-core/tests/getProps.test.ts
+++ b/packages/faustwp-core/tests/getProps.test.ts
@@ -1,0 +1,53 @@
+import { getNextStaticProps } from '../src/getProps';
+
+//@ts-ignore-next-line
+global.fetch = jest.fn(() =>
+  Promise.resolve({
+    json: () => Promise.resolve(),
+  }),
+);
+
+beforeEach(() => {
+  //@ts-ignore-next-line
+  fetch.mockClear();
+});
+
+describe('getProps', () => {
+  describe('getNextStaticProps()', () => {
+    test('getNextStaticProps() handles `notFound`', async () => {
+      expect.assertions(1);
+      expect(
+        await getNextStaticProps({}, { Page: {}, notFound: true }),
+      ).toStrictEqual({ notFound: true });
+    });
+
+    test('getNextStaticProps() handles `redirect`', async () => {
+      expect.assertions(1);
+      expect(
+        await getNextStaticProps(
+          {},
+          { Page: {}, redirect: { destination: '/', permanent: false } },
+        ),
+      ).toStrictEqual({ redirect: { destination: '/', permanent: false } });
+    });
+
+    test('getNextStaticProps() handles `revalidate`', async () => {
+      expect.assertions(2);
+      expect(
+        await getNextStaticProps({}, { Page: {}, revalidate: 100 }),
+      ).toStrictEqual({
+        props: {
+          __APOLLO_STATE__: {},
+        },
+        revalidate: 100,
+      });
+
+      expect(await getNextStaticProps({}, { Page: {} })).toStrictEqual({
+        props: {
+          __APOLLO_STATE__: {},
+        },
+        revalidate: 900,
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Tasks

- [ ] I have signed a [Contributor License Agreement (CLA)](https://github.com/wpengine/faustjs#contributor-license-agreement) with WP Engine.

## Description

<!--
Include a summary of the change and some contextual information.
-->

- This PR fixes a bug with `getNextStaticProps` not properly propagating the `revalidate` property causing issues with ISR.
- Adds test cases.

## Related Issue(s):

<!--
Provide the GitHub issue(s) number for issue tracking purposes, use the following syntax:

- #1234
-->

## Testing

<!--
Describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Also list any relevant details for your test configuration such as how to test the changes locally or in staging.
-->

1. Create a Next.js file based page and set revalidate to a low value in getNextStaticProps

2. Update something in WordPress. 

3. The Page is not invalidated after the revalidate time elapsed causing ISR issues.

## Screenshots

<!--
If this is a visual change include relevant screenshots about the behavior of the application before and after this change.
-->

## Documentation Changes

<!--
List corresponding changes to the documentation.
-->

## Dependant PRs

<!--
List any dependent PR's that are awaiting review. Use the following syntax:

- #1234
-->
