### PR TITLE
Syntax Highlighting for Customizing the Toolbar guide

### DIFF
--- a/internal/faustjs.org/docs/guides/custom-toolbar.mdx
+++ b/internal/faustjs.org/docs/guides/custom-toolbar.mdx
@@ -6,6 +6,38 @@ description: How to customize the Toolbar for your Faust.js site
 
 This guide covers how to customize your site's Toolbar utilizing the `toolbarNodes` filter.
 
+## Enable the Toolbar
+
+:::caution
+
+The Toolbar is currently an experimental feature. You can opt-in to using this feature by setting experimentalToolbar: true within your project's faust.config.js.
+
+:::
+
+### Import Styles
+
+The (Faust) Toolbar shares mostly the the same HTML as the WordPress core Toolbar. This enables the use of the same styles that exist in WordPress core, and have been converiently provided for you to import within `@faustwp/core`.
+
+```js title="pages/_app.js"
+import '@faustwp/core/dist/css/toolbar.css';
+```
+
+### Enable Experiment Toolbar
+
+Import and register your new plugin in `faust.config.js`.
+
+```js title="faust.config.js"
+import { setConfig } from '@faustwp/core';
+import templates from './wp-templates';
+import possibleTypes from './possibleTypes.json';
+
+export default setConfig({
+  experimentalToolbar: true, // Enable experimental toolbar
+  templates,
+  possibleTypes,
+});
+```
+
 ## Create the plugin
 
 Create a new file in your Faust project: `plugins/CustomPlugin.tsx`.
@@ -105,14 +137,6 @@ export function CustomNodeWithSubmenu() {
 }
 ```
 
-## Import Styles
-
-The (Faust) Toolbar shares mostly the the same HTML as the WordPress core Toolbar. This enables the use of the same styles that exist in WordPress core, and have been converiently provided for you to import within `@faustwp/core`.
-
-```js title="pages/_app.js"
-import '@faustwp/core/dist/css/toolbar.css';
-```
-
 ## Register The Plugin
 
 Import and register your new plugin in `faust.config.js`.
@@ -125,7 +149,7 @@ import { CustomToolbar } from './plugins/CustomToolbar.tsx';
 
 export default setConfig({
   templates,
-  experimentalToolbar: true, // Enable experimental toolbar
+  experimentalToolbar: true,
   experimentalPlugins: [new CustomToolbar()], // Register plugin
   possibleTypes,
 });

--- a/internal/faustjs.org/docs/guides/custom-toolbar.mdx
+++ b/internal/faustjs.org/docs/guides/custom-toolbar.mdx
@@ -22,9 +22,9 @@ The (Faust) Toolbar shares mostly the the same HTML as the WordPress core Toolba
 import '@faustwp/core/dist/css/toolbar.css';
 ```
 
-### Enable Experiment Toolbar
+### Enable Toolbar
 
-Import and register your new plugin in `faust.config.js`.
+Add `experimentalToolbar: true` to your project's `faust.config.js`.
 
 ```js title="faust.config.js"
 import { setConfig } from '@faustwp/core';

--- a/internal/faustjs.org/docs/guides/custom-toolbar.mdx
+++ b/internal/faustjs.org/docs/guides/custom-toolbar.mdx
@@ -18,12 +18,9 @@ See [Creating a Plugin](/plugin-system/creating-a-plugin) for additional informa
 
 Add the following code to `plugins/CustomPlugin.tsx`.
 
-```JavaScript
+```js title="plugins/CustomPlugin.tsx"
 import React from 'react';
-import {
-  FaustHooks,
-  FaustPlugin,
-} from '@faustwp/core';
+import { FaustHooks, FaustPlugin } from '@faustwp/core';
 import {
   FaustToolbarNodes,
   FaustToolbarContext,
@@ -41,22 +38,26 @@ export class CustomToolbar implements FaustPlugin {
      * This example demonstrates how to filter on the core Toolbar nodes
      * in order to add your own custom nodes!
      */
-    hooks.addFilter('toolbarNodes', 'faust', (toolbarNodes: FaustToolbarNodes, context: FaustToolbarContext) => {
-      const customToolbarNodes: FaustToolbarNodes = [
-        {
-          id: 'custom-node',
-          location: 'primary',
-          component: <CustomNode />,
-        },
-        {
-          id: 'custom-node-with-submenu',
-          location: 'primary',
-          component: <CustomNodeWithSubmenu />
-        },
-      ];
+    hooks.addFilter(
+      'toolbarNodes',
+      'faust',
+      (toolbarNodes: FaustToolbarNodes, context: FaustToolbarContext) => {
+        const customToolbarNodes: FaustToolbarNodes = [
+          {
+            id: 'custom-node',
+            location: 'primary',
+            component: <CustomNode />,
+          },
+          {
+            id: 'custom-node-with-submenu',
+            location: 'primary',
+            component: <CustomNodeWithSubmenu />,
+          },
+        ];
 
-      return [...toolbarNodes, ...customToolbarNodes];
-    });
+        return [...toolbarNodes, ...customToolbarNodes];
+      },
+    );
   }
 }
 
@@ -65,7 +66,7 @@ export class CustomToolbar implements FaustPlugin {
  */
 export function CustomNode() {
   return (
-    <ToolbarItem href='https://wpengine.com' rel='nofollow'>
+    <ToolbarItem href="https://wpengine.com" rel="nofollow">
       Custom Node
     </ToolbarItem>
   );
@@ -77,19 +78,25 @@ export function CustomNode() {
 export function CustomNodeWithSubmenu() {
   return (
     <>
-      <ToolbarItem href='https://wpengine.com' rel='nofollow'>
+      <ToolbarItem href="https://wpengine.com" rel="nofollow">
         Custom Node w/ Submenu
       </ToolbarItem>
       <ToolbarSubmenuWrapper>
         <ToolbarSubmenu>
           <li>
-            <ToolbarItem href='https://wpengine.com' rel='nofollow'>Link</ToolbarItem>
+            <ToolbarItem href="https://wpengine.com" rel="nofollow">
+              Link
+            </ToolbarItem>
           </li>
           <li>
-            <ToolbarItem href='https://wpengine.com' rel='nofollow'>Link</ToolbarItem>
+            <ToolbarItem href="https://wpengine.com" rel="nofollow">
+              Link
+            </ToolbarItem>
           </li>
           <li>
-            <ToolbarItem href='https://wpengine.com' rel='nofollow'>Link</ToolbarItem>
+            <ToolbarItem href="https://wpengine.com" rel="nofollow">
+              Link
+            </ToolbarItem>
           </li>
         </ToolbarSubmenu>
       </ToolbarSubmenuWrapper>
@@ -98,11 +105,19 @@ export function CustomNodeWithSubmenu() {
 }
 ```
 
+## Import Styles
+
+The (Faust) Toolbar shares mostly the the same HTML as the WordPress core Toolbar. This enables the use of the same styles that exist in WordPress core, and have been converiently provided for you to import within `@faustwp/core`.
+
+```js title="pages/_app.js"
+import '@faustwp/core/dist/css/toolbar.css';
+```
+
 ## Register The Plugin
 
 Import and register your new plugin in `faust.config.js`.
 
-```JavaScript
+```js title="faust.config.js"
 import { setConfig } from '@faustwp/core';
 import templates from './wp-templates';
 import possibleTypes from './possibleTypes.json';
@@ -111,7 +126,7 @@ import { CustomToolbar } from './plugins/CustomToolbar.tsx';
 export default setConfig({
   templates,
   experimentalToolbar: true, // Enable experimental toolbar
-  experimentalPlugins: [new CustomToolbar()],  // Register plugin
+  experimentalPlugins: [new CustomToolbar()], // Register plugin
   possibleTypes,
 });
 ```

--- a/internal/faustjs.org/docs/guides/custom-toolbar.mdx
+++ b/internal/faustjs.org/docs/guides/custom-toolbar.mdx
@@ -8,9 +8,9 @@ This guide covers how to customize your site's Toolbar utilizing the `toolbarNod
 
 ## Enable the Toolbar
 
-:::caution
+:::info
 
-The Toolbar is currently an experimental feature. You can opt-in to using this feature by setting experimentalToolbar: true within your project's faust.config.js.
+The Toolbar is currently an experimental feature that was introduced in `@faustwp/core@0.2.5`.
 
 :::
 


### PR DESCRIPTION
## Tasks

- [X] I have signed a [Contributor License Agreement (CLA)](https://github.com/wpengine/faustjs#contributor-license-agreement) with WP Engine.

## Description

These changes add instructions for importing the WordPress toolbar stylesheet and fix syntax highlighting within code blocks.
