### PR TITLE
Expose hooks in Faust Core

### DIFF
--- a/.changeset/popular-melons-fold.md
+++ b/.changeset/popular-melons-fold.md
@@ -1,0 +1,5 @@
+---
+'@faustwp/core': patch
+---
+
+Expose `hooks` in `@faustwp/core` so other packages can register their own filters and actions

--- a/packages/faustwp-core/src/index.ts
+++ b/packages/faustwp-core/src/index.ts
@@ -22,7 +22,7 @@ import {
   getApolloAuthClient,
   addApolloState,
 } from './client.js';
-import { FaustPlugin } from './wpHooks/index.js';
+import { FaustPlugin, hooks } from './wpHooks/index.js';
 import { FaustHooks } from './wpHooks/overloads.js';
 import {
   getSitemapProps,
@@ -80,4 +80,5 @@ export {
   ToolbarSubmenuWrapper,
   FaustTemplate,
   FaustPage,
+  hooks,
 };


### PR DESCRIPTION
## Tasks

- [x] I have signed a [Contributor License Agreement (CLA)](https://github.com/wpengine/faustjs#contributor-license-agreement) with WP Engine.

## Description

Expose the `hooks` from the plugin system so other packages can register their own filters and actions.

For example:

```js
import {hooks} from '@faustwp/core'

function MyPackageLogic() {
  let items = [];

  items = hooks.addFilter('myFilter', items)

  return items;
}
```

<!--
Include a summary of the change and some contextual information.
-->

## Related Issue(s):

<!--
Provide the GitHub issue(s) number for issue tracking purposes, use the following syntax:

- #1234
-->

## Testing

<!--
Describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Also list any relevant details for your test configuration such as how to test the changes locally or in staging.
-->

## Screenshots

<!--
If this is a visual change include relevant screenshots about the behavior of the application before and after this change.
-->

## Documentation Changes

<!--
List corresponding changes to the documentation.
-->

## Dependant PRs

<!--
List any dependent PR's that are awaiting review. Use the following syntax:

- #1234
-->
