### PR TITLE
[nojira] Exports `getNextServerSideProps`

### DIFF
--- a/packages/faustwp-core/src/index.ts
+++ b/packages/faustwp-core/src/index.ts
@@ -4,7 +4,7 @@ import {
   FaustTemplateProps,
 } from './components/WordPressTemplate.js';
 import { getWordPressProps } from './getWordPressProps.js';
-import { getNextStaticProps } from './getProps.js';
+import { getNextStaticProps, getNextServerSideProps } from './getProps.js';
 import { getConfig, setConfig, FaustConfig } from './config/index.js';
 import { ensureAuthorization } from './auth/index.js';
 import { authorizeHandler, logoutHandler, apiRouter } from './server/index.js';
@@ -33,6 +33,7 @@ export {
   FaustTemplateProps,
   getWordPressProps,
   getNextStaticProps,
+  getNextServerSideProps,
   getConfig,
   setConfig,
   FaustConfig,


### PR DESCRIPTION
## Tasks

- [ ] I have signed a [Contributor License Agreement (CLA)](https://github.com/wpengine/faustjs#contributor-license-agreement) with WP Engine.

## Description

<!--
Include a summary of the change and some contextual information.
-->

Exports missing `getNextServerSideProps` in public exports index.

## Related Issue(s):

<!--
Provide the GitHub issue(s) number for issue tracking purposes, use the following syntax:

- #1234
-->

## Testing

<!--
Describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Also list any relevant details for your test configuration such as how to test the changes locally or in staging.
-->

Make sure you can import `getNextServerSideProps` from @faustwp/core`

## Screenshots

<!--
If this is a visual change include relevant screenshots about the behavior of the application before and after this change.
-->

## Documentation Changes

<!--
List corresponding changes to the documentation.
-->

## Dependant PRs

<!--
List any dependent PR's that are awaiting review. Use the following syntax:

- #1234
-->
