### PR TITLE
Fix Plugin Deploy / Add workflow to manually deploy plugin if needed

### DIFF
--- a/.github/workflows/deploy-plugin.yml
+++ b/.github/workflows/deploy-plugin.yml
@@ -1,0 +1,22 @@
+# NOTE: This workflow is only to be used if the plugin needs to be deployed manually.
+# Otherwise, changesets and the release-packages workflow should take care of 
+# deploying the plugin automatically.
+name: Deploy Plugin
+
+on:
+  workflow_dispatch:
+
+jobs:
+  deploy_plugin:
+    name: Deploy Plugin
+    runs-on: ubuntu-latest
+    steps:
+    - name: Deploy plugin to WordPress.org
+      # Use a variant of 10up/action-wordpress-plugin-deploy that allows us to specify a PLUGIN_DIR
+      # to support our monorepo structure.
+      uses: ./.github/actions/release-plugin
+      env:
+        SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
+        SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
+        PLUGIN_DIR: plugins/faustwp
+        SLUG: faustwp

--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -48,7 +48,7 @@ jobs:
         # If there is a published package named "@faustwp/wordpress-plugin"
         # Then deploy the WordPress plugin
         # https://github.com/changesets/action#outputs
-        if: contains(steps.changesets.outputs.publishedPackages.*.name, '@faustwp/wordpress-plugin')
+        if: contains(fromJSON(steps.changesets.outputs.publishedPackages).*.name, '@faustwp/wordpress-plugin')
         # Use a variant of 10up/action-wordpress-plugin-deploy that allows us to specify a PLUGIN_DIR
         # to support our monorepo structure.
         uses: ./.github/actions/release-plugin


### PR DESCRIPTION
## Tasks

- [x] I have signed a [Contributor License Agreement (CLA)](https://github.com/wpengine/faustjs#contributor-license-agreement) with WP Engine.

## Description

This PR fixes automatic plugin deployments from changesets, and also creates a workflow that can be invoked manually via the "actions" tab in GitHub.

<!--
Include a summary of the change and some contextual information.
-->

## Related Issue(s):

<!--
Provide the GitHub issue(s) number for issue tracking purposes, use the following syntax:

- #1234
-->

## Testing

Testing was done in my private GitHub repo for changesets testing and I can confirm that the conditional statement worked as expected.

<!--
Describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Also list any relevant details for your test configuration such as how to test the changes locally or in staging.
-->

## Screenshots

<!--
If this is a visual change include relevant screenshots about the behavior of the application before and after this change.
-->

## Documentation Changes

<!--
List corresponding changes to the documentation.
-->

## Dependant PRs

<!--
List any dependent PR's that are awaiting review. Use the following syntax:

- #1234
-->
