### PR TITLE
Style: Use `div` for `DefaultBlock` instead of `span`

### DIFF
--- a/.changeset/sweet-sloths-grin.md
+++ b/.changeset/sweet-sloths-grin.md
@@ -1,0 +1,5 @@
+---
+'@faustwp/blocks': patch
+---
+
+Change DefaultBlock to use `div` instead of `span`

--- a/packages/blocks/src/components/DefaultBlock.tsx
+++ b/packages/blocks/src/components/DefaultBlock.tsx
@@ -9,7 +9,7 @@ import { ContentBlock } from './WordPressBlocksViewer.js';
  */
 export default function DefaultBlock({ renderedHtml }: ContentBlock) {
   // eslint-disable-next-line react/no-danger
-  return <span dangerouslySetInnerHTML={{ __html: renderedHtml ?? '' }} />;
+  return <div dangerouslySetInnerHTML={{ __html: renderedHtml ?? '' }} />;
 }
 
 DefaultBlock.displayName = 'DefaultBlock';


### PR DESCRIPTION
## Tasks

- [ ] I have signed a [Contributor License Agreement (CLA)](https://github.com/wpengine/faustjs#contributor-license-agreement) with WP Engine.

## Description

<!--
Include a summary of the change and some contextual information.
-->

Changes the default element for `DefaultBlock` from `<span>` to `<div>`.

## Related Issue(s):

<!--
Provide the GitHub issue(s) number for issue tracking purposes, use the following syntax:

- #1234
-->

## Testing

<!--
Describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Also list any relevant details for your test configuration such as how to test the changes locally or in staging.
-->

* Use `WordPressBlocksViewer` to render a list of blocks that are not implemented. The final markup should contain divs for fallback blocks instead of spans.

## Screenshots

<!--
If this is a visual change include relevant screenshots about the behavior of the application before and after this change.
-->

## Documentation Changes

<!--
List corresponding changes to the documentation.
-->

## Dependant PRs

<!--
List any dependent PR's that are awaiting review. Use the following syntax:

- #1234
-->
