### PR TITLE
Add `resolvedUrl` filter for modifying the resolved URL in the Faust template system

### DIFF
--- a/.changeset/swift-impalas-kneel.md
+++ b/.changeset/swift-impalas-kneel.md
@@ -1,0 +1,5 @@
+---
+'@faustwp/core': patch
+---
+
+Add `resolvedUrl` filter for modifying the resolved URL in the Faust template system

--- a/internal/faustjs.org/docs/plugin-system/filters.mdx
+++ b/internal/faustjs.org/docs/plugin-system/filters.mdx
@@ -187,7 +187,7 @@ Allows you to override the resolved URL in the Faust template system.
 
 ### Context Object
 
-- `nextContext`: GetServerSidePropsContext | GetStaticPropsContext`: The Next.js context object from either `getServerSideProps`or`getStaticProps`
+- `nextContext: GetServerSidePropsContext | GetStaticPropsContext`: The Next.js context object from either `getServerSideProps`or`getStaticProps`
 
 ### Signature
 

--- a/internal/faustjs.org/docs/plugin-system/filters.mdx
+++ b/internal/faustjs.org/docs/plugin-system/filters.mdx
@@ -180,3 +180,27 @@ Allows you to modify Faust's Toolbar nodes.
     priority?: number | undefined,
   ): void;
 ```
+
+## resolvedUrl
+
+Allows you to override the resolved URL in the Faust template system.
+
+### Context Object
+
+- `nextContext`: GetServerSidePropsContext | GetStaticPropsContext`: The Next.js context object from either `getServerSideProps`or`getStaticProps`
+
+### Signature
+
+```tsx
+addFilter(
+  hookName: 'resolvedUrl',
+  namespace: string,
+  callback: (
+    resolvedUrl: string | null,
+    context: {
+      nextContext: GetServerSidePropsContext | GetStaticPropsContext;
+    },
+  ) => string | null,
+  priority?: number | undefined,
+): void;
+```

--- a/packages/faustwp-core/src/getWordPressProps.tsx
+++ b/packages/faustwp-core/src/getWordPressProps.tsx
@@ -71,6 +71,10 @@ export async function getWordPressProps(
     ctx.res.setHeader('x-using', 'faust');
   }
 
+  resolvedUrl = hooks.applyFilters('resolvedUrl', resolvedUrl, {
+    nextContext: ctx,
+  }) as string | null;
+
   if (!resolvedUrl) {
     return {
       notFound: true,

--- a/packages/faustwp-core/src/wpHooks/overloads.ts
+++ b/packages/faustwp-core/src/wpHooks/overloads.ts
@@ -5,9 +5,9 @@ import {
   NormalizedCacheObject,
 } from '@apollo/client';
 import { _Hooks } from '@wordpress/hooks/build-types/createHooks.js';
+import { GetServerSidePropsContext, GetStaticPropsContext } from 'next';
 import { FaustToolbarNodes } from '../components/Toolbar/index.js';
 import { SeedNode } from '../queries/seedQuery.js';
-import { GetServerSidePropsContext, GetStaticPropsContext } from 'next';
 
 type FaustCoreFilters = {
   addFilter(

--- a/packages/faustwp-core/src/wpHooks/overloads.ts
+++ b/packages/faustwp-core/src/wpHooks/overloads.ts
@@ -7,6 +7,7 @@ import {
 import { _Hooks } from '@wordpress/hooks/build-types/createHooks.js';
 import { FaustToolbarNodes } from '../components/Toolbar/index.js';
 import { SeedNode } from '../queries/seedQuery.js';
+import { GetServerSidePropsContext, GetStaticPropsContext } from 'next';
 
 type FaustCoreFilters = {
   addFilter(
@@ -77,6 +78,18 @@ type FaustCoreFilters = {
       toolbarNodes: FaustToolbarNodes,
       context: { seedNode?: SeedNode },
     ) => string,
+    priority?: number | undefined,
+  ): void;
+
+  addFilter(
+    hookName: 'resolvedUrl',
+    namespace: string,
+    callback: (
+      resolvedUrl: string | null,
+      context: {
+        nextContext: GetServerSidePropsContext | GetStaticPropsContext;
+      },
+    ) => string | null,
     priority?: number | undefined,
   ): void;
 };


### PR DESCRIPTION
## Tasks

- [x] I have signed a [Contributor License Agreement (CLA)](https://github.com/wpengine/faustjs#contributor-license-agreement) with WP Engine.

## Description

This filter allows you to modify the resolved URL in the Faust template system, say for instance, adding or striping a locale from a URL.

<!--
Include a summary of the change and some contextual information.
-->

## Related Issue(s):

<!--
Provide the GitHub issue(s) number for issue tracking purposes, use the following syntax:

- #1234
-->

## Testing

<!--
Describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Also list any relevant details for your test configuration such as how to test the changes locally or in staging.
-->

## Screenshots

<!--
If this is a visual change include relevant screenshots about the behavior of the application before and after this change.
-->

## Documentation Changes

<!--
List corresponding changes to the documentation.
-->

## Dependant PRs

<!--
List any dependent PR's that are awaiting review. Use the following syntax:

- #1234
-->
