### PR TITLE
Merl 759 wp graphql content blocks set content blocks flat true by default

### DIFF
--- a/internal/faustjs.org/docs/gutenberg/getting-started.mdx
+++ b/internal/faustjs.org/docs/gutenberg/getting-started.mdx
@@ -53,11 +53,11 @@ const blocks = flatListToHierarchical(editorBlocks);
 return <WordPressBlocksViewer blocks={blocks}/>
 ```
 
-Example `editorBlocks` GraphQL query fragment. Setting `flat: true` brings all the nodes back in one array instead of a bunch of separate nodes with their own arrays:
+Example `editorBlocks` GraphQL query fragment. 
 
 ```graphql
 ${components.CoreParagraph.fragments.entry}
-editorBlocks(flat: true) {
+editorBlocks(flat: false) {
   __typename
   renderedHtml
   id: clientId
@@ -65,6 +65,11 @@ editorBlocks(flat: true) {
   ...${components.CoreParagraph.fragments.key}
 }
 ```
+:::note
+
+Setting `flat: false` above returns separate nodes with their own arrays. By default, editorBlocks brings all the nodes back in one array instead.
+
+:::
 
 ## A Simple Block Example
 This is a simple block called `CoreParagraph`. The block is a `p` tag that sets its content to `attributes.content` which is passed in from the props.

--- a/internal/faustjs.org/docs/gutenberg/wp-graphql-content-blocks.mdx
+++ b/internal/faustjs.org/docs/gutenberg/wp-graphql-content-blocks.mdx
@@ -147,8 +147,7 @@ If the resolved block has values for those fields, it will return them, otherwis
 
 ## What about innerBlocks?
 
-In order to facilitate querying `innerBlocks` fields more efficiently you want to use `editorBlocks(flat: true)` instead of `editorBlocks`.
-By passing this argument, all the blocks available (both blocks and innerBlocks) will be returned all flattened in the same list.
+All the blocks available (both blocks and innerBlocks) will be returned flattened in the same list by default. If you want to query `innerBlocks` fields and return separate nodes with their own arrays, use `editorBlocks(flat: false)` instead of `editorBlocks`.
 
 For example, given the following HTML Content:
 
@@ -217,7 +216,7 @@ In each case we would have to copy the whole fragment list again and again. This
 This is how you request all blocks as a flat list:
 
 ```graphql
-editorBlocks(flat:true) {
+editorBlocks {
     __typename
     name
 	id: clientId


### PR DESCRIPTION
## Description

This PR is for one of two to fulfill [MERL-759](https://wpengine.atlassian.net/jira/software/c/projects/MERL/boards/1007?modal=detail&selectedIssue=MERL-759). This changes the documentation to match the new `flat` by default configuration for `editorBlocks`, and explains how to set it to false if desired.

The other pull request that contains the changes to the editorBlocks `flat` arg for MERL-759 is located in the plugin, here: https://github.com/wpengine/wp-graphql-content-blocks/pull/39 


[MERL-759]: https://wpengine.atlassian.net/browse/MERL-759?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ