### PR TITLE
[@faustwp/blocks] Use correct types for @faustwp/blocks package in package.json

### DIFF
--- a/.changeset/four-days-hang.md
+++ b/.changeset/four-days-hang.md
@@ -1,0 +1,5 @@
+---
+'@faustwp/blocks': patch
+---
+
+Bug: Reference correct type definitions in package.json

--- a/packages/blocks/package.json
+++ b/packages/blocks/package.json
@@ -4,7 +4,7 @@
   "description": "Faust Blocks",
   "main": "dist/cjs/index.js",
   "module": "dist/mjs/index.js",
-  "types": "dist/cjs/index.d.ts",
+  "types": "dist/mjs/index.d.ts",
   "peerDependencies": {
     "react": ">=17.0.2",
     "react-dom": ">=17.0.2"


### PR DESCRIPTION
## Tasks

- [ ] I have signed a [Contributor License Agreement (CLA)](https://github.com/wpengine/faustjs#contributor-license-agreement) with WP Engine.

## Description
This PR corrects the package.json type reference in the @faustwp/blocks package to use the correct types.
<!--
Include a summary of the change and some contextual information.
-->

## Related Issue(s):

<!--
Provide the GitHub issue(s) number for issue tracking purposes, use the following syntax:

- #1234
-->

https://github.com/wpengine/faustjs/issues/1337

## Testing

<!--
Describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Also list any relevant details for your test configuration such as how to test the changes locally or in staging.
-->

1. Create a new TS project and try to import `@faustwp/blocks` package.
2. It should not complain for non-existing type definitions for the @faustwp/blocks package

## Screenshots

<!--
If this is a visual change include relevant screenshots about the behavior of the application before and after this change.
-->

## Documentation Changes

<!--
List corresponding changes to the documentation.
-->

## Dependant PRs

<!--
List any dependent PR's that are awaiting review. Use the following syntax:

- #1234
-->
