### PR TITLE
Show Faust Toolbar based on user preferences in WordPress

### DIFF
--- a/packages/faustwp-core/package.json
+++ b/packages/faustwp-core/package.json
@@ -58,7 +58,7 @@
     "build-fonts": "mkdir -p dist/fonts && shx cp src/fonts/* dist/fonts",
     "build-styles": "sass src/styles/toolbar.scss dist/css/toolbar.css --embed-sources",
     "watch-styles": "sass src/styles/toolbar.scss dist/css/toolbar.css --embed-sources --watch",
-    "watch-js": "tsc -p . --watch"
+    "watch-js": "concurrently \"npm:build-js -- --watch\" \"npm:build-cjs -- --watch\""
   },
   "repository": {
     "type": "git",

--- a/packages/faustwp-core/src/components/Toolbar/Toolbar.tsx
+++ b/packages/faustwp-core/src/components/Toolbar/Toolbar.tsx
@@ -183,7 +183,7 @@ export function ToolbarAwaitUser({ seedNode }: ToolbarProps) {
     gql`
       {
         viewer {
-          isToolbarVisible
+          shouldShowFaustToolbar
         }
       }
     `,

--- a/packages/faustwp-core/src/components/Toolbar/Toolbar.tsx
+++ b/packages/faustwp-core/src/components/Toolbar/Toolbar.tsx
@@ -190,6 +190,12 @@ export function ToolbarAwaitUser({ seedNode }: ToolbarProps) {
     { client },
   );
 
+  /**
+   * If the above query for "shouldShowFaustToolbar" fails, it likely means
+   * that the user doesn't have a version of the FaustWP plugin installed where
+   * this field was made available. In that case, don't throw an error, and
+   * just continue with showing the toolbar.
+   */
   if (error) {
     return <AuthenticatedToolbar seedNode={seedNode} />;
   }
@@ -198,7 +204,7 @@ export function ToolbarAwaitUser({ seedNode }: ToolbarProps) {
     return null;
   }
 
-  if (data.viewer.isToolbarVisible === false) {
+  if (data.viewer.shouldShowFaustToolbar === false) {
     return null;
   }
 

--- a/plugins/faustwp/includes/graphql/callbacks.php
+++ b/plugins/faustwp/includes/graphql/callbacks.php
@@ -44,28 +44,32 @@ function register_templates_field() {
 	);
 }
 
-add_action( 'graphql_register_types',  __NAMESPACE__ . '\\register_faust_toolbar_field' );
+add_action( 'graphql_register_types', __NAMESPACE__ . '\\register_faust_toolbar_field' );
 /**
  * Registers a field on the User model called "shouldShowFaustToolbar" which
  * gets the user's WP Admin toolbar preference. This is then used to conditionally
  * show the Faust toolbar on the headless frontend.
- * 
+ *
  * @return void
- * 
+ *
  * @uses register_graphql_field
  * @uses wp_get_current_user
  * @uses get_user_meta
  */
 function register_faust_toolbar_field() {
-	register_graphql_field( 'User', 'shouldShowFaustToolbar', [
-		'type' => 'Boolean',
-		'resolve' => function() {
-			$user = wp_get_current_user();
-			$toolbar_preference_meta = get_user_meta( $user->ID, 'show_admin_bar_front', true );
+	register_graphql_field(
+		'User',
+		'shouldShowFaustToolbar',
+		array(
+			'type'    => 'Boolean',
+			'resolve' => function() {
+				$user                    = wp_get_current_user();
+				$toolbar_preference_meta = get_user_meta( $user->ID, 'show_admin_bar_front', true );
 
-			return 'true' === $toolbar_preference_meta ? true : false;
-		},
-	]);
+				return 'true' === $toolbar_preference_meta ? true : false;
+			},
+		)
+	);
 }
 
 /**

--- a/plugins/faustwp/includes/graphql/callbacks.php
+++ b/plugins/faustwp/includes/graphql/callbacks.php
@@ -44,6 +44,30 @@ function register_templates_field() {
 	);
 }
 
+add_action( 'graphql_register_types',  __NAMESPACE__ . '\\register_faust_toolbar_field' );
+/**
+ * Registers a field on the User model called "shouldShowFaustToolbar" which
+ * gets the user's WP Admin toolbar preference. This is then used to conditionally
+ * show the Faust toolbar on the headless frontend.
+ * 
+ * @return void
+ * 
+ * @uses register_graphql_field
+ * @uses wp_get_current_user
+ * @uses get_user_meta
+ */
+function register_faust_toolbar_field() {
+	register_graphql_field( 'User', 'shouldShowFaustToolbar', [
+		'type' => 'Boolean',
+		'resolve' => function() {
+			$user = wp_get_current_user();
+			$toolbar_preference_meta = get_user_meta( $user->ID, 'show_admin_bar_front', true );
+
+			return 'true' === $toolbar_preference_meta ? true : false;
+		},
+	]);
+}
+
 /**
  * Resolver for getting the templates that will be loaded on a given node
  *


### PR DESCRIPTION
## Tasks

- [x] I have signed a [Contributor License Agreement (CLA)](https://github.com/wpengine/faustjs#contributor-license-agreement) with WP Engine.

## Description

This PR shows or hides the Faust Toolbar based on the user's toolbar preferences in WordPress:
<img width="599" alt="Screenshot 2023-03-31 at 11 13 15 AM" src="https://user-images.githubusercontent.com/5946219/229174203-7e13acfc-2723-4738-b041-053df46db2d0.png">

A field was added to the `viewer` model in WPGraphQL called `shouldShowFaustToolbar` which we use to either show or hide the toolbar component.

If the user is using a version of Faust where this field does not exist, the query will throw an error, and show the toolbar. If the query fails, there is no blocking errors, the behavior just falls back to showing the toolbar.

<!--
Include a summary of the change and some contextual information.
-->

## Related Issue(s):

<!--
Provide the GitHub issue(s) number for issue tracking purposes, use the following syntax:

- #1234
-->

## Testing

Tests have been provided. Additionally, here are some manual testing instructions:

1. Checkout this branch
2. Build the core and cli packages
3. In the example app, ensure `experimentalToolbar` is set
4. Make sure you are using the version of FaustWP from this branch
5. Start the dev server
6. Authenticate via previews
7. Notice the toolbar will now show based on your preferences in WordPress

<!--
Describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Also list any relevant details for your test configuration such as how to test the changes locally or in staging.
-->

## Screenshots

<!--
If this is a visual change include relevant screenshots about the behavior of the application before and after this change.
-->

## Documentation Changes

<!--
List corresponding changes to the documentation.
-->

## Dependant PRs

<!--
List any dependent PR's that are awaiting review. Use the following syntax:

- #1234
-->
