### PR TITLE
Bug: Improve TS types for Blocks and Templates

### DIFF
--- a/.changeset/eleven-walls-hear.md
+++ b/.changeset/eleven-walls-hear.md
@@ -1,0 +1,5 @@
+---
+'@faustwp/blocks': patch
+---
+
+WordPressBlocksViewer returns a single div element now instead of a list

--- a/.changeset/sour-eggs-remain.md
+++ b/.changeset/sour-eggs-remain.md
@@ -1,0 +1,6 @@
+---
+'@faustwp/blocks': patch
+'@faustwp/core': patch
+---
+
+Type Definition fixes+improvements for Blocks and Core

--- a/packages/blocks/src/components/WordPressBlocksProvider.tsx
+++ b/packages/blocks/src/components/WordPressBlocksProvider.tsx
@@ -1,16 +1,20 @@
-import React from 'react';
+import React, { FC } from 'react';
+
+export type WordPressBlockBase = React.FC & {
+  displayName: string;
+  name: string;
+  config: {
+    name: string;
+  };
+};
 
 /**
  * WordPressBlock is a React component that contains some optional properties that we are
  * used to match it with equivalent block data from the API
  */
-export type WordPressBlock = React.FC & {
-  displayName?: string;
-  name?: string;
-  config?: {
-    name: string;
-  };
-};
+export type WordPressBlock<P = Record<string, any>> = FC<P> &
+  Partial<Pick<WordPressBlockBase, 'config' | 'displayName' | 'name'>>;
+
 export const WordPressBlocksContext =
   React.createContext<WordPressBlocksContextType>({});
 

--- a/packages/blocks/src/components/WordPressBlocksViewer.tsx
+++ b/packages/blocks/src/components/WordPressBlocksViewer.tsx
@@ -24,7 +24,7 @@ export function BlockDataProvider(
 }
 
 export interface WordpressBlocksViewerProps {
-  blocks: ContentBlock[];
+  blocks: Array<ContentBlock | null>;
   className?: string;
 }
 
@@ -32,7 +32,7 @@ export interface ContentBlock {
   __typename?: string;
   apiVersion?: number;
   cssClassNames?: string;
-  innerBlocks?: ContentBlock[];
+  innerBlocks?: Array<ContentBlock | null>;
   isDynamic?: boolean;
   name?: string;
   renderedHtml?: string;

--- a/packages/blocks/src/components/WordPressBlocksViewer.tsx
+++ b/packages/blocks/src/components/WordPressBlocksViewer.tsx
@@ -25,6 +25,7 @@ export function BlockDataProvider(
 
 export interface WordpressBlocksViewerProps {
   blocks: ContentBlock[];
+  className?: string;
 }
 
 export interface ContentBlock {
@@ -47,7 +48,7 @@ export function WordPressBlocksViewer(props: WordpressBlocksViewerProps) {
     throw new Error('Blocks are required. Please add them to your config.');
   }
 
-  const { blocks: editorBlocks } = props;
+  const { blocks: editorBlocks, className } = props;
   const renderedBlocks = editorBlocks.map((blockProps, idx) => {
     const BlockTemplate = resolveBlockTemplate(blockProps, blocks);
     return (
@@ -58,5 +59,5 @@ export function WordPressBlocksViewer(props: WordpressBlocksViewerProps) {
     );
   });
 
-  return renderedBlocks;
+  return <div className={className}>{renderedBlocks}</div>;
 }

--- a/packages/blocks/src/resolveBlockTemplate.ts
+++ b/packages/blocks/src/resolveBlockTemplate.ts
@@ -12,7 +12,7 @@ import DefaultBlock from './components/DefaultBlock.js';
  * @returns An instance of the WordPressBlock component that matches the the provided contentBlock or a DefaultBlock if no such match exists.
  */
 export default function resolveBlockTemplate(
-  contentBlock: ContentBlock,
+  contentBlock: ContentBlock | null,
   blocks: WordPressBlock[],
 ): WordPressBlock {
   // eslint-disable-next-line no-underscore-dangle

--- a/packages/faustwp-core/src/getWordPressProps.tsx
+++ b/packages/faustwp-core/src/getWordPressProps.tsx
@@ -2,6 +2,7 @@ import { GetServerSidePropsContext, GetStaticPropsContext } from 'next';
 import type { DocumentNode } from 'graphql';
 import { SeedNode, SEED_QUERY } from './queries/seedQuery.js';
 import { getPossibleTemplates, getTemplate } from './getTemplate.js';
+import { FaustTemplateProps } from './components/WordPressTemplate.js';
 import { addApolloState, getApolloClient } from './client.js';
 import { getConfig } from './config/index.js';
 import { hooks } from './wpHooks/index.js';
@@ -22,6 +23,12 @@ export type WordPressTemplate = React.FC & {
     context?: { asPreview?: boolean; locale?: string },
   ) => { [key: string]: any };
 };
+
+export interface FaustTemplate<Data>
+  extends React.FC<FaustTemplateProps<Data>> {
+  query?: WordPressTemplate['query'];
+  variables?: WordPressTemplate['variables'];
+}
 
 export interface GetWordPressPropsConfig<Props = Record<string, unknown>> {
   ctx: GetServerSidePropsContext | GetStaticPropsContext;

--- a/packages/faustwp-core/src/index.ts
+++ b/packages/faustwp-core/src/index.ts
@@ -3,7 +3,7 @@ import {
   WordPressTemplate,
   FaustTemplateProps,
 } from './components/WordPressTemplate.js';
-import { getWordPressProps } from './getWordPressProps.js';
+import { getWordPressProps, FaustTemplate } from './getWordPressProps.js';
 import { getNextStaticProps, getNextServerSideProps } from './getProps.js';
 import { getConfig, setConfig, FaustConfig } from './config/index.js';
 import { ensureAuthorization } from './auth/index.js';
@@ -74,4 +74,5 @@ export {
   ToolbarNodeSkeleton,
   ToolbarSubmenu,
   ToolbarSubmenuWrapper,
+  FaustTemplate,
 };


### PR DESCRIPTION
## Tasks

- [ ] I have signed a [Contributor License Agreement (CLA)](https://github.com/wpengine/faustjs#contributor-license-agreement) with WP Engine.

## Description

This PR Improve TS types for the `WordPressBlock`, `WordpressBlocksViewer` and exposes a dedicated type for WordPressTemplate called `FaustTemplate`. This is mainly to address the feedback from https://github.com/wpengine/faustjs/issues/1339  and https://github.com/wpengine/faustjs/issues/1338
<!--
Include a summary of the change and some contextual information.
-->

## Related Issue(s):

<!--
Provide the GitHub issue(s) number for issue tracking purposes, use the following syntax:

- #1234
-->

## Testing
This should compile without issues:

```ts
import { FaustTemplate } from '@faustwp/core';
import { PageDocument, PageQuery } from './page.generated';
const Page: FaustTemplate<PageQuery> = ({ data }) => (
  <div className="page-wrapper">
    <h1>{data?.page?.title}</h1>
    {!!data?.page?.contentBlocks && (
      <WordPressBlocksViewer contentBlocks={data.page.contentBlocks} />
    )}
  </div>
);

Page.query = PageDocument;

Page.variables = (seedNode, context) => ({
  databaseId: seedNode.databaseId,
});

export default Page;
```

<!--
Describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Also list any relevant details for your test configuration such as how to test the changes locally or in staging.
-->

## Screenshots

<!--
If this is a visual change include relevant screenshots about the behavior of the application before and after this change.
-->

## Documentation Changes

<!--
List corresponding changes to the documentation.
-->

## Dependant PRs

<!--
List any dependent PR's that are awaiting review. Use the following syntax:

- #1234
-->
