### PR TITLE
Remove `disableLogging` property from `FaustConfig` type

### DIFF
--- a/.changeset/clean-planes-impress.md
+++ b/.changeset/clean-planes-impress.md
@@ -1,0 +1,5 @@
+---
+'@faustwp/core': patch
+---
+
+Remove `disableLogging` property from `FaustConfig` TypeScript type, as this was only a property in old Faust.

--- a/packages/faustwp-core/src/config/index.ts
+++ b/packages/faustwp-core/src/config/index.ts
@@ -8,7 +8,6 @@ import { hooks, FaustPlugin } from '../hooks/index.js';
 
 export interface FaustConfig {
   templates: { [key: string]: WordPressTemplate };
-  disableLogging: boolean;
   loginPagePath?: string;
   experimentalPlugins: FaustPlugin[];
   possibleTypes: PossibleTypesMap;
@@ -31,7 +30,6 @@ export function setConfig(_config: FaustConfig) {
 export function normalizeConfig(_config: FaustConfig): FaustConfig {
   const cfg = defaults({}, _config, {
     loginPagePath: '/login',
-    disableLogging: false,
   });
 
   Object.keys(cfg).forEach((key) => {


### PR DESCRIPTION
## Tasks

- [x] I have signed a [Contributor License Agreement (CLA)](https://github.com/wpengine/faustjs#contributor-license-agreement) with WP Engine.

## Description

The `disableLogging` property was a reminant of old Faust. This PR removes it from the config type as it was causing issues a type mismatch when using a ts extension for the `faust.config` file.

[Additional context on discord](https://discord.com/channels/836253505944813629/1076600966473842758/1076600966473842758)

<!--
Include a summary of the change and some contextual information.
-->

## Related Issue(s):

<!--
Provide the GitHub issue(s) number for issue tracking purposes, use the following syntax:

- #1234
-->

## Testing

<!--
Describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Also list any relevant details for your test configuration such as how to test the changes locally or in staging.
-->

## Screenshots

<!--
If this is a visual change include relevant screenshots about the behavior of the application before and after this change.
-->

## Documentation Changes

<!--
List corresponding changes to the documentation.
-->

## Dependant PRs

<!--
List any dependent PR's that are awaiting review. Use the following syntax:

- #1234
-->
