### PR TITLE
Export everything under the main entry point

### DIFF
--- a/.changeset/chilly-lemons-whisper.md
+++ b/.changeset/chilly-lemons-whisper.md
@@ -1,0 +1,5 @@
+---
+'@faustwp/core': patch
+---
+
+Fixed issue "Cannot find module"

--- a/internal/faustjs.org/docs/guides/custom-toolbar.mdx
+++ b/internal/faustjs.org/docs/guides/custom-toolbar.mdx
@@ -52,14 +52,15 @@ Add the following code to `plugins/CustomPlugin.tsx`.
 
 ```js title="plugins/CustomPlugin.tsx"
 import React from 'react';
-import { FaustHooks, FaustPlugin } from '@faustwp/core';
 import {
+  FaustHooks,
+  FaustPlugin,
   FaustToolbarNodes,
   FaustToolbarContext,
   ToolbarItem,
   ToolbarSubmenu,
   ToolbarSubmenuWrapper,
-} from '@faustwp/core/toolbar';
+} from '@faustwp/core';
 
 /**
  * Example Custom Toolbar Plugin.
@@ -145,7 +146,7 @@ Import and register your new plugin in `faust.config.js`.
 import { setConfig } from '@faustwp/core';
 import templates from './wp-templates';
 import possibleTypes from './possibleTypes.json';
-import { CustomToolbar } from './plugins/CustomToolbar.tsx';
+import { CustomToolbar } from './plugins/CustomToolbar.js';
 
 export default setConfig({
   templates,

--- a/packages/faustwp-core/package.json
+++ b/packages/faustwp-core/package.json
@@ -5,18 +5,6 @@
   "main": "dist/cjs/index.js",
   "module": "dist/mjs/index.js",
   "types": "dist/cjs/index.d.ts",
-  "exports": {
-    ".": {
-      "require": "./dist/cjs/index.js",
-      "import": "./dist/mjs/index.js"
-    },
-    "./toolbar": {
-      "require": "./dist/cjs/components/Toolbar/index.js",
-      "import": "./dist/mjs/components/Toolbar/index.js"
-    },
-    "./dist/css/toolbar.css": "./dist/css/toolbar.css",
-    "./package.json": "./package.json"
-  },
   "peerDependencies": {
     "@apollo/client": ">=3.6.6",
     "next": ">=12.1.6",

--- a/packages/faustwp-core/src/index.ts
+++ b/packages/faustwp-core/src/index.ts
@@ -27,7 +27,16 @@ import {
 import { useAuth } from './hooks/useAuth.js';
 import { useLogin } from './hooks/useLogin.js';
 import { useLogout } from './hooks/useLogout.js';
-import * as Toolbar from './components/Toolbar';
+
+import {
+  FaustToolbarNodes,
+  FaustToolbarContext,
+  ToolbarNode,
+  ToolbarItem,
+  ToolbarNodeSkeleton,
+  ToolbarSubmenu,
+  ToolbarSubmenuWrapper,
+} from './components/Toolbar/index.js';
 
 export {
   FaustProvider,
@@ -58,5 +67,11 @@ export {
   useAuth,
   useLogin,
   useLogout,
-  Toolbar,
+  FaustToolbarNodes,
+  FaustToolbarContext,
+  ToolbarNode,
+  ToolbarItem,
+  ToolbarNodeSkeleton,
+  ToolbarSubmenu,
+  ToolbarSubmenuWrapper,
 };

--- a/packages/faustwp-core/src/index.ts
+++ b/packages/faustwp-core/src/index.ts
@@ -27,6 +27,7 @@ import {
 import { useAuth } from './hooks/useAuth.js';
 import { useLogin } from './hooks/useLogin.js';
 import { useLogout } from './hooks/useLogout.js';
+import * as Toolbar from './components/Toolbar';
 
 export {
   FaustProvider,
@@ -57,4 +58,5 @@ export {
   useAuth,
   useLogin,
   useLogout,
+  Toolbar,
 };

--- a/packages/faustwp-core/toolbar.d.ts
+++ b/packages/faustwp-core/toolbar.d.ts
@@ -1,1 +1,0 @@
-export * from './dist/cjs/components/Toolbar';


### PR DESCRIPTION
These changes fix an issue introduced in `@faustwp/core@0.2.5` where modules were not found.