### PR TITLE
Return fragment from blocks

### DIFF
--- a/.changeset/eleven-walls-hear.md
+++ b/.changeset/eleven-walls-hear.md
@@ -1,5 +1,0 @@
----
-'@faustwp/blocks': patch
----
-
-WordPressBlocksViewer returns a single div element now instead of a list

--- a/packages/blocks/src/components/WordPressBlocksViewer.tsx
+++ b/packages/blocks/src/components/WordPressBlocksViewer.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable prettier/prettier */
-/* eslint-disable react/jsx-props-no-spreading */
 import React from 'react';
 import resolveBlockTemplate from '../resolveBlockTemplate.js';
 import { WordPressBlocksContext } from './WordPressBlocksProvider.js';
@@ -25,7 +23,6 @@ export function BlockDataProvider(
 
 export interface WordpressBlocksViewerProps {
   blocks: Array<ContentBlock | null>;
-  className?: string;
 }
 
 export interface ContentBlock {
@@ -48,16 +45,19 @@ export function WordPressBlocksViewer(props: WordpressBlocksViewerProps) {
     throw new Error('Blocks are required. Please add them to your config.');
   }
 
-  const { blocks: editorBlocks, className } = props;
+  const { blocks: editorBlocks } = props;
   const renderedBlocks = editorBlocks.map((blockProps, idx) => {
     const BlockTemplate = resolveBlockTemplate(blockProps, blocks);
     return (
       // eslint-disable-next-line react/no-array-index-key
       <BlockDataProvider data={blockProps} key={idx}>
-        <>{React.createElement<ContentBlock>(BlockTemplate, { ...blockProps })}</>
+        <>
+          {React.createElement<ContentBlock>(BlockTemplate, { ...blockProps })}
+        </>
       </BlockDataProvider>
     );
   });
 
-  return <div className={className}>{renderedBlocks}</div>;
+  // eslint-disable-next-line react/jsx-no-useless-fragment
+  return <>{renderedBlocks}</>;
 }


### PR DESCRIPTION
## Tasks

- [x] I have signed a [Contributor License Agreement (CLA)](https://github.com/wpengine/faustjs#contributor-license-agreement) with WP Engine.

## Description

Returning a `div` from the `WordPressBlockViewer` was messing with styles and CSS selectors. Replacing it in favor of a React fragment.

<!--
Include a summary of the change and some contextual information.
-->

## Related Issue(s):

<!--
Provide the GitHub issue(s) number for issue tracking purposes, use the following syntax:

- #1234
-->

## Testing

<!--
Describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Also list any relevant details for your test configuration such as how to test the changes locally or in staging.
-->

## Screenshots

<!--
If this is a visual change include relevant screenshots about the behavior of the application before and after this change.
-->

## Documentation Changes

<!--
List corresponding changes to the documentation.
-->

## Dependant PRs

<!--
List any dependent PR's that are awaiting review. Use the following syntax:

- #1234
-->
