### PR TITLE
Add `faustwp_exclude_from_public_redirect` filter to companion WordPress plugin

### DIFF
--- a/.changeset/beige-owls-glow.md
+++ b/.changeset/beige-owls-glow.md
@@ -1,0 +1,5 @@
+---
+'@faustwp/wordpress-plugin': minor
+---
+
+- Added new filter `faustwp_exclude_from_public_redirect`, allowing WordPress plugins and themes to exclude certain routes from being redirected when the [enable public route redirects](https://faustjs.org/docs/faustwp/settings#enabling-public-route-redirects) setting is active.

--- a/internal/faustjs.org/docs/faustwp/filters.mdx
+++ b/internal/faustjs.org/docs/faustwp/filters.mdx
@@ -1,0 +1,28 @@
+---
+slug: /faustwp/filters
+title: Faust WordPress Plugin Filters
+description: Reference documentation for the available filters in the Faust WordPress plugin.
+---
+
+## Filters
+
+### faustwp_exclude_from_public_redirect
+
+Exclude certain routes from being redirected when the [enable public route redirects](https://faustjs.org/docs/faustwp/settings#enabling-public-route-redirects) setting is active.
+
+#### Parameters
+
+- **$excluded** (array): List of WordPress routes to exclude from redirecting.
+
+#### Example Usage
+
+```php
+add_filter( 'faustwp_exclude_from_public_redirect', function( $excluded ) {
+  $excluded = array_merge( $excluded, [
+    'checkout',
+    'cart',
+    'shop',
+  ]);
+  return $excluded;
+}, 10, 1 );
+```

--- a/internal/faustjs.org/docs/faustwp/settings.mdx
+++ b/internal/faustjs.org/docs/faustwp/settings.mdx
@@ -7,7 +7,6 @@ description: This section describes the various WordPress Plugin Settings.
 The `Faust` page of the Faust WordPress Plugin (located within the WP Admin `Settings` Sidebar)
 allows you to customize the behavior of the plugin by configuring certain features. We explain those features in detail:
 
-
 ## Features Explained
 
 The following options are available to enable/disabled based on your requirements:
@@ -18,10 +17,10 @@ This option is controlled by the `Disable WordPress theme admin pages` checkbox.
 When enabled it removes certain wp-admin menu items that aren't supported in a headless environment.
 For example, it will remove the following menu items:
 
-* `Appearance > Themes`
-* `Appearance > Theme Editor`
-* `Appearance > Widgets`
-* `Appearance > Customize`
+- `Appearance > Themes`
+- `Appearance > Theme Editor`
+- `Appearance > Widgets`
+- `Appearance > Customize`
 
 It will also remove any features that require the `Customizer` which means that the
 `Appearance` tab will only contain the menu options.
@@ -57,7 +56,6 @@ then if you visit any page on your `WordPress URL` will be redirected to the hea
 
 If you don't want this redirect to happen then you can disable this option which allows you to access the original WP site.
 
-
 ### Using the WordPress Domain for Media URLs in Post Content
 
 This option is controlled by the `Use the WordPress domain for media URLs in post content` checkbox and is disabled by default.
@@ -81,4 +79,4 @@ WP site a root domain and when you switch the live domain to headless,
 you should disable the option to replace those links worrying about missing media.
 
 > **NOTE:** When moving your site to a new domain it is recommended to perform a search/replace on your website’s database.
-This is to ensure all hard-coded references of the old domain in your database point to your live production domain instead. [Read more about search/replace](https://wpengine.com/support/move-domain-new-environment/#Optional_Perform_a_search_and_replace)
+> This is to ensure all hard-coded references of the old domain in your database point to your live production domain instead. [Read more about search/replace](https://wpengine.com/support/move-domain-new-environment/#Optional_Perform_a_search_and_replace)

--- a/internal/faustjs.org/sidebars.js
+++ b/internal/faustjs.org/sidebars.js
@@ -132,6 +132,11 @@ module.exports = {
           label: 'Settings Reference',
           id: 'faustwp/settings',
         },
+        {
+          type: 'doc',
+          label: 'Filters',
+          id: 'faustwp/filters',
+        },
       ],
     },
     {

--- a/plugins/faustwp/includes/deny-public-access/callbacks.php
+++ b/plugins/faustwp/includes/deny-public-access/callbacks.php
@@ -48,7 +48,7 @@ function deny_public_access() {
 	 *
 	 * @param array $excluded_routes The array of routes to exclude from redirect.
 	 */
-	$excluded_routes = apply_filters( 'faustwp_exclude_from_public_redirect', [] );
+	$excluded_routes = apply_filters( 'faustwp_exclude_from_public_redirect', array() );
 
 	if ( in_array( basename( add_query_arg( null, null ) ), $excluded_routes ) ) {
 		return;

--- a/plugins/faustwp/includes/deny-public-access/callbacks.php
+++ b/plugins/faustwp/includes/deny-public-access/callbacks.php
@@ -50,7 +50,7 @@ function deny_public_access() {
 	 */
 	$excluded_routes = apply_filters( 'faustwp_exclude_from_public_redirect', array() );
 
-	if ( in_array( basename( add_query_arg( null, null ) ), $excluded_routes ) ) {
+	if ( in_array( basename( add_query_arg( null, null ) ), $excluded_routes, true ) ) {
 		return;
 	}
 

--- a/plugins/faustwp/includes/deny-public-access/callbacks.php
+++ b/plugins/faustwp/includes/deny-public-access/callbacks.php
@@ -40,6 +40,20 @@ function deny_public_access() {
 		return;
 	}
 
+	/**
+	 * Filter 'faustwp_exclude_from_public_redirect'.
+	 *
+	 * Used to exclude certain routes from being redirected
+	 * when enable public route redirects is active.
+	 *
+	 * @param array $excluded_routes The array of routes to exclude from redirect.
+	 */
+	$excluded_routes = apply_filters( 'faustwp_exclude_from_public_redirect', [] );
+
+	if ( in_array( basename( add_query_arg( null, null ) ), $excluded_routes ) ) {
+		return;
+	}
+
 	$frontend_uri = trailingslashit( $frontend_uri );
 
 	// Get the request uri with query params.


### PR DESCRIPTION
## Tasks

- [X] I have signed a [Contributor License Agreement (CLA)](https://github.com/wpengine/faustjs#contributor-license-agreement) with WP Engine.

## Description

These changes are based on the originally proposed solution from https://github.com/wpengine/faustjs/pull/740. Unfortunately that GitHub account is no longer active.

## Related Issue(s):

These changes will close https://github.com/wpengine/faustjs/issues/739.

## Testing

1. Create the pages "checkout" & "cart" in WordPress.
2. Make sure the "Enable public route redirect" setting is active within the Faust WordPress plugin.
3. Make sure that your front-end URL is using `http://localhost:3000`
4. Observe that the WordPress pages `/checkout` and `/cart` redirect to their corresponding pages on `http://localhost:3000`
5. Add the following snippet to your WordPress site (bottom of the active theme's `/functions.php` is fine for this)
    ```php
    add_filter( 'faustwp_exclude_from_public_redirect', function( $excluded ) {
      $excluded = array_merge( $excluded, [
        'checkout',
        'cart',
      ]);
      return $excluded;
    }, 10, 1 );
    ```
6. Observe that the WordPress pages `/checkout` and `/cart` DO NOT redirect away from WordPress.

## Documentation Changes

- New [Filters Page](https://hc6rj2ozl1butfbxsj7ux8fbq.js.wpenginepowered.com/docs/faustwp/filters) has been created
