### PR TITLE
Throw an error if "blocks" prop does not exist on WordPressBlocksViewer

### DIFF
--- a/.changeset/clean-doors-travel.md
+++ b/.changeset/clean-doors-travel.md
@@ -1,0 +1,5 @@
+---
+'@faustwp/blocks': patch
+---
+
+Added: Throw an error if the `blocks` prop was not set on the `<WordPressBlocksViewer>` component

--- a/packages/blocks/src/components/WordPressBlocksViewer.tsx
+++ b/packages/blocks/src/components/WordPressBlocksViewer.tsx
@@ -46,6 +46,11 @@ export function WordPressBlocksViewer(props: WordpressBlocksViewerProps) {
   }
 
   const { blocks: editorBlocks } = props;
+
+  if (!editorBlocks) {
+    throw new Error('The "blocks" prop is required in <WordPressBlocksViewer>');
+  }
+
   const renderedBlocks = editorBlocks.map((blockProps, idx) => {
     const BlockTemplate = resolveBlockTemplate(blockProps, blocks);
     return (


### PR DESCRIPTION
## Tasks

- [x] I have signed a [Contributor License Agreement (CLA)](https://github.com/wpengine/faustjs#contributor-license-agreement) with WP Engine.

## Description

This PR throws a human readable error if the `blocks` prop does not exist on the `WordPressBlocksViewer` component.

<!--
Include a summary of the change and some contextual information.
-->

## Related Issue(s):

<!--
Provide the GitHub issue(s) number for issue tracking purposes, use the following syntax:

- #1234
-->

## Testing

<!--
Describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Also list any relevant details for your test configuration such as how to test the changes locally or in staging.
-->

## Screenshots

<!--
If this is a visual change include relevant screenshots about the behavior of the application before and after this change.
-->

## Documentation Changes

<!--
List corresponding changes to the documentation.
-->

## Dependant PRs

<!--
List any dependent PR's that are awaiting review. Use the following syntax:

- #1234
-->
