### PR TITLE
[MERL-727] BREAKING! `contentBlocks` to `editorBlocks`

### DIFF
--- a/.changeset/honest-pugs-live.md
+++ b/.changeset/honest-pugs-live.md
@@ -1,0 +1,5 @@
+---
+'@faustwp/blocks': minor
+---
+
+Changes `contentBlocks` field to `blocks` in WordpressBlocksViewer

--- a/internal/faustjs.org/docs/gutenberg/filters.mdx
+++ b/internal/faustjs.org/docs/gutenberg/filters.mdx
@@ -66,7 +66,7 @@ If you've done everything right, you will be able to query that field in GraphQL
 {
   posts {
     nodes {
-      contentBlocks {
+      editorBlocks {
         ... on CreateBlockMyFirstBlock {
           align
         }
@@ -95,7 +95,7 @@ If the structure is correct you will be able to query the new `align` attribute:
 {
   posts {
     nodes {
-      contentBlocks {
+      editorBlocks {
         ... on CreateBlockMyFirstBlock {
           name
           attributes {

--- a/internal/faustjs.org/docs/gutenberg/getting-started.mdx
+++ b/internal/faustjs.org/docs/gutenberg/getting-started.mdx
@@ -41,21 +41,23 @@ import blocks from '../wp-blocks';
 </FaustProvider>
 ```
 
-Then, inside your templates you need to pass on the `contentBlocks` data in your `WordPressBlocksViewer`. The helper function `flatListToHierarchical` is referenced [here](www.wpgraphql.com/docs/menus/#hierarchical-data):
+Then, inside your templates you need to pass on the `editorBlocks` data in your `WordPressBlocksViewer`. The helper function `flatListToHierarchical` is referenced [here](www.wpgraphql.com/docs/menus/#hierarchical-data):
 
 ```js title="wp-templates/single.js"
 import { WordPressBlocksViewer } from '@faustwp/blocks';
 import components from '../wp-blocks';
 
-const { contentBlocks } = props.data.post;
-const blocks = flatListToHierarchical(contentBlocks);
+const { editorBlocks } = props.data.post;
+const blocks = flatListToHierarchical(editorBlocks);
+
+return <WordPressBlocksViewer blocks={blocks}/>
 ```
 
-Example `contentBlock` GraphQL query fragment. Setting `flat: true` brings all the nodes back in one array instead of a bunch of separate nodes with their own arrays:
+Example `editorBlocks` GraphQL query fragment. Setting `flat: true` brings all the nodes back in one array instead of a bunch of separate nodes with their own arrays:
 
 ```graphql
 ${components.CoreParagraph.fragments.entry}
-contentBlocks(flat: true) {
+editorBlocks(flat: true) {
   __typename
   renderedHtml
   id: clientId

--- a/internal/faustjs.org/docs/gutenberg/tutorial/create-a-block-from-third-party.mdx
+++ b/internal/faustjs.org/docs/gutenberg/tutorial/create-a-block-from-third-party.mdx
@@ -64,7 +64,7 @@ There are a lot of attributes associated with that block. You can use the follow
 ```graphql
 {
   post(id: "/posts/test", idType: URI) {
-    contentBlocks {
+    editorBlocks {
       renderedHtml
       ...on UbCallToActionBlock {
         attributes {
@@ -86,7 +86,7 @@ This will resolve into:
 ```
 "data": {
     "post": {
-      "contentBlocks": [
+      "editorBlocks": [
         {
           "renderedHtml": "<div class=\"ub_call_to_action\" id=\"ub_call_to_action_37aa7f1a-5d3a-4077-9c2b-a29b3672896c\">\n                <div class=\"ub_call_to_action_headline\">\n                    <p class=\"ub_call_to_action_headline_text\">Call To Action</p></div>\n                <div class=\"ub_call_to_action_content\">\n                    <p class=\"ub_cta_content_text\">Help us achieve our goals</p></div>\n                <div class=\"ub_call_to_action_button\">\n                    <a href=\"http://locahost:3000/donate\" target=\"_self\" rel=\"noopener noreferrer\"\n                        class=\"ub_cta_button\">\n                        <p class=\"ub_cta_button_text\">Donate Now</p></a></div></div>",
           "attributes": {
@@ -203,7 +203,7 @@ query GetPost(
 ...
 	post(id: $databaseId, idType: DATABASE_ID, asPreview: $asPreview) {
 		...
-		contentBlocks {
+		editorBlocks {
 			name
 			__typename
 			renderedHtml

--- a/internal/faustjs.org/docs/gutenberg/tutorial/create-a-block-from-wordpress-core.mdx
+++ b/internal/faustjs.org/docs/gutenberg/tutorial/create-a-block-from-wordpress-core.mdx
@@ -56,7 +56,7 @@ There are a lot of attributes associated with that block. You can use the follow
 ```graphql
 {
   post(id: "/posts/testing", idType: URI) {
-    contentBlocks {
+    editorBlocks {
       renderedHtml
       ...on CoreCode {
         attributes {
@@ -78,7 +78,7 @@ This will resolve into:
 ```
 "data": {
     "post": {
-      "contentBlocks": [
+      "editorBlocks": [
         {
           "renderedHtml": "\n<pre class=\"wp-block-code has-border-color has-tertiary-background-color has-text-color has-background has-small-font-size\" style=\"border-color:#333333;border-width:2px;color:#333333\"><code>// Computes the nth Fibonacci number\nfunction fib(n) {\n    var a = 0, b = 1, c;\n    if (n &lt; 3) {\n        if (n &lt; 0) return fib(-n);\n        if (n === 0) return 0;\n        return 1;\n    }\n    while (--n)\n        c = a + b, a = b, b = c;\n    return c;\n}</code></pre>\n",
           "attributes": {
@@ -178,7 +178,7 @@ query GetPost(
 ...
 	post(id: $databaseId, idType: DATABASE_ID, asPreview: $asPreview) {
 		...
-		contentBlocks {
+		editorBlocks {
 			name
 			__typename
 			renderedHtml

--- a/internal/faustjs.org/docs/gutenberg/wp-graphql-content-blocks.mdx
+++ b/internal/faustjs.org/docs/gutenberg/wp-graphql-content-blocks.mdx
@@ -30,15 +30,15 @@ There is no other configuration needed once you install the plugin.
 ## Getting started
 
 Once the plugin is installed, head over to the GraphiQL IDE and you should be able to perform queries for the block data (This plugin is an extension of [wp-graphql](https://www.wpgraphql.com/), so make sure you have it installed first.).
-There is a new field added in the Post and Page models called `contentBlocks`.
+There is a new field added in the Post and Page models called `editorBlocks`.
 This represents a list of available blocks for that content type:
 
 <img
   src="/docs/img/querying-with-content-blocks.png"
-  alt="Example query for contentBlocks using GraphiQL IDE"
+  alt="Example query for editorBlocks using GraphiQL IDE"
 />
 
-If you search in GraphiQL's documentation explorer tab for the `contentBlocks` type you will be able to see the available block fields.
+If you search in GraphiQL's documentation explorer tab for the `editorBlocks` type you will be able to see the available block fields.
 The most important ones are:
 
 * `renderedHTML`: It's the HTML of the block as rendered by the [render_block](https://developer.wordpress.org/reference/functions/render_block/) function.
@@ -116,7 +116,7 @@ For example, to use `CoreParagraph` attributes you need to use the following que
 {
   posts {
     nodes {
-      contentBlocks {
+      editorBlocks {
         __typename
         name
         ...on CoreParagraph {
@@ -146,7 +146,7 @@ If the resolved block has values for those fields, it will return them, otherwis
 
 ## What about innerBlocks?
 
-In order to facilitate querying `innerBlocks` fields more efficiently you want to use `contentBlocks(flat: true)` instead of `contentBlocks`.
+In order to facilitate querying `innerBlocks` fields more efficiently you want to use `editorBlocks(flat: true)` instead of `editorBlocks`.
 By passing this argument, all the blocks available (both blocks and innerBlocks) will be returned all flattened in the same list.
 
 For example, given the following HTML Content:
@@ -192,7 +192,7 @@ The `CoreColumns` contains one or more `CoreColumn` block, and each `CoreColumn`
 If we were to create a query to resolve this hierarchy, we would have to use:
 
 ```graphql
-contentBlocks {
+editorBlocks {
     __typename
     name
     ...on CoreColumns {
@@ -216,7 +216,7 @@ In each case we would have to copy the whole fragment list again and again. This
 This is how you request all blocks as a flat list:
 
 ```graphql
-contentBlocks(flat:true) {
+editorBlocks(flat:true) {
     __typename
     name
 	id: clientId
@@ -254,10 +254,10 @@ This way you can reconstruct the block tree as before and pass it on to the `Wor
 import { WordPressBlocksViewer } from '@faustwp/blocks';
 import flatListToHierarchical from '../utilities/flatListToHierarchical';
 ...
-const { contentBlocks } = props.data.post;
-const blocks = flatListToHierarchical(contentBlocks);
+const { editorBlocks } = props.data.post;
+const blocks = flatListToHierarchical(editorBlocks);
 
-<WordPressBlocksViewer contentBlocks={blocks} />
+<WordPressBlocksViewer blocks={blocks} />
 ...
 ```
 :::note

--- a/internal/faustjs.org/docs/reference/WordPressBlocksProvider.mdx
+++ b/internal/faustjs.org/docs/reference/WordPressBlocksProvider.mdx
@@ -67,5 +67,5 @@ import blocks from '../wp-blocks/index.js';
 <WordPressBlocksProvider
   config={{
     blocks,
-  }}></WordPressBlocksProvider>;
+  }} />;
 ```

--- a/internal/faustjs.org/docs/reference/WordPressBlocksViewer.mdx
+++ b/internal/faustjs.org/docs/reference/WordPressBlocksViewer.mdx
@@ -4,21 +4,21 @@ title: WordPressBlocksViewer Reference
 description: Reference docs for the WordPressBlocksViewer Component in Faust.
 ---
 
-`WordPressBlocksViewer` is a component used to render blocks received from WordPress. It uses the react components passed to the `WordPressBlocksProvider` and matches them to the appropriate blocks received in the [`contentBlocks`](#props) prop.
+`WordPressBlocksViewer` is a component used to render blocks received from WordPress. It uses the react components passed to the `WordPressBlocksProvider` and matches them to the appropriate blocks received in the [`editorBlocks`](#props) prop.
 
 ## Usage
 
-The below example shows how a [Faust Template](/docs/templates) can use the requested `contentBlocks` from WPGraphQL and render them using the `WordPressBlocksViewer` component.
+The below example shows how a [Faust Template](/docs/templates) can use the requested `editorBlocks` from WPGraphQL and render them using the `WordPressBlocksViewer` component.
 
 ```jsx {1,9,13} title="wp-blocks/CoreColumn.jsx"
 import { WordPressBlocksViewer } from '@faustwp/blocks';
 
 export default function Component(props) {
-  const { contentBlocks } = props.data.post;
+  const { editorBlocks } = props.data.post;
 
   return (
     <>
-      <WordPressBlocksViewer contentBlocks={contentBlocks} />
+      <WordPressBlocksViewer blocks={editorBlocks} />
     </>
   );
 }
@@ -28,7 +28,7 @@ Component.query = gql`
     $databaseId: ID!
   ) {
     post(id: $databaseId, idType: DATABASE_ID) {
-      contentBlocks {
+      editorBlocks {
         __typename
         renderedHtml
         id: clientId
@@ -51,7 +51,7 @@ Below is `WordPressBlocksViewer`'s props defined as a TypeScript interface:
 
 :::note
 
-The `contentBlocks` type defined below is data received from WPGraphQL and the [WPGraphQL Content Blocks](https://github.com/wpengine/wp-graphql-content-blocks) companion plugin.
+The `editorBlocks` type defined below is data received from WPGraphQL and the [WPGraphQL Content Blocks](https://github.com/wpengine/wp-graphql-content-blocks) companion plugin.
 
 :::
 
@@ -67,6 +67,6 @@ export interface ContentBlock {
 }
 
 export interface WordpressBlocksViewerProps {
-  contentBlocks: ContentBlock[];
+  blocks: ContentBlock[];
 }
 ```

--- a/packages/blocks/README.md
+++ b/packages/blocks/README.md
@@ -54,20 +54,22 @@ import { WordPressBlocksProvider } from '@faustwp/blocks';
 </FaustProvider>
 ```
 
-Then, inside your templates you need to pass on the `contentBlocks` data in your `WordPressBlocksViewer`. The helper function `flatListToHierarchical` is referenced [here](www.wpgraphql.com/docs/menus/#hierarchical-data):
+Then, inside your templates you need to pass on the `editorBlocks` data in your `WordPressBlocksViewer`. The helper function `flatListToHierarchical` is referenced [here](www.wpgraphql.com/docs/menus/#hierarchical-data):
 
 ```js
 import { WordPressBlocksViewer } from '@faustwp/blocks';
 
-const { contentBlocks } = props.data.post;
-const blocks = flatListToHierarchical(contentBlocks);
+const { editorBlocks } = props.data.post;
+const blocks = flatListToHierarchical(editorBlocks);
+
+return <WordPressBlocksViewer blocks={blocks}/>
 ```
 
-Example `contentBlock` GraphQL query fragment. Setting `flat: true` brings all the nodes back in one array instead of a bunch of separate nodes with their own arrays:
+Example `editorBlocks` GraphQL query fragment. Setting `flat: true` brings all the nodes back in one array instead of a bunch of separate nodes with their own arrays:
 
 ```graphql
 ${components.CoreParagraph.fragments.entry}
-contentBlocks(flat: true) {
+editorBlocks(flat: true) {
   __typename
   renderedHtml
   id: clientId

--- a/packages/blocks/src/components/WordPressBlocksViewer.tsx
+++ b/packages/blocks/src/components/WordPressBlocksViewer.tsx
@@ -24,7 +24,7 @@ export function BlockDataProvider(
 }
 
 export interface WordpressBlocksViewerProps {
-  contentBlocks: ContentBlock[];
+  blocks: ContentBlock[];
 }
 
 export interface ContentBlock {
@@ -47,8 +47,8 @@ export function WordPressBlocksViewer(props: WordpressBlocksViewerProps) {
     throw new Error('Blocks are required. Please add them to your config.');
   }
 
-  const { contentBlocks } = props;
-  const renderedBlocks = contentBlocks.map((blockProps, idx) => {
+  const { blocks: editorBlocks } = props;
+  const renderedBlocks = editorBlocks.map((blockProps, idx) => {
     const BlockTemplate = resolveBlockTemplate(blockProps, blocks);
     return (
       // eslint-disable-next-line react/no-array-index-key


### PR DESCRIPTION
## Tasks

- [ ] I have signed a [Contributor License Agreement (CLA)](https://github.com/wpengine/faustjs#contributor-license-agreement) with WP Engine.

## Description

This PR introduces a breaking change (Sorry!)

* Updates any references to `contentBlocks` in the docs.
* Changes the `contentBlocks` property, in `WordPressBlocksViewer` to accept a `blocks` property instead.

<!--
Include a summary of the change and some contextual information.
-->

## Related Issue(s):
https://wpengine.atlassian.net/browse/MERL-727
<!--
Provide the GitHub issue(s) number for issue tracking purposes, use the following syntax:

- #1234
-->

## Testing

<!--
Describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Also list any relevant details for your test configuration such as how to test the changes locally or in staging.
-->

* Make sure that any references in the documentation of `contentBlocks` is not there.
* Instead of using the `contentBlocks` property, the WordPressBlocksViewer should accept a `blocks` property instead.

## Screenshots

<!--
If this is a visual change include relevant screenshots about the behavior of the application before and after this change.
-->

## Documentation Changes

<!--
List corresponding changes to the documentation.
-->

* All Gutenberg tutorials
* @faustwp/block README file

## Dependant PRs

<!--
List any dependent PR's that are awaiting review. Use the following syntax:

- #1234
-->
