### PR TITLE
[MERL-778] Bug fix: Use frontend_uri scheme in preview links

### DIFF
--- a/plugins/faustwp/includes/deny-public-access/callbacks.php
+++ b/plugins/faustwp/includes/deny-public-access/callbacks.php
@@ -61,8 +61,9 @@ function deny_public_access() {
 
 	$response_code = 302;
 	$redirect_url  = str_replace( trailingslashit( get_home_url() ), $frontend_uri, $request_uri );
+	$protocols = array( 'http', 'https' );
 
 	header( 'X-Redirect-By: WP Engine Headless plugin' ); // For support teams. See https://developer.yoast.com/blog/x-redirect-by-header/.
-	header( 'Location: ' . esc_url_raw( $redirect_url ), true, $response_code );
+	header( 'Location: ' . esc_url_raw( $redirect_url, $protocols ), true, $response_code );
 	exit;
 }

--- a/plugins/faustwp/includes/replacement/callbacks.php
+++ b/plugins/faustwp/includes/replacement/callbacks.php
@@ -224,7 +224,7 @@ add_action( 'enqueue_block_editor_assets', __NAMESPACE__ . '\\enqueue_preview_sc
  */
 function enqueue_preview_scripts() {
 	wp_enqueue_script( 'faustwp-gutenberg-filters', plugins_url( '/previewlinks.js', __FILE__ ), array(), '1.0.0', true );
-	wp_localize_script( 'faustwp-gutenberg-filters', '_faustwp_preview_link', array( '_preview_link' => get_preview_post_link() ) );
+	wp_localize_script( 'faustwp-gutenberg-filters', '_faustwp_preview_link', array( '_preview_link' => equivalent_frontend_url(get_preview_post_link()) ) );
 }
 
 add_filter( 'wp_sitemaps_posts_entry', __NAMESPACE__ . '\\sitemaps_posts_entry' );

--- a/plugins/faustwp/includes/replacement/functions.php
+++ b/plugins/faustwp/includes/replacement/functions.php
@@ -56,6 +56,13 @@ function normalize_url( $url, $frontend = false ) {
 		? str_replace( $home_url, $frontend_uri, $url )
 		: str_replace( $frontend_uri, $home_url, $url );
 
+	// Replace the schemes, if different
+	$frontend_uri_scheme = wp_parse_url( $frontend_uri, PHP_URL_SCHEME );
+	$normalized_url_scheme = wp_parse_url( $normalized_url, PHP_URL_SCHEME );
+	if ( $frontend_uri_scheme !== $normalized_url_scheme ) {
+		$normalized_url = str_replace( $normalized_url_scheme . '://', $frontend_uri_scheme. '://', $normalized_url );
+	}
+
 	return $normalized_url;
 }
 

--- a/plugins/faustwp/includes/settings/callbacks.php
+++ b/plugins/faustwp/includes/settings/callbacks.php
@@ -180,12 +180,12 @@ add_filter( 'sanitize_option_faustwp_settings', __NAMESPACE__ . '\\sanitize_faus
  */
 function sanitize_faustwp_settings( $settings, $option ) {
 	$errors = null;
-
+	$protocols = array( 'http', 'https' );
 	foreach ( $settings as $name => $value ) {
 		switch ( $name ) {
 			case 'frontend_uri':
 				if ( '' === $value || preg_match( '#http(s?)://(.+)#i', $value ) ) {
-					$settings[ $name ] = esc_url_raw( $value );
+					$settings[ $name ] = esc_url_raw( $value, $protocols );
 				} else {
 					$errors[ $name ]   = __( 'The Front-end site URL you entered did not appear to be a valid URL. Please enter a valid URL.', 'faustwp' );
 					$settings[ $name ] = faustwp_get_setting( $name );

--- a/plugins/faustwp/tests/integration/ReplacementFunctionsTests.php
+++ b/plugins/faustwp/tests/integration/ReplacementFunctionsTests.php
@@ -78,6 +78,14 @@ class ReplacementFunctionsTests extends \WP_UnitTestCase {
 		$this->assertStringContainsString( $wp_url, $frontend_url );
 	}
 
+	public function test_equivalent_frontend_url_uses_frontend_uri_scheme() {
+		$home_url = str_replace( 'http://', 'https://', get_home_url() );
+		$wp_url       = $home_url . '/posts/hello-world/';
+		$frontend_url = equivalent_frontend_url( $wp_url );
+
+		$this->assertStringStartsWith( 'http://', $frontend_url );
+	}
+
 	public function test_normalize_sitemap_entry_replaces_frontend_uri_with_home_url() {
 		$frontend_post_url = $this->init_settings['frontend_uri'] . '/posts/hello-world/';
 


### PR DESCRIPTION
## Tasks

- [ ] I have signed a [Contributor License Agreement (CLA)](https://github.com/wpengine/faustjs#contributor-license-agreement) with WP Engine.

## Description
This PR fixes the bug when the frontend_uri scheme is different than the get_site_url() scheme so that previews won't work when using the link from the Block editor.

<!--
Include a summary of the change and some contextual information.
-->

## Related Issue(s):

<!--
Provide the GitHub issue(s) number for issue tracking purposes, use the following syntax:

- #1234
-->

## Testing

1. Set the "Front-end site URL" setting to match the Next.js dev server e.g. http://localhost:3000

2. Disable the "Post and Category URL rewrites" setting, save, flush rewrites

3; Observe that preview links begin with the correct http://localhost:3000 base

4. Enable the "Post and Category URL rewrites" setting, save, flush rewrites

5 Observe that preview links are replaced with the correct http://localhost:3000 base, which will not resolve


<!--
Describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Also list any relevant details for your test configuration such as how to test the changes locally or in staging.
-->

## Screenshots

<!--
If this is a visual change include relevant screenshots about the behavior of the application before and after this change.
-->

## Documentation Changes

<!--
List corresponding changes to the documentation.
-->

## Dependant PRs

<!--
List any dependent PR's that are awaiting review. Use the following syntax:

- #1234
-->
