### PR TITLE
Code coverage for new faust

### DIFF
--- a/.github/actions/run-coverage/action.yml
+++ b/.github/actions/run-coverage/action.yml
@@ -9,7 +9,7 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - uses: ArtiomTr/jest-coverage-report-action@v2
+    - uses: ArtiomTr/jest-coverage-report-action@v2.1.2
       with:
         test-script: npm run test:coverage:ci
         working-directory: ${{ inputs.working-directory }}

--- a/.github/actions/run-coverage/action.yml
+++ b/.github/actions/run-coverage/action.yml
@@ -9,6 +9,8 @@ inputs:
 runs:
   using: 'composite'
   steps:
+    # We are currently fixed at 2.1.2 since 2.2 was throwing errors
+    # Remove this when the issue has been resolved.
     - uses: ArtiomTr/jest-coverage-report-action@v2.1.2
       with:
         test-script: npm run test:coverage:ci

--- a/.github/workflows/test-packages.yml
+++ b/.github/workflows/test-packages.yml
@@ -22,22 +22,22 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node }}
+
       - name: Install
         run: npm ci
 
-      - run: npm run build
+      - name: Build
+        run: npm run build
 
-      - name: Code Coverage for Core Package
-        uses: ./.github/actions/run-coverage
-        with:
-          working-directory: packages/core
-
-      - name: Code Coverage for Next Package
-        uses: ./.github/actions/run-coverage
-        with:
-          working-directory: packages/next
+      - name: Tests
+        run: npm run test
 
       - name: Code Coverage for FaustWP Core Package
         uses: ./.github/actions/run-coverage
         with:
           working-directory: packages/faustwp-core
+
+      - name: Code Coverage for FaustWP CLI Package
+        uses: ./.github/actions/run-coverage
+        with:
+          working-directory: packages/faustwp-cli

--- a/packages/faustwp-cli/.gitignore
+++ b/packages/faustwp-cli/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+dist
+coverage
+report.json

--- a/packages/faustwp-cli/package.json
+++ b/packages/faustwp-cli/package.json
@@ -28,7 +28,10 @@
     "clean": "rimraf dist",
     "dev": "tsc -p tsconfig.json --watch",
     "format": "prettier --write .",
-    "test": "npm test"
+    "test": "jest",
+    "test:coverage:ci": "jest --ci --json --coverage --testLocationInResults --outputFile=report.json",
+    "test:coverage": "jest --coverage",
+    "test:watch": "jest --watch"
   },
   "repository": {
     "type": "git",

--- a/packages/faustwp-cli/package.json
+++ b/packages/faustwp-cli/package.json
@@ -29,7 +29,7 @@
     "dev": "tsc -p tsconfig.json --watch",
     "format": "prettier --write .",
     "test": "jest",
-    "test:coverage:ci": "jest --ci --json --coverage --testLocationInResults --outputFile=report.json",
+    "test:coverage:ci": "jest --ci --json --coverage --testLocationInResults --passWithNoTests --outputFile=report.json",
     "test:coverage": "jest --coverage",
     "test:watch": "jest --watch"
   },


### PR DESCRIPTION
## Tasks

- [x] I have signed a [Contributor License Agreement (CLA)](https://github.com/wpengine/faustjs#contributor-license-agreement) with WP Engine.

## Description

Downgrades our Jest coverage action from 2.2 to 2.1.2 as it looks like the most recent release is broken/had breaking changes.

Additionally, the FaustWP CLI and FaustWP Core coverage reports are now visible and I've removed the legacy packages.

<!--
Include a summary of the change and some contextual information.
-->

## Related Issue(s):

<!--
Provide the GitHub issue(s) number for issue tracking purposes, use the following syntax:

- #1234
-->

## Testing

<!--
Describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Also list any relevant details for your test configuration such as how to test the changes locally or in staging.
-->

## Screenshots

<!--
If this is a visual change include relevant screenshots about the behavior of the application before and after this change.
-->

## Documentation Changes

<!--
List corresponding changes to the documentation.
-->

## Dependant PRs

<!--
List any dependent PR's that are awaiting review. Use the following syntax:

- #1234
-->
