### PR TITLE
Deleted duplicate text

### DIFF
--- a/internal/faustjs.org/docs/gutenberg/wp-graphql-content-blocks.mdx
+++ b/internal/faustjs.org/docs/gutenberg/wp-graphql-content-blocks.mdx
@@ -87,7 +87,6 @@ type MyPluginNotice {
 ```
 
 When you request to resolve the `message` attribute for `MyPluginNotice`, the plugin will use a resolver that tries to extract the field by sourcing the text element using the `selector`. For example, given the following HTML:
-this field by sourcing the text element using the `selector`. For example given the following HTML:
 
 ```
 <div class="message">Hello World</div>


### PR DESCRIPTION
Duplicate line in the wp-graphql-content-blocks.mdx. Deleted.