### PR TITLE
Support WordPress template in possible templates list

### DIFF
--- a/.changeset/cool-owls-battle.md
+++ b/.changeset/cool-owls-battle.md
@@ -1,0 +1,5 @@
+---
+'@faustwp/core': patch
+---
+
+Added the WordPress template to the possible templates list

--- a/packages/faustwp-core/src/getTemplate.ts
+++ b/packages/faustwp-core/src/getTemplate.ts
@@ -5,6 +5,16 @@ import { hooks } from './wpHooks/index.js';
 export function getPossibleTemplates(node: SeedNode) {
   let possibleTemplates: string[] = [];
 
+  if (
+    node.isContentNode &&
+    node.template?.templateName &&
+    node.contentType?.node?.name
+  ) {
+    possibleTemplates.push(
+      `${node.contentType.node.name}-template-${node.template.templateName}`,
+    );
+  }
+
   // Front page
   if (node.isFrontPage) {
     possibleTemplates.push('front-page');

--- a/packages/faustwp-core/src/getTemplate.ts
+++ b/packages/faustwp-core/src/getTemplate.ts
@@ -5,14 +5,8 @@ import { hooks } from './wpHooks/index.js';
 export function getPossibleTemplates(node: SeedNode) {
   let possibleTemplates: string[] = [];
 
-  if (
-    node.isContentNode &&
-    node.template?.templateName &&
-    node.contentType?.node?.name
-  ) {
-    possibleTemplates.push(
-      `${node.contentType.node.name}-template-${node.template.templateName}`,
-    );
+  if (node.template?.templateName) {
+    possibleTemplates.push(`template-${node.template.templateName}`);
   }
 
   // Front page

--- a/packages/faustwp-core/tests/getTemplate.test.ts
+++ b/packages/faustwp-core/tests/getTemplate.test.ts
@@ -1,0 +1,109 @@
+import * as getTemplate from '../src/getTemplate';
+
+describe('getPossibleTemplates', () => {
+  test('home page possible templates list', () => {
+    // Seed Node for resolved url: "/"
+    const seedNode = {
+      __typename: 'Page',
+      uri: '/',
+      id: 'cG9zdDozNjE=',
+      databaseId: '361',
+      isContentNode: true,
+      slug: 'home',
+      contentType: {
+        __typename: 'ContentNodeToContentTypeConnectionEdge',
+        node: { __typename: 'ContentType', name: 'page' },
+      },
+      template: { __typename: 'DefaultTemplate', templateName: 'Default' },
+      isFrontPage: true,
+      isPostsPage: false,
+    };
+
+    expect(getTemplate.getPossibleTemplates(seedNode)).toStrictEqual([
+      'template-Default',
+      'front-page',
+      'page-home',
+      'page-361',
+      'page',
+      'singular',
+      'index',
+    ]);
+  });
+
+  test('uncategorized category archive possible templates list', () => {
+    // Seed Node for resolved url: "/category/uncategorized"
+    const seedNode = {
+      __typename: 'Category',
+      uri: '/category/uncategorized/',
+      id: 'dGVybTox',
+      databaseId: '1',
+      isTermNode: true,
+      slug: 'uncategorized',
+      taxonomyName: 'category',
+    };
+
+    expect(getTemplate.getPossibleTemplates(seedNode)).toStrictEqual([
+      'category-uncategorized',
+      'category-1',
+      'category',
+      'archive',
+      'index',
+    ]);
+  });
+
+  test('cpt post possible templates list', () => {
+    // Seed Node for resolved url: "/movies/the-dark-knight"
+    const seedNode = {
+      __typename: 'Movie',
+      uri: '/movies/the-dark-knight/',
+      id: 'cG9zdDo0NDM=',
+      databaseId: '443',
+      isContentNode: true,
+      slug: 'the-dark-knight',
+      contentType: {
+        __typename: 'ContentNodeToContentTypeConnectionEdge',
+        node: { __typename: 'ContentType', name: 'movies' },
+      },
+      template: { __typename: 'DefaultTemplate', templateName: 'Default' },
+    };
+
+    expect(getTemplate.getPossibleTemplates(seedNode)).toStrictEqual([
+      'template-Default',
+      'single-movies-the-dark-knight',
+      'single-movies',
+      'singular',
+      'index',
+    ]);
+  });
+
+  test('single page custom template possible templates list', () => {
+    // Seed Node for resolved url: "/testing"
+    const seedNode = {
+      __typename: 'Page',
+      uri: '/testing/',
+      id: 'cG9zdDozMjk=',
+      databaseId: '329',
+      isContentNode: true,
+      slug: 'testing',
+      contentType: {
+        __typename: 'ContentNodeToContentTypeConnectionEdge',
+        node: { __typename: 'ContentType', name: 'page' },
+      },
+      template: {
+        __typename: 'Template_PageWithoutSidebar',
+        templateName: 'PageWithoutSidebar',
+      },
+      isFrontPage: false,
+      isPostsPage: false,
+    };
+
+    expect(getTemplate.getPossibleTemplates(seedNode)).toStrictEqual([
+      'template-PageWithoutSidebar',
+      'page-testing',
+      'page-329',
+      'page',
+      'singular',
+      'index',
+    ]);
+  });
+});


### PR DESCRIPTION
## Tasks

- [x] I have signed a [Contributor License Agreement (CLA)](https://github.com/wpengine/faustjs#contributor-license-agreement) with WP Engine.

## Description

Adds support for WordPress [Page Templates](https://developer.wordpress.org/themes/template-files-section/page-template-files/) in the Faust template system.

<!--
Include a summary of the change and some contextual information.
-->

## Related Issue(s):

<!--
Provide the GitHub issue(s) number for issue tracking purposes, use the following syntax:

- #1234
-->

## Testing

Unit tests have been added.

To manually test, do the following:

1. Checkout this PR
2. Build the packages
3. Run the dev server
4. Navigate to a single page/post
5. Notice at the top of the possible templates you have `template-Default`
6. Now create a custom Page Template in your WP theme called `ContentWithoutSidebar.php`
7. Go to a page and select that template for the page
8. Now, view that page in the Faust app
9. Notice at the top of the possible templates list you have `template-ContentWithoutSidebar`

<!--
Describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Also list any relevant details for your test configuration such as how to test the changes locally or in staging.
-->

## Screenshots

<!--
If this is a visual change include relevant screenshots about the behavior of the application before and after this change.
-->

## Documentation Changes

<!--
List corresponding changes to the documentation.
-->

## Dependant PRs

<!--
List any dependent PR's that are awaiting review. Use the following syntax:

- #1234
-->
