### PR TITLE
Docs: Add example with `BlockWithSupportsAnchor`

### DIFF
--- a/internal/faustjs.org/docs/gutenberg/how-to-query-blocks.mdx
+++ b/internal/faustjs.org/docs/gutenberg/how-to-query-blocks.mdx
@@ -269,3 +269,58 @@ query GetAllPostsWhichSupportPageEditorBlocks {
   }
 }
 ```
+
+## BlockWithSupportsAnchor
+
+* An interface type which represents a single block that supports an anchor field.
+* This is registered for every block that contains the following [supports](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-supports/#anchor) config in their `block.json`.
+
+```json title="block.json"
+supports: {
+    anchor: true
+}
+```
+
+Here is an example query:
+
+```graphql title="GraphQL"
+nodeByUri(uri: "/posts/hello-world") {
+    ... on NodeWithPostEditorBlocks {
+      editorBlocks {
+        name
+        ... on BlockWithSupportsAnchor {
+          anchor
+        }
+      }
+    }
+  }
+```
+
+And here is a result assuming that one paragraph has an `anchor` field set as "hello-world":
+
+```json
+{
+  "data": {
+    "nodeByUri": {
+      "editorBlocks": [
+        {
+          "name": "core/paragraph",
+          "anchor": "hello-world"
+        },
+        {
+          "name": "core/columns",
+          "anchor": null
+        },
+        {
+          "name": "core/column",
+          "anchor": null
+        },
+        {
+          "name": "core/paragraph",
+          "anchor": null
+        },
+	  ]
+    }
+  },
+}
+```

--- a/internal/faustjs.org/docs/gutenberg/how-to-query-blocks.mdx
+++ b/internal/faustjs.org/docs/gutenberg/how-to-query-blocks.mdx
@@ -324,3 +324,22 @@ And here is a result assuming that one paragraph has an `anchor` field set as "h
   },
 }
 ```
+
+:::note
+
+The `BlockWithSupportsAnchor` will be attached to both the block and the block attributes object, so you can request this field from both places as well:
+
+```graphql
+editorBlocks {
+    name
+    ... on CoreParagraph {
+		# Request from the block itself
+        anchor
+		attributes {
+			# Request from the block attributes object
+        	anchor
+		}
+    }
+}
+```
+:::


### PR DESCRIPTION
## Tasks

- [x] I have signed a [Contributor License Agreement (CLA)](https://github.com/wpengine/faustjs#contributor-license-agreement) with WP Engine.

## Description
Adds sections in the `how-to-query-blocks` page about using the new `BlockWithSupportsAnchor` interface.

<!--
Include a summary of the change and some contextual information.
-->

## Related Issue(s):

<!--
Provide the GitHub issue(s) number for issue tracking purposes, use the following syntax:

- #1234
-->

## Testing


<!--
Describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Also list any relevant details for your test configuration such as how to test the changes locally or in staging.
-->

## Screenshots
<img width="1088" alt="Screenshot 2023-04-18 at 13 06 53" src="https://user-images.githubusercontent.com/328805/232772959-95b91f50-0ed4-4fd2-bcb4-c0ea97d28472.png">
<!--
If this is a visual change include relevant screenshots about the behavior of the application before and after this change.
-->

## Documentation Changes
* Updated `docs/gutenberg/how-to-query-blocks`
<!--
List corresponding changes to the documentation.
-->

## Dependant PRs

<!--
List any dependent PR's that are awaiting review. Use the following syntax:

- #1234
-->
