### PR TITLE
TS: Fix getWordPressProps/getNextStaticProps invalid return type

### DIFF
--- a/.changeset/thirty-apricots-compare.md
+++ b/.changeset/thirty-apricots-compare.md
@@ -1,0 +1,5 @@
+---
+'@faustwp/core': patch
+---
+
+Rectifies return type of getWordPressProps and getNextStaticProps for TypeScript

--- a/packages/faustwp-core/src/getProps.ts
+++ b/packages/faustwp-core/src/getProps.ts
@@ -1,5 +1,6 @@
 import {
   GetStaticPropsContext,
+  GetStaticPropsResult,
   GetServerSidePropsResult,
   GetServerSidePropsContext,
   Redirect,
@@ -36,7 +37,7 @@ export interface GetNextStaticPropsConfig<Props = Record<string, unknown>>
 export async function getNextStaticProps<Props>(
   context: GetStaticPropsContext,
   cfg: GetNextStaticPropsConfig<Props>,
-): Promise<GetServerSidePropsResult<Props>> {
+): Promise<GetStaticPropsResult<Props>> {
   const { notFound, redirect, Page, revalidate, props } = cfg;
   const apolloClient = getApolloClient();
   if (isBoolean(notFound) && notFound === true) {
@@ -60,7 +61,7 @@ export async function getNextStaticProps<Props>(
 
   const pageProps = addApolloState(apolloClient, { props: { ...props } });
   pageProps.revalidate = revalidate ?? DEFAULT_ISR_REVALIDATE;
-  return pageProps as GetServerSidePropsResult<Props>;
+  return pageProps as GetStaticPropsResult<Props>;
 }
 
 /**

--- a/packages/faustwp-core/src/getProps.ts
+++ b/packages/faustwp-core/src/getProps.ts
@@ -18,7 +18,7 @@ export interface GetNextServerSidePropsConfig<Props = Record<string, unknown>> {
     ) => { [key: string]: any };
   };
   props?: Props;
-  notFound?: boolean;
+  notFound?: true;
   redirect?: Redirect;
 }
 
@@ -36,7 +36,7 @@ export interface GetNextStaticPropsConfig<Props = Record<string, unknown>>
 export async function getNextStaticProps<Props>(
   context: GetStaticPropsContext,
   cfg: GetNextStaticPropsConfig<Props>,
-) {
+): Promise<GetServerSidePropsResult<Props>> {
   const { notFound, redirect, Page, revalidate, props } = cfg;
   const apolloClient = getApolloClient();
   if (isBoolean(notFound) && notFound === true) {
@@ -60,7 +60,7 @@ export async function getNextStaticProps<Props>(
 
   const pageProps = addApolloState(apolloClient, { props: { ...props } });
   pageProps.revalidate = revalidate ?? DEFAULT_ISR_REVALIDATE;
-  return pageProps;
+  return pageProps as GetServerSidePropsResult<Props>;
 }
 
 /**

--- a/packages/faustwp-core/src/getWordPressProps.tsx
+++ b/packages/faustwp-core/src/getWordPressProps.tsx
@@ -28,8 +28,19 @@ export interface GetWordPressPropsConfig<Props = Record<string, unknown>> {
   props?: Props;
   revalidate?: number | boolean;
 }
-
-export async function getWordPressProps(options: GetWordPressPropsConfig) {
+export async function getWordPressProps(
+  options: GetWordPressPropsConfig,
+): Promise<
+  | {
+      props: {
+        [key: string]: any;
+      };
+      revalidate?: number | boolean | undefined;
+    }
+  | {
+      notFound: true;
+    }
+> {
   const { templates } = getConfig();
 
   if (!templates) {


### PR DESCRIPTION
## Tasks

- [ ] I have signed a [Contributor License Agreement (CLA)](https://github.com/wpengine/faustjs#contributor-license-agreement) with WP Engine.

## Description
This PR rectifies the return types of `getWordPressProps` and `getNextStaticProps` for TS.
Fixes: https://github.com/wpengine/faustjs/issues/1340
<!--
Include a summary of the change and some contextual information.
-->

## Related Issue(s):

<!--
Provide the GitHub issue(s) number for issue tracking purposes, use the following syntax:

- #1234
-->

## Testing

- Create a new Project using TS
- Try to assign a return type for `getWordPressProps` in `getServerSideProps` and `getStaticProps`

```
export const getServerSideProps: GetServerSideProps = async (
  ctx: GetServerSidePropsContext
) => getNextServerSideProps(ctx, {Page, props: {title: 'File Page Example'}});
```
```
export const getServerSideProps: GetServerSideProps = async (
  ctx: GetServerSidePropsContext
) => getWordPressProps({ ctx });
```

It should not fail to typecheck when running `npm build`

<!--
Describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Also list any relevant details for your test configuration such as how to test the changes locally or in staging.
-->

## Screenshots

<!--
If this is a visual change include relevant screenshots about the behavior of the application before and after this change.
-->

## Documentation Changes

<!--
List corresponding changes to the documentation.
-->

## Dependant PRs

<!--
List any dependent PR's that are awaiting review. Use the following syntax:

- #1234
-->
