### PR TITLE
Provide skeleton component for individual toolbar nodes

### DIFF
--- a/.changeset/orange-terms-try.md
+++ b/.changeset/orange-terms-try.md
@@ -1,0 +1,5 @@
+---
+'@faustwp/core': patch
+---
+
+Added a new skeleton component for toolbar nodes. Users can leverage this new component to handle loading states within custom toolbar nodes.

--- a/examples/next/faustwp-getting-started/.env.local.sample
+++ b/examples/next/faustwp-getting-started/.env.local.sample
@@ -1,5 +1,5 @@
 # Your WordPress site URL
 NEXT_PUBLIC_WORDPRESS_URL=https://faustexample.wpengine.com
 
-# Plugin secret found in WordPress Settings->Headless
+# Plugin secret found in WordPress Settings->Faust
 # FAUST_SECRET_KEY=YOUR_PLUGIN_SECRET

--- a/packages/faustwp-core/src/components/Toolbar/ToolbarNodeSkeleton.tsx
+++ b/packages/faustwp-core/src/components/Toolbar/ToolbarNodeSkeleton.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+/**
+ * Skeleton component for a Toolbar Node.
+ */
+export function ToolbarNodeSkeleton() {
+  return (
+    <div className='toolbar-node-skeleton-wrapper'>
+      <div aria-hidden="true" className='toolbar-node-skeleton' />
+    </div>
+  );
+}

--- a/packages/faustwp-core/src/components/Toolbar/ToolbarNodeSkeleton.tsx
+++ b/packages/faustwp-core/src/components/Toolbar/ToolbarNodeSkeleton.tsx
@@ -5,8 +5,8 @@ import React from 'react';
  */
 export function ToolbarNodeSkeleton() {
   return (
-    <div className='toolbar-node-skeleton-wrapper'>
-      <div aria-hidden="true" className='toolbar-node-skeleton' />
+    <div className="toolbar-node-skeleton-wrapper">
+      <div aria-hidden="true" className="toolbar-node-skeleton" />
     </div>
   );
 }

--- a/packages/faustwp-core/src/components/Toolbar/index.ts
+++ b/packages/faustwp-core/src/components/Toolbar/index.ts
@@ -1,5 +1,6 @@
 export { Toolbar, FaustToolbarNodes, FaustToolbarContext } from './Toolbar.js';
 export { ToolbarNode } from './ToolbarNode.js';
+export { ToolbarNodeSkeleton } from './ToolbarNodeSkeleton.js';
 export { ToolbarItem } from './ToolbarItem.js';
 export { ToolbarSubmenu } from './ToolbarSubmenu.js';
 export { ToolbarSubmenuWrapper } from './ToolbarSubmenuWrapper.js';

--- a/packages/faustwp-core/src/components/Toolbar/nodes/MyAccount.tsx
+++ b/packages/faustwp-core/src/components/Toolbar/nodes/MyAccount.tsx
@@ -6,6 +6,7 @@ import { useAuth } from '../../../hooks/useAuth.js';
 import { getAdminUrl } from '../../../lib/getAdminUrl.js';
 import {
   ToolbarItem,
+  ToolbarNodeSkeleton,
   ToolbarSubmenu,
   ToolbarSubmenuWrapper,
 } from '../index.js';
@@ -38,7 +39,7 @@ export function AuthenticatedAccount() {
   );
 
   if (loading) {
-    return <>Loading...</>;
+    return <ToolbarNodeSkeleton />;
   }
 
   return (
@@ -97,7 +98,7 @@ export function MyAccount() {
   });
 
   if (!isReady) {
-    return <>Loading...</>;
+    return <ToolbarNodeSkeleton />;
   }
 
   if (isAuthenticated === true) {

--- a/packages/faustwp-core/src/styles/_body-classes.scss
+++ b/packages/faustwp-core/src/styles/_body-classes.scss
@@ -1,0 +1,3 @@
+body.admin-bar {
+  margin-top: var(--wp-admin--admin-bar--height);
+}

--- a/packages/faustwp-core/src/styles/_loaders.scss
+++ b/packages/faustwp-core/src/styles/_loaders.scss
@@ -1,0 +1,40 @@
+#wpadminbar .toolbar-node-skeleton-wrapper {
+  --toolbar-node-skeleton-gradient--dark: rgba(240, 246, 252, 0.2);
+  --toolbar-node-skeleton-gradient--light: rgba(240, 246, 252, 0.5);
+
+  box-sizing: border-box;
+  min-width: 100px;
+  padding: 6px;
+  height: var(--wp-admin--admin-bar--height);
+  cursor: progress;
+}
+
+#wpadminbar .toolbar-node-skeleton {
+  width: 100%;
+  height: 100%;
+  border-radius: 3px;
+  background: linear-gradient(
+    -90deg,
+    var(--toolbar-node-skeleton-gradient--dark) 0%,
+    var(--toolbar-node-skeleton-gradient--light) 50%,
+    var(--toolbar-node-skeleton-gradient--dark) 100%
+  );
+  background-size: 400% 400%;
+  animation: pulse 1.2s ease-in-out infinite;
+}
+
+// Tone down the animation to avoid vestibular motion triggers like scaling or panning large objects.
+@media (prefers-reduced-motion) {
+  #wpadminbar .toolbar-node-skeleton {
+    animation: none;
+  }
+}
+
+@keyframes pulse {
+  0% {
+    background-position: 0% 0%;
+  }
+  100% {
+    background-position: -135% 0%;
+  }
+}

--- a/packages/faustwp-core/src/styles/_loaders.scss
+++ b/packages/faustwp-core/src/styles/_loaders.scss
@@ -1,10 +1,10 @@
 #wpadminbar .toolbar-node-skeleton-wrapper {
-  --toolbar-node-skeleton-gradient--dark: rgba(240, 246, 252, 0.2);
-  --toolbar-node-skeleton-gradient--light: rgba(240, 246, 252, 0.5);
+  --toolbar-node-skeleton-gradient--dark: rgba(240, 246, 252, 0.1);
+  --toolbar-node-skeleton-gradient--light: rgba(240, 246, 252, 0.3);
 
   box-sizing: border-box;
   min-width: 100px;
-  padding: 6px;
+  padding: 7px;
   height: var(--wp-admin--admin-bar--height);
   cursor: progress;
 }

--- a/packages/faustwp-core/src/styles/toolbar.scss
+++ b/packages/faustwp-core/src/styles/toolbar.scss
@@ -1,7 +1,7 @@
+// WordPress core styles.
 @import 'wpcore/admin-bar';
 @import 'wpcore/dashicons';
 
-// Make room for the admin bar.
-body.admin-bar {
-  margin-top: var(--wp-admin--admin-bar--height);
-}
+// Faust styles.
+@import 'loaders';
+@import 'body-classes';


### PR DESCRIPTION
## Tasks

- [X] I have signed a [Contributor License Agreement (CLA)](https://github.com/wpengine/faustjs#contributor-license-agreement) with WP Engine.

## Description

These changes introduce a new skeleton component that replaces internal "Loading..." fragments. This component has also been made available for users to use in custom nodes.

## Testing

1. Checkout this branch: `MERL-698-skeleton-loader`
2. Run `npm run build -w @faustwp/core`
4. Drop [this Faust plugin](https://gist.github.com/josephfusco/b781839e8c33dc729b64f94eaa8a57c3) into your test site
5. Register the plugin from step 3 in `faust.config.js`
    ```js
      experimentalPlugins: [new CustomToolbar()],
    ```
6. Observe 2 toolbar nodes with a pulsing background.
7. Observe 2 toolbar nodes with a static background when a user's system setting is set to [prefer reduced motion](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion).

## Screenshots

<img width="804" alt="no motion preference" src="https://user-images.githubusercontent.com/6676674/221259177-0d2fe2c7-b159-4c06-b65e-052e62ae3c60.png">
<img width="768" alt="prefers reduced motion" src="https://user-images.githubusercontent.com/6676674/221259180-6f92c6e5-8df4-4ba9-85df-2a6a87c050d2.png">

