### PR TITLE
Add support for querying the WordPress global stylesheet

### DIFF
--- a/.changeset/bright-bugs-cry.md
+++ b/.changeset/bright-bugs-cry.md
@@ -1,0 +1,5 @@
+---
+'@faustwp/cli': patch
+---
+
+Added new command `faust generateGlobalStyles` which adds the connected WordPress site's global stylesheet to the root of your project.

--- a/.changeset/loud-cars-knock.md
+++ b/.changeset/loud-cars-knock.md
@@ -1,0 +1,5 @@
+---
+'@faustwp/wordpress-plugin': patch
+---
+
+Registered a new GraphQL field, `globalStylesheet`, that returns [wp_get_global_stylesheet](https://developer.wordpress.org/reference/functions/wp_get_global_stylesheet/) and provides the same arguments as the core WordPress function.

--- a/audit-ci.jsonc
+++ b/audit-ci.jsonc
@@ -1,7 +1,5 @@
 {
-  "$schema": "https://github.com/IBM/audit-ci/raw/main/docs/schema.json",
-  "moderate": true,
-  "allowlist": [
-    "json5"
-  ]
+	"$schema": "https://github.com/IBM/audit-ci/raw/main/docs/schema.json",
+	"moderate": true,
+	"allowlist": []
 }

--- a/internal/faustjs.org/docs/global-stylesheet.mdx
+++ b/internal/faustjs.org/docs/global-stylesheet.mdx
@@ -1,0 +1,24 @@
+---
+slug: global-stylesheet
+title: Global Stylesheet
+description: Strategies for adding the WordPress global stylesheet to your application
+---
+
+The [Faust.js WordPress plugin](https://wordpress.org/plugins/faustwp) adds the ability to query the WordPress global stylesheet using the `globalStylesheet` field.
+
+## WordPress global styles at build time
+
+The WordPress global stylesheet can be grabbed at build time by using the `faust generateGlobalStylesheet` command.
+This will create a new file named `globalStylesheet.css` in the root of your application.
+
+Example
+
+```json title="package.json"
+scripts": {
+    "dev": "faust dev",
+    "build": "faust build",
+    "generate": "faust generatePossibleTypes && faust generateGlobalStylesheet",
+    "start": "faust start",
+    ...
+}
+```

--- a/internal/faustjs.org/sidebars.js
+++ b/internal/faustjs.org/sidebars.js
@@ -83,6 +83,11 @@ module.exports = {
         },
         {
           type: 'doc',
+          label: 'Global Stylesheet',
+          id: 'global-stylesheet',
+        },
+        {
+          type: 'doc',
           label: 'API Router',
           id: 'next/reference/api-router',
         },

--- a/packages/faustwp-cli/src/generateGlobalStylesheet.ts
+++ b/packages/faustwp-cli/src/generateGlobalStylesheet.ts
@@ -1,0 +1,59 @@
+import 'isomorphic-fetch';
+import fs from 'fs';
+
+import { infoLog, errorLog, debugLog } from './stdout/index.js';
+import { getGraphqlEndpoint, getWpUrl } from './utils/index.js';
+
+export async function generateGlobalStylesheet(): Promise<void> {
+  const graphqlEndpoint = getGraphqlEndpoint();
+
+  try {
+    const response: Response = await fetch(graphqlEndpoint, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        variables: {},
+        query: `
+        {
+            globalStylesheet
+        }
+        `,
+      }),
+    });
+
+    const json: {
+      data: { globalStylesheet: string };
+      errors?: {
+        message: string;
+      }[];
+    } = await response.json();
+
+    if (json.errors) {
+      const errors = json.errors.map((error) => {
+        return error.message;
+      });
+
+      throw new Error(
+        `There were errors in the GraphQL request: ${errors.join(', ')}`,
+      );
+    }
+
+    fs.writeFileSync('./globalStylesheet.css', json.data.globalStylesheet);
+
+    infoLog("This project's globalStylesheet.css has been updated!");
+  } catch (err) {
+    debugLog(
+      `"faust generateGlobalStylesheet" failed with the following error: `,
+      err,
+    );
+
+    errorLog("Unable to update this project's globalStylesheet.css");
+    errorLog(
+      `Make sure you have "Enable Public Introspection" checked in WPGraphQL: ${getWpUrl()}/wp-admin/admin.php?page=graphql-settings`,
+    );
+
+    process.exit(0);
+  }
+}

--- a/packages/faustwp-cli/src/index.ts
+++ b/packages/faustwp-cli/src/index.ts
@@ -6,6 +6,7 @@ import { v4 as uuid } from 'uuid';
 import { debugLog, infoLog } from './stdout/index.js';
 import { healthCheck } from './healthCheck/index.js';
 import { generatePossibleTypes } from './generatePossibleTypes.js';
+import { generateGlobalStylesheet } from './generateGlobalStylesheet.js';
 import { userConfig } from './userConfig.js';
 import { getCliArgs, getWpSecret, getWpUrl, isDebug } from './utils/index.js';
 import {
@@ -74,6 +75,12 @@ import {
     }
     case 'generatePossibleTypes': {
       await generatePossibleTypes();
+      process.exit(0);
+
+      break;
+    }
+    case 'generateGlobalStylesheet': {
+      await generateGlobalStylesheet();
       process.exit(0);
 
       break;

--- a/plugins/faustwp/faustwp.php
+++ b/plugins/faustwp/faustwp.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * Plugin Name: Faust
+ * Plugin Name: Faust.js™
  * Plugin URI: https://faustjs.org/
- * Description: Plugin for working with Faust, the Headless WordPress Framework.
+ * Description: Plugin for working with Faust.js™, the Headless WordPress Framework.
  * Author: WP Engine
  * Author URI: https://wpengine.com/
  * License: GPLv2 or later

--- a/plugins/faustwp/includes/graphql/callbacks.php
+++ b/plugins/faustwp/includes/graphql/callbacks.php
@@ -72,6 +72,62 @@ function register_faust_toolbar_field() {
 	);
 }
 
+add_action( 'graphql_register_types', __NAMESPACE__ . '\\register_global_stylesheet_field' );
+/**
+ * Registers a field on the User model called "globalStylesheet" which
+ * returns the stylesheet resulting of merging core, theme, and user data.
+ *
+ * @return void
+ *
+ * @uses register_graphql_enum_type
+ * @uses register_graphql_field
+ * @uses wp_get_global_stylesheet
+ *
+ * @link https://developer.wordpress.org/reference/functions/wp_get_global_stylesheet/
+ */
+function register_global_stylesheet_field() {
+	register_graphql_enum_type(
+		'GlobalStylesheetTypesEnum',
+		array(
+			'description' => __( 'Types of styles to load', 'faustwp' ),
+			'values'      => array(
+				'VARIABLES'          => array(
+					'value' => 'variables',
+				),
+				'PRESETS'            => array(
+					'value' => 'presets',
+				),
+				'STYLES'             => array(
+					'value' => 'styles',
+				),
+				'BASE_LAYOUT_STYLES' => array(
+					'value' => 'base-layout-styles',
+				),
+			),
+		)
+	);
+
+	register_graphql_field(
+		'RootQuery',
+		'globalStylesheet',
+		array(
+			'type'        => 'String',
+			'args'        => array(
+				'types' => array(
+					'type'        => array( 'list_of' => 'GlobalStylesheetTypesEnum' ),
+					'description' => __( 'Types of styles to load.', 'faustwp' ),
+				),
+			),
+			'description' => __( 'Returns the stylesheet resulting of merging core, theme, and user data.', 'faustwp' ),
+			'resolve'     => function( $root, $args, $context, $info ) {
+				$types = $args['types'] ?? null;
+
+				return wp_get_global_stylesheet( $types );
+			},
+		)
+	);
+}
+
 /**
  * Resolver for getting the templates that will be loaded on a given node
  *

--- a/plugins/faustwp/readme.txt
+++ b/plugins/faustwp/readme.txt
@@ -1,6 +1,6 @@
-=== Faust ===
+=== Faust.js ===
 Contributors: antpb, apmatthe, blakewpe, chriswiegman, claygriffiths, jasonkonen, joefusco, markkelnar, matthewguywright, mindctrl, modernnerd, rfmeier, TeresaGobble, thdespou, wpengine
-Tags: faustjs, faust, headless, decoupled
+Tags: faustjs, faust, headless, decoupled, composable-architecture
 Requires at least: 5.7
 Tested up to: 6.2
 Stable tag: 0.8.5
@@ -8,11 +8,11 @@ Requires PHP: 7.2
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
-Faust transforms your traditional WordPress installation into a flexible headless CMS.
+Faust.js™ transforms your traditional WordPress installation into a flexible headless CMS.
 
 == Description ==
 
-In conjunction with the [Faust NPM packages](https://www.npmjs.com/search?q=%40faustwp), Faust enables a decoupled front-end to authenticate with WordPress through GraphQL mutations and REST API endpoints. It is the bridge between a Faust-powered front-end application, and a WordPress backend.
+In conjunction with the [Faust.js™ NPM packages](https://www.npmjs.com/search?q=%40faustwp), the Faust.js™ WordPress plugin enables a decoupled front-end to authenticate with WordPress through GraphQL mutations and REST API endpoints. It is the bridge between a Faust.js™ powered front-end application, and a WordPress backend.
 
 The plugin also provides useful options for headless sites, such as the ability to:
 
@@ -25,27 +25,27 @@ The plugin also provides useful options for headless sites, such as the ability 
 1. Search for the plugin in WordPress under "Plugins -> Add New".
 2. Click the “Install Now” button, followed by "Activate".
 
-That's it! For more information on getting started with headless WordPress, see [Getting Started with Faust](https://faustjs.org/docs/tutorial/dev-env-setup).
+That's it! For more information on getting started with headless WordPress, see [Getting Started with Faust.js](https://faustjs.org/docs/tutorial/dev-env-setup).
 
 == Frequently Asked Questions ==
 
 = If I need more support, where should I ask questions? =
-Use one of the channels below to contact the Faust team for support.
-[GitHub](https://github.com/wpengine/faustjs) - Faust GitHub documentation and codebase.
+Use one of the channels below to contact the Faust.js team for support.
+[GitHub](https://github.com/wpengine/faustjs) - Faust.js GitHub documentation and codebase.
 [Discord](https://discord.gg/J2khkF9XYK) - Interactive chat support on Discord.
 
 = Where can I find more information about development and future features for this plugin? =
 
-Great question! The development team posts weekly summaries of sprints related to Faust, [here](https://faustjs.org/blog).
+Great question! The development team posts weekly summaries of sprints related to Faust.js, [here](https://faustjs.org/blog).
 
-= Why the name “Faust”? =
+= Why the name “Faust.js”? =
 
 Johann Faust was a German printer and was instrumental in the invention of the printing press, along with his partner Johann Gutenberg. In the same way the printing press democratized the spread of information, the mission of Faust.js is to support and further the vision of WordPress to democratize publishing on the web.
 
 == Screenshots ==
 
 1. The settings page
-2. Portfolio, blog, and basic blueprints for headless sites built with Faust
+2. Portfolio, blog, and basic blueprints for headless sites built with Faust.js
 3. A code snippet
 
 plugins/faustwp/.wordpress-org/screenshot-1.png


### PR DESCRIPTION
## Tasks

- [X] I have signed a [Contributor License Agreement (CLA)](https://github.com/wpengine/faustjs#contributor-license-agreement) with WP Engine.

## Description

These changes registered a new GraphQL field, `globalStylesheet`, that returns [wp_get_global_stylesheet](https://developer.wordpress.org/reference/functions/wp_get_global_stylesheet/) and exposes the same arguments as the core WordPress function.

If no arguments are used, it'll load the following:
for themes without theme.json: `VARIABLES`, `PRESETS`, `BASE_LAYOUT_STYLES`.
for themes with theme.json: `VARIABLES`, `PRESETS`, `STYLES`.

These changes also include some legal adjustments to appropriately reference the Faust.js™ trademark.

## Testing

There is really no need for unit tests here as these changes are simply exposing WordPress core functionality.

1. Checkout this branch: `MERL-766-expose-global-css`
2. Query the global stylesheet without arguments
   ```
   query GlobalStylesheet {
     globalStylesheet
   }
   ```
3. Query the global stylesheet using a single argument
   ```
   query GlobalStylesheet {
     globalStylesheet(types: VARIABLES)
   }
   ```
4. Query the global stylesheet using multiple arguments
   ```
   query GlobalStylesheet {
     globalStylesheet(types: [VARIABLES, PRESETS])
   }
   ```

## Screenshots

<img width="1157" alt="Screenshot 2023-04-21 at 2 25 54 PM" src="https://user-images.githubusercontent.com/6676674/233709015-61943c52-6c07-4a5b-b59c-947f4cf0e662.png">