### PR TITLE
Pass data and variables in next helpers

### DIFF
--- a/.changeset/lucky-islands-deny.md
+++ b/.changeset/lucky-islands-deny.md
@@ -1,0 +1,5 @@
+---
+'@faustwp/core': patch
+---
+
+Return `data` in props from Next.js pages that use the `getNextStaticProps`/`getNextServerSideProps` Faust helper functions

--- a/.changeset/sweet-seas-appear.md
+++ b/.changeset/sweet-seas-appear.md
@@ -1,0 +1,24 @@
+---
+'@faustwp/core': patch
+---
+
+Create `FaustPage<Data, Props>` TypeScript type for Next.js pages that use Faust helpers:
+
+```tsx
+import { FaustPage } from '@faustwp/core';
+
+type GetPageData = {
+  generalSettings: {
+    title: string;
+  };
+};
+
+type PageProps = {
+  myProp: string;
+};
+
+const Page: FaustPage<GetPageData, PageProps> = (props) => {
+  const { myProp, data } = props;
+  return <></>;
+};
+```

--- a/packages/faustwp-core/src/getProps.ts
+++ b/packages/faustwp-core/src/getProps.ts
@@ -52,14 +52,27 @@ export async function getNextStaticProps<Props>(
     };
   }
 
+  const pageVariables = Page?.variables ? Page?.variables(context) : undefined;
+
+  let pageQueryRes;
   if (Page.query) {
-    await apolloClient.query({
+    pageQueryRes = await apolloClient.query({
       query: Page.query,
-      variables: Page?.variables ? Page?.variables(context) : undefined,
+      variables: pageVariables,
     });
   }
 
-  const pageProps = addApolloState(apolloClient, { props: { ...props } });
+  let returnedProps = { ...props };
+
+  if (pageQueryRes?.data) {
+    returnedProps = { ...returnedProps, data: pageQueryRes.data };
+  }
+
+  if (pageVariables) {
+    returnedProps = { ...returnedProps, __PAGE_VARIABLES: pageVariables };
+  }
+
+  const pageProps = addApolloState(apolloClient, { props: returnedProps });
   pageProps.revalidate = revalidate ?? DEFAULT_ISR_REVALIDATE;
   return pageProps as GetStaticPropsResult<Props>;
 }
@@ -92,15 +105,27 @@ export async function getNextServerSideProps<Props>(
     };
   }
 
+  const pageVariables = Page?.variables ? Page?.variables(context) : undefined;
+
+  let pageQueryRes;
   if (Page.query) {
-    await apolloClient.query({
+    pageQueryRes = await apolloClient.query({
       query: Page.query,
-      variables: Page?.variables ? Page?.variables(context) : undefined,
+      variables: pageVariables,
     });
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+  let returnedProps = { ...props };
+
+  if (pageQueryRes?.data) {
+    returnedProps = { ...returnedProps, data: pageQueryRes.data };
+  }
+
+  if (pageVariables) {
+    returnedProps = { ...returnedProps, __PAGE_VARIABLES: pageVariables };
+  }
+
   return addApolloState(apolloClient, {
-    props: { ...props },
+    props: returnedProps,
   }) as GetServerSidePropsResult<Props>;
 }

--- a/packages/faustwp-core/src/getProps.ts
+++ b/packages/faustwp-core/src/getProps.ts
@@ -16,7 +16,9 @@ export interface GetNextServerSidePropsConfig<Props = Record<string, unknown>> {
     query?: DocumentNode;
     variables?: (
       context: GetStaticPropsContext | GetServerSidePropsContext,
-    ) => { [key: string]: any };
+    ) => {
+      [key: string]: any;
+    };
   };
   props?: Props;
   notFound?: true;
@@ -26,6 +28,16 @@ export interface GetNextServerSidePropsConfig<Props = Record<string, unknown>> {
 export interface GetNextStaticPropsConfig<Props = Record<string, unknown>>
   extends GetNextServerSidePropsConfig<Props> {
   revalidate?: number | boolean;
+}
+
+export interface FaustPage<Data, Props = void>
+  extends React.FC<
+    { data?: Data; __PAGE_VARIABLES__?: { [key: string]: any } } & Props
+  > {
+  query?: DocumentNode;
+  variables?: (context: GetStaticPropsContext | GetServerSidePropsContext) => {
+    [key: string]: any;
+  };
 }
 
 /**
@@ -69,7 +81,7 @@ export async function getNextStaticProps<Props>(
   }
 
   if (pageVariables) {
-    returnedProps = { ...returnedProps, __PAGE_VARIABLES: pageVariables };
+    returnedProps = { ...returnedProps, __PAGE_VARIABLES__: pageVariables };
   }
 
   const pageProps = addApolloState(apolloClient, { props: returnedProps });
@@ -122,7 +134,7 @@ export async function getNextServerSideProps<Props>(
   }
 
   if (pageVariables) {
-    returnedProps = { ...returnedProps, __PAGE_VARIABLES: pageVariables };
+    returnedProps = { ...returnedProps, __PAGE_VARIABLES__: pageVariables };
   }
 
   return addApolloState(apolloClient, {

--- a/packages/faustwp-core/src/index.ts
+++ b/packages/faustwp-core/src/index.ts
@@ -4,7 +4,11 @@ import {
   FaustTemplateProps,
 } from './components/WordPressTemplate.js';
 import { getWordPressProps, FaustTemplate } from './getWordPressProps.js';
-import { getNextStaticProps, getNextServerSideProps } from './getProps.js';
+import {
+  getNextStaticProps,
+  getNextServerSideProps,
+  FaustPage,
+} from './getProps.js';
 import { getConfig, setConfig, FaustConfig } from './config/index.js';
 import { ensureAuthorization } from './auth/index.js';
 import { authorizeHandler, logoutHandler, apiRouter } from './server/index.js';
@@ -75,4 +79,5 @@ export {
   ToolbarSubmenu,
   ToolbarSubmenuWrapper,
   FaustTemplate,
+  FaustPage,
 };


### PR DESCRIPTION
## Tasks

- [x] I have signed a [Contributor License Agreement (CLA)](https://github.com/wpengine/faustjs#contributor-license-agreement) with WP Engine.

## Description

This PR adds the Next.js file based page's query response as `props.data` in both `getNextServerSideProps` and `getNextStaticProps`

Additionally, adds a `FaustPage` type much like `FaustTemplate` to help properly type Next.js pages that use Faust helpers.

<!--
Include a summary of the change and some contextual information.
-->

## Related Issue(s):

<!--
Provide the GitHub issue(s) number for issue tracking purposes, use the following syntax:

- #1234
-->

## Testing

1. Checkout this PR
2. Build core `npm run build -w @faustwp/core`
3. Run the example project `npm run dev -w @faustwp/getting-started-example`
4. In the `example.js` page, console.log the `props`
5. Notice that there is now `props.data` which includes the `Page.query`'s data, and `__PAGE_VARIABLES__` prop, which includes the computed variables (this value should not really be used, but we include it just in case to be compatible with the Faust Templates)
<img width="1457" alt="Screenshot 2023-03-29 at 3 41 24 PM" src="https://user-images.githubusercontent.com/5946219/228662367-425b4e94-aa51-4bba-9bb6-3a1838ec8cf6.png">


<!--
Describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Also list any relevant details for your test configuration such as how to test the changes locally or in staging.
-->

## Screenshots

<!--
If this is a visual change include relevant screenshots about the behavior of the application before and after this change.
-->

## Documentation Changes

<!--
List corresponding changes to the documentation.
-->

## Dependant PRs

<!--
List any dependent PR's that are awaiting review. Use the following syntax:

- #1234
-->
