### PR TITLE
Bump WP tested up to 6.2

### DIFF
--- a/plugins/faustwp/readme.txt
+++ b/plugins/faustwp/readme.txt
@@ -2,7 +2,7 @@
 Contributors: antpb, apmatthe, blakewpe, chriswiegman, claygriffiths, jasonkonen, joefusco, markkelnar, matthewguywright, mindctrl, modernnerd, rfmeier, TeresaGobble, thdespou, wpengine
 Tags: faustjs, faust, headless, decoupled
 Requires at least: 5.7
-Tested up to: 6.1
+Tested up to: 6.2
 Stable tag: 0.8.3
 Requires PHP: 7.2
 License: GPLv2 or later


### PR DESCRIPTION
## Tasks

- [X] I have signed a [Contributor License Agreement (CLA)](https://github.com/wpengine/faustjs#contributor-license-agreement) with WP Engine.

## Description

These changes update the "tested up to value" for the Faust WordPress plugin after testing the plugin within 6.2-RC5.

**No Changeset found** is intentional as there are no code changes here.
This might have to wait for some code changes to push this update into SVN.

## Relevant PRs

- See https://github.com/wpengine/faustjs/pull/875