### PR TITLE
useAuth: Only make request to token endpoint once, add changesets

### DIFF
--- a/.changeset/hungry-candles-carry.md
+++ b/.changeset/hungry-candles-carry.md
@@ -1,0 +1,13 @@
+---
+'@faustwp/core': patch
+---
+
+Introduced the `useLogin` hook to handle logging into your Faust app without being redirected to WordPress:
+
+```js
+import { useLogin } from '@faustwp/core';
+
+const { login, loading, data, error } = useLogin();
+```
+
+Please visit the [reference docs](https://faustjs.org/docs/reference/useLogin) for more information on the API.

--- a/.changeset/slimy-queens-scream.md
+++ b/.changeset/slimy-queens-scream.md
@@ -1,0 +1,13 @@
+---
+'@faustwp/core': patch
+---
+
+Introduced the `useLogout` hook to handle logging out in your Faust app:
+
+```js
+import { useLogout } from '@faustwp/core';
+
+const { error, logout, loading } = useLogin();
+```
+
+Please visit the [reference docs](https://faustjs.org/docs/reference/useLogout) for more information on the API.

--- a/.changeset/small-guests-itch.md
+++ b/.changeset/small-guests-itch.md
@@ -1,0 +1,13 @@
+---
+'@faustwp/core': patch
+---
+
+Re-introduced the `useAuth` hook to handle authentication in your Faust app:
+
+```js
+import {useAuth} from '@faustwp/core'
+
+const {isAuthenticated, isReady, loginUrl} = useAuth(options?);
+```
+
+Please visit the [reference docs](https://faustjs.org/docs/reference/useAuth) for more information on the API.

--- a/packages/faustwp-core/src/hooks/useAuth.tsx
+++ b/packages/faustwp-core/src/hooks/useAuth.tsx
@@ -71,7 +71,11 @@ export function useAuth(_config?: UseAuthConfig) {
 
       setIsReady(true);
     })();
-  }, [config]);
+
+    // NOTE: This effect should only be ran once on mount, so we are not
+    // providing the exhaustive deps to useEffect.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   /**
    * Automatically redirect the user to the login page if the


### PR DESCRIPTION
## Tasks

- [x] I have signed a [Contributor License Agreement (CLA)](https://github.com/wpengine/faustjs#contributor-license-agreement) with WP Engine.

## Description

`useAuth` was making numerous calls to the token endpoint due to the `useEffect` rerendering. This PR removes the dependencies causing the unneeded rerender.

<!--
Include a summary of the change and some contextual information.
-->

## Related Issue(s):

<!--
Provide the GitHub issue(s) number for issue tracking purposes, use the following syntax:

- #1234
-->

## Testing

1. Checkout branch
2. Build the libraries
3. Create `pages/auth.js` in example project with the following content:
    ```jsx
    import { useAuth } from '@faustwp/core';
    
    export default function Auth() {
      const { isAuthenticated } = useAuth();
    
      return <>Auth page</>;
    }
    ```
4. Run the dev server and visit `/auth`
5. Check the network tab and only see one request to the token endpoint.

<!--
Describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Also list any relevant details for your test configuration such as how to test the changes locally or in staging.
-->

## Screenshots

Before:
<img width="2560" alt="Screenshot 2023-02-22 at 10 49 31 AM" src="https://user-images.githubusercontent.com/5946219/220699100-0754665f-82ac-467d-a3df-778964fadde3.png">

After:
<img width="2560" alt="Screenshot 2023-02-22 at 10 49 01 AM" src="https://user-images.githubusercontent.com/5946219/220699140-f101acc0-daa6-4594-9309-c1d42bfa38cc.png">


<!--
If this is a visual change include relevant screenshots about the behavior of the application before and after this change.
-->

## Documentation Changes

<!--
List corresponding changes to the documentation.
-->

## Dependant PRs

<!--
List any dependent PR's that are awaiting review. Use the following syntax:

- #1234
-->
