### PR TITLE
Update getNextServerSideProps to getNextStaticProps

### DIFF
--- a/internal/faustjs.org/docs/next/reference/getNextStaticProps.mdx
+++ b/internal/faustjs.org/docs/next/reference/getNextStaticProps.mdx
@@ -25,7 +25,7 @@ This is merely a convenient way to fetch the page data while reusing the logic b
 
 This is the same object that Next.js provides in `getStaticProps`. You can read the [list of parameters here](https://nextjs.org/docs/api-reference/data-fetching/get-static-props#context-parameter).
 
-## GetNextServerSidePropsConfig Parameter
+## GetNextStaticPropsConfig Parameter
 
 The second argument of `getNextStaticProps` is of type `GetNextStaticPropsConfig` and accepts the following parameters:
 
@@ -35,6 +35,6 @@ The second argument of `getNextStaticProps` is of type `GetNextStaticPropsConfig
 
 Because the `GetNextStaticPropsConfig` type extends `GetNextServerSidePropsConfig`, it can also accept any other properties of the [getNextServerSideProps](/docs/next/reference/getNextServerSideProps).
 
-## getNextServerSideProps Return Values
+## getNextStaticProps Return Values
 
 The `getNextStaticProps` function returns an object that is required by the `getStaticProps` function.


### PR DESCRIPTION
Update docs references in `getNextStaticProps.mdx` to refer to static props instead of server-side props.

## Tasks

- [ ] I have signed a [Contributor License Agreement (CLA)](https://github.com/wpengine/faustjs#contributor-license-agreement) with WP Engine.

## Description

<!--
Include a summary of the change and some contextual information.
-->

## Related Issue(s):

<!--
Provide the GitHub issue(s) number for issue tracking purposes, use the following syntax:

- #1234
-->

## Testing

<!--
Describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Also list any relevant details for your test configuration such as how to test the changes locally or in staging.
-->

## Screenshots

<!--
If this is a visual change include relevant screenshots about the behavior of the application before and after this change.
-->

## Documentation Changes

<!--
List corresponding changes to the documentation.
-->

## Dependant PRs

<!--
List any dependent PR's that are awaiting review. Use the following syntax:

- #1234
-->
