### PR TITLE
MERL-709 - Docs: Migration Guide from wp-graphql-gutenberg

### DIFF
--- a/internal/faustjs.org/docs/gutenberg/getting-started.mdx
+++ b/internal/faustjs.org/docs/gutenberg/getting-started.mdx
@@ -19,10 +19,13 @@ Install the blocks package:
 npm i @faustwp/blocks
 ```
 
-Open `_app.js` and import the blocks provider:
+Create a new folder inside your application root that you will place all the blocks. For conventional reasons, we name it `wp-blocks`.
+
+Open `_app.js` and import the blocks provider, passing the list of blocks in the `config` property:
 
 ```jsx
 import { WordPressBlocksProvider } from '@faustwp/blocks';
+import blocks from '../wp-blocks';
 
 <FaustProvider pageProps={pageProps}>
   <WordPressBlocksProvider
@@ -38,6 +41,7 @@ Then, inside your templates you need to pass on the `contentBlocks` data in your
 
 ```js
 import { WordPressBlocksViewer } from '@faustwp/blocks';
+import components from '../wp-blocks';
 
 const { contentBlocks } = props.data.post;
 const blocks = flatListToHierarchical(contentBlocks);
@@ -87,7 +91,7 @@ CoreParagraph.fragments = {
 };
 ```
 
-`Import` and `export default` the CoreParagraph Block in `index.js`:
+`import` and `export default` the `CoreParagraph` Block in `wp-blocks/index.js`:
 ```js
 import CoreParagraph from './CoreParagraph';
 export default {

--- a/internal/faustjs.org/docs/gutenberg/getting-started.mdx
+++ b/internal/faustjs.org/docs/gutenberg/getting-started.mdx
@@ -21,6 +21,10 @@ npm i @faustwp/blocks
 
 Create a new folder inside your application root that you will place all the blocks. For conventional reasons, we name it `wp-blocks`.
 
+```js title="wp-blocks/index.js"
+export default {};
+``
+
 Open `_app.js` and import the blocks provider, passing the list of blocks in the `config` property:
 
 ```jsx
@@ -39,7 +43,7 @@ import blocks from '../wp-blocks';
 
 Then, inside your templates you need to pass on the `contentBlocks` data in your `WordPressBlocksViewer`. The helper function `flatListToHierarchical` is referenced [here](www.wpgraphql.com/docs/menus/#hierarchical-data):
 
-```js
+```js title="wp-templates/single.js"
 import { WordPressBlocksViewer } from '@faustwp/blocks';
 import components from '../wp-blocks';
 

--- a/internal/faustjs.org/docs/gutenberg/migration-from-wp-graphql-gutenberg.mdx
+++ b/internal/faustjs.org/docs/gutenberg/migration-from-wp-graphql-gutenberg.mdx
@@ -10,7 +10,7 @@ The purpose of this guide is to provide a list of recommended steps to migrate a
 ## What is wp-graphql-gutenberg?
 
 As explained in this [tutorial](https://developers.wpengine.com/blog/gutenberg-in-headless-wordpress-wpgraphql-gutenberg),
-is an extension for WPGraphQL that adds the blocks to the WPGraphQL schema just like the `wp-graphql-content-blocks`.
+it's an extension for WPGraphQL that adds the blocks to the WPGraphQL schema just like the `wp-graphql-content-blocks`.
 
 However there are some key differences that you need to be aware of:
 

--- a/internal/faustjs.org/docs/gutenberg/migration-from-wp-graphql-gutenberg.mdx
+++ b/internal/faustjs.org/docs/gutenberg/migration-from-wp-graphql-gutenberg.mdx
@@ -44,7 +44,7 @@ It mainly depends on the way that you queried the blocks using `wp-graphql-guten
 
 `wp-graphql-content-blocks` does not expose the `blocksJSON` fields because it is problematic to do so.
 Getting the data as plain JSON directly from the database completely overrides the principles of GraphQL and ignores the type safety of the system.
-If one of the properties is altered then, you have no guarantees that the GraphQL server with catch them.
+If one of the properties is altered, you have no guarantee that the GraphQL server will catch them.
 Plus most of the times you will over fetch data leading to slower queries especially if you have lots of content in the screen.
 
 So due to the lack of Introspection and unpredictability and in order to promote best practices, we do not expose the block data as plain JSON.

--- a/internal/faustjs.org/docs/gutenberg/migration-from-wp-graphql-gutenberg.mdx
+++ b/internal/faustjs.org/docs/gutenberg/migration-from-wp-graphql-gutenberg.mdx
@@ -16,7 +16,7 @@ However there are some key differences that you need to be aware of:
 
 * WPGraphQL Gutenberg gets the blocks registry and sends it in a network request to the WordPress PHP application. So it needs to be synced from time to time.
 
-* It also allows the blocks to be served as JSON using the `blocksJSON` field. If requesting data this way, the data are not typechecked and you may overfetch data as a side effect.
+* It also allows the blocks to be served as JSON using the `blocksJSON` field. If requesting data this way, the data is not typechecked and you may overfetch data as a side effect.
 
 * Block attributes are using their own types, containing different type for deprecated versions. For example:
 ```

--- a/internal/faustjs.org/docs/gutenberg/migration-from-wp-graphql-gutenberg.mdx
+++ b/internal/faustjs.org/docs/gutenberg/migration-from-wp-graphql-gutenberg.mdx
@@ -19,7 +19,7 @@ However there are some key differences that you need to be aware of:
 * It also allows the blocks to be served as JSON using the `blocksJSON` field. If requesting data this way, the data is not typechecked and you may overfetch data as a side effect.
 
 * Block attributes are using their own types, containing different type for deprecated versions. For example:
-```
+```graphql
 ...on CoreParagraphBlock {
     attributes {
         ...on CoreParagraphBlockAttributes {

--- a/internal/faustjs.org/docs/gutenberg/migration-from-wp-graphql-gutenberg.mdx
+++ b/internal/faustjs.org/docs/gutenberg/migration-from-wp-graphql-gutenberg.mdx
@@ -81,7 +81,7 @@ When the `WordPressBlocksViewer`, renders the component, it passes the the whole
 ```jsx
 export default function CoreCode({attributes, children}) {
 	const BlockCode = dynamic(() => import('@/components/blocks/core/BlockCode'))
-	return <BlockCode {...attributes} innerBlocks={children} >
+	return <BlockCode {...attributes} innerBlocks={children}>
 }
 ```
 

--- a/internal/faustjs.org/docs/gutenberg/migration-from-wp-graphql-gutenberg.mdx
+++ b/internal/faustjs.org/docs/gutenberg/migration-from-wp-graphql-gutenberg.mdx
@@ -76,7 +76,7 @@ CoreCode.fragments = {
 };
 ```
 
-When the `WordPressBlocksViewer`, renders the component, it passes the the whole block data as a property of that block. If your block is desinged to accept different properties for attributes and for children you may have create a wrapper to forward the properties into the right slots:
+When the `WordPressBlocksViewer`, renders the component, it passes the the whole block data as a property of that block. If your block is designed to accept different properties for attributes and for innerBlocks you may have create a wrapper to forward the properties into the right slots:
 
 ```jsx
 export default function CoreCode({attributes, children}) {
@@ -85,7 +85,7 @@ export default function CoreCode({attributes, children}) {
 }
 ```
 
-If you are not satisfied by the way `WordPressBlocksViewer` passes on the properties, you can open a please open a [new Feature Request](https://github.com/wpengine/wp-graphql-content-blocks/issues/new) so that the Faust team can review it.
+If you are not satisfied by the way `WordPressBlocksViewer` passes on the properties, you can open a [new Feature Request](https://github.com/wpengine/wp-graphql-content-blocks/issues/new) so that the Faust team can review it.
 
 ### You used the `block` field with GraphQL types and fragments:
 

--- a/internal/faustjs.org/docs/gutenberg/migration-from-wp-graphql-gutenberg.mdx
+++ b/internal/faustjs.org/docs/gutenberg/migration-from-wp-graphql-gutenberg.mdx
@@ -40,7 +40,7 @@ However there are some key differences that you need to be aware of:
 
 It mainly depends on the way that you queried the blocks using `wp-graphql-gutenberg`. There are two different cases that you have to consider here:
 
-### You used the `blocksJSON` to get the blocks data:
+### You used the `blocksJSON` property to get the blocks data:
 
 `wp-graphql-content-blocks` does not expose the `blocksJSON` fields because it is problematic to do so.
 Getting the data as plain JSON directly from the database completely overrides the principles of GraphQL and ignores the type safety of the system.

--- a/internal/faustjs.org/docs/gutenberg/migration-from-wp-graphql-gutenberg.mdx
+++ b/internal/faustjs.org/docs/gutenberg/migration-from-wp-graphql-gutenberg.mdx
@@ -1,0 +1,127 @@
+---
+slug: /gutenberg/migration-from-wp-graphql-gutenberg
+title: Migration guide from wp-graphql-gutenberg
+description: Migration guide from wp-graphql-gutenberg plugin
+---
+
+The purpose of this guide is to provide a list of recommended steps to migrate any blocks you have developed from
+`wp-graphql-gutenberg` plugin to `wp-graphql-content-blocks` plugin.
+
+## What is wp-graphql-gutenberg?
+
+As explained in this [tutorial](https://developers.wpengine.com/blog/gutenberg-in-headless-wordpress-wpgraphql-gutenberg),
+is an extension for WPGraphQL that adds the blocks to the WPGraphQL schema just like the `wp-graphql-content-blocks`.
+
+However there are some key differences that you need to be aware of:
+
+* WPGraphQL Gutenberg gets the blocks registry and sends it in a network request to the WordPress PHP application. So it needs to be synced from time to time.
+
+* It also allows the blocks to be served as JSON using the `blocksJSON` field. If requesting data this way, the data are not typechecked and you may overfetch data as a side effect.
+
+* Block attributes are using their own types, containing different type for deprecated versions. For example:
+```
+...on CoreParagraphBlock {
+    attributes {
+        ...on CoreParagraphBlockAttributes {
+            content
+    	}
+        ...on CoreParagraphBlockDeprecatedV1Attributes {
+            content
+        }
+    }
+}
+```
+
+* It does not allow blocks to be returned as a flat list so you have to use deeply nested queries to get the list of `innerBlocks` (and this won't nearly solve the issue 100%).
+
+* `wp-graphql-content-blocks` does not save anything in the database (this is actually a good thing) compared to `wp-graphql-gutenberg`. Therefore it only supports previews when the hitting of preview button.
+
+## How do I migrate a block from wp-graphql-gutenberg?
+
+It mainly depends on the way that you queried the blocks using `wp-graphql-gutenberg`. There are two different cases that you have to consider here:
+
+### You used the `blocksJSON` to get the blocks data:
+
+`wp-graphql-content-blocks` does not expose the `blocksJSON` fields because it is problematic to do so.
+Getting the data as plain JSON directly from the database completely overrides the principles of GraphQL and ignores the type safety of the system.
+If one of the properties is altered then, you have no guarantees that the GraphQL server with catch them.
+Plus most of the times you will over fetch data leading to slower queries especially if you have lots of content in the screen.
+
+So due to the lack of Introspection and unpredictability and in order to promote best practices, we do not expose the block data as plain JSON.
+
+However the effort required to add block fragments is not very high. If you follow the recommended approach of co-located fragments you can just add them as properties to each of your block expected attribute list and make sure that you include those into the page query string.
+
+Take a look at the following example taken from [WebDevStudios nextjs-wordpress-starter](https://github.com/WebDevStudios/nextjs-wordpress-starter/blob/main/components/blocks/core/BlockCode/BlockCode.js).
+
+It shows an implementation of the `CoreCode` block using `wp-graphql-gutenberg` and getting the data using [blockJSON].
+
+If you followed one of our the tutorials for [creating a new block](docs/gutenberg/tutorial/create-a-block-from-wordpress-core#53-create-the-block-fragment) from the WordPress Core Blocks you just need to add the following fragment as a new property:
+
+```jsx
+CoreCode.fragments = {
+  key: `CoreCodeBlockFragment`,
+  entry: gql`
+    fragment CoreCodeBlockFragment on CoreCode {
+      attributes {
+        anchor
+  		backgroundColor
+  		content
+  		className
+  		gradient
+  		style
+  		textColor
+      }
+    }
+  `,
+};
+```
+
+When the `WordPressBlocksViewer`, renders the component, it passes the the whole block data as a property of that block. If your block is desinged to accept different properties for attributes and for children you may have create a wrapper to forward the properties into the right slots:
+
+```jsx
+export default function CoreCode({attributes, children}) {
+	const BlockCode = dynamic(() => import('@/components/blocks/core/BlockCode'))
+	return <BlockCode {...attributes} innerBlocks={children} >
+}
+```
+
+If you are not satisfied by the way `WordPressBlocksViewer` passes on the properties, you can open a please open a [new Feature Request](https://github.com/wpengine/wp-graphql-content-blocks/issues/new) so that the Faust team can review it.
+
+### You used the `block` field with GraphQL types and fragments:
+
+If you were using the `block` field from the `wp-graphql-gutenberg` then most of the component fragment queries should be the same with the following exceptions:
+
+* You should be querying the block attributes without qualifying their type:
+
+This:
+
+```graphql
+...on CoreParagraphBlock {
+	attributes {
+		content
+	}
+```
+Instead of:
+
+```graphql
+...on CoreParagraphBlock {
+    attributes {
+        ...on CoreParagraphBlockAttributes {
+            content
+    	}
+    }
+}
+```
+
+* There are no seperate fields `previewBlocks` and `previewBlocksJSON`. If you want to preview posts or pages, you should be using the [Faust.js Previews](/docs/next/guides/post-page-previews) mechanism.
+
+* There base interface for each block contains different fields, so you need to make sure your queries use the valid ones from this list:
+
+ 	* `renderedHTML`: It's the HTML of the block as rendered by the [render_block](https://developer.wordpress.org/reference/functions/render_block/) function.
+	* `name`: The actual name of the block taken from it's `block.json` spec.
+	* `__typename`: The type of block transformed from the `name` field in camel-case notation.
+	* `apiVersion`: The apiVersion of the block taken from its `block.json` spec.
+	* `innerBlocks`: The innerblock list of that block.
+	* `isDynamic`: Whether the block is dynamic or not, taken from its `block.json` spec.
+	* `nodeId`, `parentId`: Unique identifiers for the block and the parent of the block.
+

--- a/internal/faustjs.org/docs/gutenberg/migration-from-wp-graphql-gutenberg.mdx
+++ b/internal/faustjs.org/docs/gutenberg/migration-from-wp-graphql-gutenberg.mdx
@@ -34,7 +34,7 @@ However there are some key differences that you need to be aware of:
 
 * It does not allow blocks to be returned as a flat list so you have to use deeply nested queries to get the list of `innerBlocks` (and this won't nearly solve the issue 100%).
 
-* `wp-graphql-content-blocks` does not save anything in the database (this is actually a good thing) compared to `wp-graphql-gutenberg`. Therefore it only supports previews when the hitting of preview button.
+* `wp-graphql-content-blocks` does not save anything in the database (this is actually a good thing) compared to `wp-graphql-gutenberg`. Therefore it only supports previews when the "preview" button is hit in the editor.
 
 ## How do I migrate a block from wp-graphql-gutenberg?
 

--- a/internal/faustjs.org/docs/gutenberg/migration-from-wp-graphql-gutenberg.mdx
+++ b/internal/faustjs.org/docs/gutenberg/migration-from-wp-graphql-gutenberg.mdx
@@ -115,7 +115,7 @@ Instead of:
 
 * There are no seperate fields `previewBlocks` and `previewBlocksJSON`. If you want to preview posts or pages, you should be using the [Faust.js Previews](/docs/next/guides/post-page-previews) mechanism.
 
-* There base interface for each block contains different fields, so you need to make sure your queries use the valid ones from this list:
+* The base interface for each block contains different fields, so you need to make sure your queries use the valid ones from this list:
 
  	* `renderedHTML`: It's the HTML of the block as rendered by the [render_block](https://developer.wordpress.org/reference/functions/render_block/) function.
 	* `name`: The actual name of the block taken from it's `block.json` spec.

--- a/internal/faustjs.org/docs/gutenberg/migration-from-wp-graphql-gutenberg.mdx
+++ b/internal/faustjs.org/docs/gutenberg/migration-from-wp-graphql-gutenberg.mdx
@@ -76,7 +76,7 @@ CoreCode.fragments = {
 };
 ```
 
-When the `WordPressBlocksViewer`, renders the component, it passes the the whole block data as a property of that block. If your block is designed to accept different properties for attributes and for innerBlocks you may have create a wrapper to forward the properties into the right slots:
+When the `WordPressBlocksViewer` renders the component, it passes the whole block data as a property of that block. If your block is designed to accept different properties for attributes and for innerBlocks you may have create a wrapper to forward the properties into the right slots:
 
 ```jsx
 export default function CoreCode({attributes, children}) {

--- a/internal/faustjs.org/docs/gutenberg/tutorial/create-a-block-from-third-party.mdx
+++ b/internal/faustjs.org/docs/gutenberg/tutorial/create-a-block-from-third-party.mdx
@@ -209,7 +209,7 @@ query GetPost(
 			renderedHtml
 			id: nodeId
 			parentId
-			${blocks.UbCallToActionBlock.fragments.key}
+			...${blocks.UbCallToActionBlock.fragments.key}
       	}
 	}
 ...

--- a/internal/faustjs.org/docs/gutenberg/tutorial/create-a-block-from-wordpress-core.mdx
+++ b/internal/faustjs.org/docs/gutenberg/tutorial/create-a-block-from-wordpress-core.mdx
@@ -184,7 +184,7 @@ query GetPost(
 			renderedHtml
 			id: nodeId
 			parentId
-			${blocks.CoreCode.fragments.key}
+			...${blocks.CoreCode.fragments.key}
       	}
 	}
 ...

--- a/internal/faustjs.org/sidebars.js
+++ b/internal/faustjs.org/sidebars.js
@@ -170,6 +170,11 @@ module.exports = {
           id: 'gutenberg/filters',
         },
         {
+          type: 'doc',
+          label: 'Migration from WPGraphQL Gutenberg',
+          id: 'gutenberg/migration-from-wp-graphql-gutenberg',
+        },
+        {
           type: 'category',
           label: 'How to Create a Block',
           items: [


### PR DESCRIPTION
## Tasks

- [ ] I have signed a [Contributor License Agreement (CLA)](https://github.com/wpengine/faustjs#contributor-license-agreement) with WP Engine.

## Description

<!--
Include a summary of the change and some contextual information.
-->

- Adds migration guide from wp-graphql-gutenberg.
- Small documentation fixes on other gutenberg pages.

## Related Issue(s):

<!--
Provide the GitHub issue(s) number for issue tracking purposes, use the following syntax:

- #1234
-->

## Testing

<!--
Describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Also list any relevant details for your test configuration such as how to test the changes locally or in staging.
-->

## Screenshots

<!--
If this is a visual change include relevant screenshots about the behavior of the application before and after this change.
-->
<img width="1780" alt="Screenshot 2023-02-27 at 15 09 47" src="https://user-images.githubusercontent.com/328805/221601400-aadcbe35-ce67-4eb6-b428-714593912dae.png">

## Documentation Changes

<!--
List corresponding changes to the documentation.
-->
New Docs Page:
`docs/gutenberg/migration-from-wp-graphql-gutenberg`

## Dependant PRs

<!--
List any dependent PR's that are awaiting review. Use the following syntax:

- #1234
-->
