### PR TITLE
MERL-753: enableExperimentalToolbar added for toolbar usage

### DIFF
--- a/examples/next/faustwp-getting-started/faust.config.js
+++ b/examples/next/faustwp-getting-started/faust.config.js
@@ -9,6 +9,6 @@ import { CustomToolbar } from './plugins/CustomToolbar.tsx';
 export default setConfig({
   templates,
   experimentalPlugins: [new CustomToolbar()],
+  enableExperimentalToolbar: false,
   possibleTypes,
-  // disableToolbar: true,
 });

--- a/examples/next/faustwp-getting-started/faust.config.js
+++ b/examples/next/faustwp-getting-started/faust.config.js
@@ -9,6 +9,6 @@ import { CustomToolbar } from './plugins/CustomToolbar.tsx';
 export default setConfig({
   templates,
   experimentalPlugins: [new CustomToolbar()],
-  enableExperimentalToolbar: false,
+  experimentalToolbar: true,
   possibleTypes,
 });

--- a/packages/faustwp-core/src/components/FaustProvider.tsx
+++ b/packages/faustwp-core/src/components/FaustProvider.tsx
@@ -18,7 +18,7 @@ export function FaustProvider(props: {
   pageProps: FaustPageProps;
 }) {
   const { pageProps, children } = props;
-  const { enableExperimentalToolbar } = getConfig();
+  const { experimentalToolbar } = getConfig();
   const router = useRouter();
   const apolloClient = useApollo(pageProps);
 

--- a/packages/faustwp-core/src/components/FaustProvider.tsx
+++ b/packages/faustwp-core/src/components/FaustProvider.tsx
@@ -24,7 +24,7 @@ export function FaustProvider(props: {
 
   return (
     <ApolloProvider client={apolloClient}>
-      {enableExperimentalToolbar && (
+      {experimentalToolbar && (
         <Toolbar
           key={`faust-toolbar-${router.asPath}`} // Required in order to load each route's own seed node.
           client={apolloClient}

--- a/packages/faustwp-core/src/components/FaustProvider.tsx
+++ b/packages/faustwp-core/src/components/FaustProvider.tsx
@@ -17,13 +17,13 @@ export function FaustProvider(props: {
   pageProps: FaustPageProps;
 }) {
   const { pageProps, children } = props;
-  const { disableToolbar } = getConfig();
+  const { enableExperimentalToolbar } = getConfig();
   const router = useRouter();
   const apolloClient = useApollo(pageProps);
 
   return (
     <ApolloProvider client={apolloClient}>
-      {!disableToolbar && (
+      {enableExperimentalToolbar && (
         <Toolbar
           key={`faust-toolbar-${router.asPath}`} // Required in order to load each route's own seed node.
           client={apolloClient}

--- a/packages/faustwp-core/src/config/index.ts
+++ b/packages/faustwp-core/src/config/index.ts
@@ -33,7 +33,7 @@ export function normalizeConfig(_config: FaustConfig): FaustConfig {
   const cfg = defaults({}, _config, {
     loginPagePath: '/login',
     disableLogging: false,
-    enableExperimentalToolbar: false,
+    experimentalToolbar: false,
   });
 
   Object.keys(cfg).forEach((key) => {

--- a/packages/faustwp-core/src/config/index.ts
+++ b/packages/faustwp-core/src/config/index.ts
@@ -9,7 +9,7 @@ import { hooks, FaustPlugin } from '../hooks/index.js';
 export interface FaustConfig {
   templates: { [key: string]: WordPressTemplate };
   disableLogging: boolean;
-  disableToolbar: boolean;
+  enableExperimentalToolbar: boolean;
   loginPagePath?: string;
   experimentalPlugins: FaustPlugin[];
   possibleTypes: PossibleTypesMap;
@@ -33,7 +33,7 @@ export function normalizeConfig(_config: FaustConfig): FaustConfig {
   const cfg = defaults({}, _config, {
     loginPagePath: '/login',
     disableLogging: false,
-    disableToolbar: false,
+    enableExperimentalToolbar: false,
   });
 
   Object.keys(cfg).forEach((key) => {

--- a/packages/faustwp-core/src/config/index.ts
+++ b/packages/faustwp-core/src/config/index.ts
@@ -9,7 +9,7 @@ import { hooks, FaustPlugin } from '../hooks/index.js';
 export interface FaustConfig {
   templates: { [key: string]: WordPressTemplate };
   disableLogging: boolean;
-  enableExperimentalToolbar: boolean;
+  experimentalToolbar: boolean;
   loginPagePath?: string;
   experimentalPlugins: FaustPlugin[];
   possibleTypes: PossibleTypesMap;


### PR DESCRIPTION
## Description
Updated config to include experimental flag for the toolbar.

## Testing
1. Check that the default for enableExperimentalToolbar=false and that the toolbar doesn't show.
2. Update the faust.config.js to set enableExperimentalToolbar=true and make sure the toolbar displays.