### PR TITLE
Docs: Clarify usage of `displayName` on production builds

### DIFF
--- a/internal/faustjs.org/docs/gutenberg/getting-started.mdx
+++ b/internal/faustjs.org/docs/gutenberg/getting-started.mdx
@@ -109,7 +109,7 @@ CoreParagraph.displayName = 'CoreParagraph';
 :::note
 
 We added a `displayName` property here to make sure that the `__typename` of the block matches this value.
-For production builds, it is required to use either a `displayName="NameOfBlock"` or a `config.name="NameOfBlock"` properties for the block to resolve successfully.
+For production builds, it is required to use either a `displayName="NameOfBlock"` or a `config.name="NameOfBlock"` properties for the block to resolve and render properly.
 
 :::
 

--- a/internal/faustjs.org/docs/gutenberg/getting-started.mdx
+++ b/internal/faustjs.org/docs/gutenberg/getting-started.mdx
@@ -53,7 +53,7 @@ const blocks = flatListToHierarchical(editorBlocks);
 return <WordPressBlocksViewer blocks={blocks}/>
 ```
 
-Example `editorBlocks` GraphQL query fragment. 
+Example `editorBlocks` GraphQL query fragment.
 
 ```graphql
 ${components.CoreParagraph.fragments.entry}
@@ -100,15 +100,30 @@ CoreParagraph.fragments = {
   `,
   key: `CoreParagraphFragment`,
 };
+
+CoreParagraph.displayName = 'CoreParagraph';
+// This also works
+// CoreParagraph.config.name = 'CoreParagraph'
 ```
 
-`import` and `export default` the `CoreParagraph` Block in `wp-blocks/index.js`:
+:::note
+
+We added a `displayName` property here to make sure that the `__typename` of the block matches this value.
+For production builds, it is required to use either a `displayName="NameOfBlock"` or a `config.name="NameOfBlock"` properties for the block to resolve successfully.
+
+:::
+
+
+Export the block in `wp-blocks/index.js`:
+
 ```js
 import CoreParagraph from './CoreParagraph';
 export default {
   CoreParagraph,
 };
 ```
+
+
 
 ## Further Learning
 

--- a/internal/faustjs.org/docs/gutenberg/tutorial/create-a-block-from-third-party.mdx
+++ b/internal/faustjs.org/docs/gutenberg/tutorial/create-a-block-from-third-party.mdx
@@ -117,9 +117,20 @@ export default function UbCallToActionBlock(props) {
   console.log(props.attributes);
   return <div>UbCallToActionBlock</div>
 }
+
+UbCallToActionBlock.displayName = 'UbCallToActionBlock';
+// This also works
+// UbCallToActionBlock.config.name = 'UbCallToActionBlock'
 ```
 
 This component prints the block attributes via the props passed as a parameter.
+
+:::note
+
+We added a `displayName` property here to make sure that the `__typename` of the block matches this value.
+For production builds, it is required to use either a `displayName="NameOfBlock"` or a `config.name="NameOfBlock"` properties for the block to resolve successfully.
+
+:::
 
 ### 6.2 Export the block in the `index.js`
 
@@ -130,7 +141,7 @@ export default {
 }
 ```
 
-By exporting the block in the `index.js` we make it available in the WordPressBlocksProvider.
+By exporting the block in the `index.js` we make it available in the `WordPressBlocksProvider`.
 You can also use a different name as long as it matches either the Block `name` or the `__typename` fields.
 
 This also works:
@@ -362,6 +373,8 @@ export default function UbCallToActionBlock(props) {
     </div>
   );
 }
+
+UbCallToActionBlock.displayName = 'UbCallToActionBlock';
 ```
 
 Don't forget to include the global scss for the block so that the right styles are applied.

--- a/internal/faustjs.org/docs/gutenberg/tutorial/create-a-block-from-third-party.mdx
+++ b/internal/faustjs.org/docs/gutenberg/tutorial/create-a-block-from-third-party.mdx
@@ -128,7 +128,7 @@ This component prints the block attributes via the props passed as a parameter.
 :::note
 
 We added a `displayName` property here to make sure that the `__typename` of the block matches this value.
-For production builds, it is required to use either a `displayName="NameOfBlock"` or a `config.name="NameOfBlock"` properties for the block to resolve successfully.
+For production builds, it is required to use either a `displayName="NameOfBlock"` or a `config.name="NameOfBlock"` properties for the block to resolve and render properly.
 
 :::
 

--- a/internal/faustjs.org/docs/gutenberg/tutorial/create-a-block-from-wordpress-core.mdx
+++ b/internal/faustjs.org/docs/gutenberg/tutorial/create-a-block-from-wordpress-core.mdx
@@ -147,7 +147,7 @@ CoreCode.displayName = 'CoreCode';
 :::note
 
 We added a `displayName` property here to make sure that the `__typename` of the block matches this value.
-For production builds, it is required to use either a `displayName="NameOfBlock"` or a `config.name="NameOfBlock"` properties for the block to resolve successfully.
+For production builds, it is required to use either a `displayName="NameOfBlock"` or a `config.name="NameOfBlock"` properties for the block to resolve and render properly.
 
 :::
 

--- a/internal/faustjs.org/docs/gutenberg/tutorial/create-a-block-from-wordpress-core.mdx
+++ b/internal/faustjs.org/docs/gutenberg/tutorial/create-a-block-from-wordpress-core.mdx
@@ -138,7 +138,18 @@ export default function CoreCode(props) {
   console.log(props.attributes);
   return <div>CoreCode</div>;
 }
+
+CoreCode.displayName = 'CoreCode';
+// This also works
+// CoreCode.config.name = 'CoreCode'
 ```
+
+:::note
+
+We added a `displayName` property here to make sure that the `__typename` of the block matches this value.
+For production builds, it is required to use either a `displayName="NameOfBlock"` or a `config.name="NameOfBlock"` properties for the block to resolve successfully.
+
+:::
 
 This component logs the block attributes to the console via the `attributes` prop passed through the `props` parameter.
 
@@ -473,6 +484,7 @@ CoreCode.fragments = {
     }
   `,
 };
+CoreCode.displayName = 'CoreCode';
 ```
 
 <img

--- a/internal/faustjs.org/docs/gutenberg/tutorial/create-a-custom-block.mdx
+++ b/internal/faustjs.org/docs/gutenberg/tutorial/create-a-custom-block.mdx
@@ -17,11 +17,11 @@ Before beginning, take stock of your activated plugins in your WordPress instanc
 
 In this tutorial, we will assume that you do not have a preexisting block in mind to use with your Decoupled site. If you have a block you want to emulate from the WordPress core blocks library, head to our [tutorial](/docs/gutenberg/tutorial/create-a-block-from-wordpress-core.mdx) to learn how to do exactly that. Likewise, if you need to recreate a block used by a third party plugin, we have a [tutorial](/docs/gutenberg/tutorial/create-a-block-from-third-party.mdx) tailored for that process, too.
 
-This tutorial assumes that you begin your block creation from nothing at all, which will therefore require a slightly different set of steps. 
+This tutorial assumes that you begin your block creation from nothing at all, which will therefore require a slightly different set of steps.
 
-:::tip 
+:::tip
 
-Check out all the components that are available to you through the [@wordpress/components](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-components/) library as you think about what you want your custom block to do and look like. 
+Check out all the components that are available to you through the [@wordpress/components](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-components/) library as you think about what you want your custom block to do and look like.
 
 :::
 
@@ -118,7 +118,18 @@ export default function MyCoolBlock(props) {
   console.log(props.attributes);
   return <div>MyCoolBlock</div>
 }
+
+MyCoolBlock.displayName = 'MyCoolBlock';
+// This also works
+// MyCoolBlock.config.name = 'MyCoolBlock'
 ```
+
+:::note
+
+We added a `displayName` property here to make sure that the `__typename` of the block matches this value.
+For production builds, it is required to use either a `displayName="NameOfBlock"` or a `config.name="NameOfBlock"` properties for the block to resolve successfully.
+
+:::
 
 This component prints the block attributes via the props passed as a parameter. This will help us understand what is happening a little later on.
 
@@ -133,7 +144,7 @@ export default {
 }
 ```
 
-By exporting the block in the `index.js`, we make it available in the `WordPressBlocksProvider`, which gives the proper context (i.e., which blocks have been defined as apart of your Faust app) to the `WordPressBlocksViewer` component. Read more about the WordPressBlocksProvider [here](http://localhost:3000/docs/reference/WordPressBlocksProvider). 
+By exporting the block in the `index.js`, we make it available in the `WordPressBlocksProvider`, which gives the proper context (i.e., which blocks have been defined as apart of your Faust app) to the `WordPressBlocksViewer` component. Read more about the WordPressBlocksProvider [here](http://localhost:3000/docs/reference/WordPressBlocksProvider).
 
 ### 4.3 Create the block fragment
 
@@ -242,6 +253,7 @@ export default function MyCoolBlock(props) {
     </pre>
   );
 }
+MyCoolBlock.displayName = 'MyCoolBlock';
 ```
 
 Now that you have the styles ported over, you can navigate into the Headless site's page and check that the block matches the styling you wish. Make sure to tweak the block in the editor and verify that the changes you want are being reflected here, too.

--- a/internal/faustjs.org/docs/gutenberg/tutorial/create-a-custom-block.mdx
+++ b/internal/faustjs.org/docs/gutenberg/tutorial/create-a-custom-block.mdx
@@ -127,7 +127,7 @@ MyCoolBlock.displayName = 'MyCoolBlock';
 :::note
 
 We added a `displayName` property here to make sure that the `__typename` of the block matches this value.
-For production builds, it is required to use either a `displayName="NameOfBlock"` or a `config.name="NameOfBlock"` properties for the block to resolve successfully.
+For production builds, it is required to use either a `displayName="NameOfBlock"` or a `config.name="NameOfBlock"` properties for the block to resolve and render properly.
 
 :::
 


### PR DESCRIPTION
## Tasks

- [x] I have signed a [Contributor License Agreement (CLA)](https://github.com/wpengine/faustjs#contributor-license-agreement) with WP Engine.

## Description

This PR adds several note sections in the docs, clarifying the use of declaring `displayName` and `config.name` properties in Block Components.

This is to ensure any production build does resolve to the correct blocks instead of rendering the DefaultBlock.
<!--
Include a summary of the change and some contextual information.
-->

## Related Issue(s):

<!--
Provide the GitHub issue(s) number for issue tracking purposes, use the following syntax:

- #1234
-->

## Testing

<!--
Describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Also list any relevant details for your test configuration such as how to test the changes locally or in staging.
-->

## Screenshots

<!--
If this is a visual change include relevant screenshots about the behavior of the application before and after this change.
-->

## Documentation Changes

Changes in all Gutenberg doc pages when declaring block component code.
<!--
List corresponding changes to the documentation.
-->

## Dependant PRs

<!--
List any dependent PR's that are awaiting review. Use the following syntax:

- #1234
-->
