### PR TITLE
Add theme property in `WordPressBlocksProvider`

### DIFF
--- a/internal/faustjs.org/docs/reference/useBlocksTheme.mdx
+++ b/internal/faustjs.org/docs/reference/useBlocksTheme.mdx
@@ -1,0 +1,37 @@
+---
+slug: /reference/useBlocksTheme
+title: useBlocksTheme Reference
+description: Reference docs for the useBlocksTheme hook.
+---
+
+`useBlocksTheme` is a React hook that can extract the theme json property passed in the `WordPressBlocksProvider` component.
+
+## Usage
+
+First, define your `theme` in the `WordPressBlocksProvider`:
+
+```jsx title="_app.js" {1,4-8,14-16}
+import { WordPressBlocksProvider } from '@faustwp/blocks';
+import blocks from 'src/wp-blocks';
+
+const theme = {
+  colors: {
+    primary: 'black'
+  }
+}
+
+export function MyApp() {
+  return (
+    <WordPressBlocksProvider config={{blocks, theme}}>
+      // Rest of your app
+    </WordPressBlocksProvider>;
+  )
+}
+
+```
+
+Then, within your application, you can use `useBlocksTheme` to retrieve the specified theme:
+
+```jsx
+const theme = useBlocksTheme();
+```

--- a/internal/faustjs.org/sidebars.js
+++ b/internal/faustjs.org/sidebars.js
@@ -118,6 +118,11 @@ module.exports = {
         },
         {
           type: 'doc',
+          label: 'useBlocksTheme',
+          id: 'reference/useBlocksTheme',
+        },
+        {
+          type: 'doc',
           label: 'getSitemapProps',
           id: 'reference/getSitemapProps',
         },

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,8 +47,8 @@
       "version": "0.1.0",
       "dependencies": {
         "@apollo/client": "^3.6.6",
-        "@faustwp/cli": "0.2.7",
-        "@faustwp/core": "0.2.9",
+        "@faustwp/cli": "0.2.12",
+        "@faustwp/core": "0.2.11",
         "@wordpress/base-styles": "^4.7.0",
         "@wordpress/block-library": "^7.13.0",
         "classnames": "^2.3.1",
@@ -63,8 +63,8 @@
       "name": "@faustjs/next-headless-getting-started",
       "version": "0.1.0",
       "dependencies": {
-        "@faustjs/core": "^0.15.7",
-        "@faustjs/next": "^0.15.9",
+        "@faustjs/core": "^0.15.10",
+        "@faustjs/next": "^0.15.10",
         "next": "^12.2.4",
         "normalize.css": "^8.0.1",
         "react": "^17.0.2",
@@ -13539,7 +13539,7 @@
     },
     "packages/blocks": {
       "name": "@faustwp/blocks",
-      "version": "0.2.1",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "lodash": "^4.17.21"
@@ -13553,7 +13553,7 @@
         "rimraf": "^4.4.0"
       },
       "peerDependencies": {
-        "@faustwp/core": ">=0.2.9",
+        "@faustwp/core": ">=0.2.10",
         "react": ">=17.0.2",
         "react-dom": ">=17.0.2"
       }
@@ -13621,7 +13621,7 @@
     },
     "packages/core": {
       "name": "@faustjs/core",
-      "version": "0.15.7",
+      "version": "0.15.10",
       "license": "MIT",
       "dependencies": {
         "cookie": "^0.4.1",
@@ -13657,7 +13657,7 @@
     },
     "packages/faustwp-cli": {
       "name": "@faustwp/cli",
-      "version": "0.2.7",
+      "version": "0.2.12",
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.1.2",
@@ -13753,7 +13753,7 @@
     },
     "packages/faustwp-core": {
       "name": "@faustwp/core",
-      "version": "0.2.9",
+      "version": "0.2.11",
       "license": "MIT",
       "dependencies": {
         "@wordpress/hooks": "^3.14.0",
@@ -13851,11 +13851,11 @@
     },
     "packages/next": {
       "name": "@faustjs/next",
-      "version": "0.15.9",
+      "version": "0.15.10",
       "license": "MIT",
       "dependencies": {
-        "@faustjs/core": "^0.15.7",
-        "@faustjs/react": "^0.15.7",
+        "@faustjs/core": "^0.15.10",
+        "@faustjs/react": "^0.15.10",
         "@gqty/logger": "^2.0.1",
         "@gqty/react": "^2.1.0",
         "common-tags": "^1.8.2",
@@ -13891,10 +13891,10 @@
     },
     "packages/react": {
       "name": "@faustjs/react",
-      "version": "0.15.7",
+      "version": "0.15.10",
       "license": "MIT",
       "dependencies": {
-        "@faustjs/core": "^0.15.7",
+        "@faustjs/core": "^0.15.10",
         "@gqty/react": "^2.1.0",
         "gqty": "^2.3.0",
         "graphql": ">=15.6",
@@ -13925,7 +13925,7 @@
     },
     "plugins/faustwp": {
       "name": "@faustwp/wordpress-plugin",
-      "version": "0.8.4"
+      "version": "0.8.6"
     }
   },
   "dependencies": {
@@ -14643,8 +14643,8 @@
     "@faustjs/next": {
       "version": "file:packages/next",
       "requires": {
-        "@faustjs/core": "^0.15.7",
-        "@faustjs/react": "^0.15.7",
+        "@faustjs/core": "^0.15.10",
+        "@faustjs/react": "^0.15.10",
         "@gqty/logger": "^2.0.1",
         "@gqty/react": "^2.1.0",
         "@testing-library/jest-dom": "^5.15.0",
@@ -14674,8 +14674,8 @@
     "@faustjs/next-headless-getting-started": {
       "version": "file:examples/next/getting-started",
       "requires": {
-        "@faustjs/core": "^0.15.7",
-        "@faustjs/next": "^0.15.9",
+        "@faustjs/core": "^0.15.10",
+        "@faustjs/next": "^0.15.10",
         "@gqty/cli": "^3.1.0",
         "@types/node": "^17.0.17",
         "@types/react": "^17.0.34",
@@ -14750,7 +14750,7 @@
     "@faustjs/react": {
       "version": "file:packages/react",
       "requires": {
-        "@faustjs/core": "^0.15.7",
+        "@faustjs/core": "^0.15.10",
         "@gqty/react": "^2.1.0",
         "@testing-library/jest-dom": "^5.15.0",
         "@testing-library/react": "^12.1.2",
@@ -14952,8 +14952,8 @@
       "version": "file:examples/next/faustwp-getting-started",
       "requires": {
         "@apollo/client": "^3.6.6",
-        "@faustwp/cli": "0.2.7",
-        "@faustwp/core": "0.2.9",
+        "@faustwp/cli": "0.2.12",
+        "@faustwp/core": "0.2.11",
         "@wordpress/base-styles": "^4.7.0",
         "@wordpress/block-library": "^7.13.0",
         "classnames": "^2.3.1",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "docs-legacy:clear": "npm run clear --prefix internal/legacy.faustjs.org",
     "docs-legacy:install": "cd internal/legacy.faustjs.org && npm i && cd ..",
     "docs-legacy:start": "npm start --prefix internal/legacy.faustjs.org",
-    "test": "npm run build && npm test --workspace=@faustjs/core --workspace=@faustjs/react --workspace=@faustjs/next --workspace=@faustwp/core",
+    "test": "npm run build && npm test --workspace=@faustjs/core --workspace=@faustjs/react --workspace=@faustjs/next --workspace=@faustwp/core --workspace=@faustwp/cli --workspace=@faustwp/blocks",
     "test:coverage": "npm run build && npm run test:coverage --workspace=@faustjs/core --workspace=@faustjs/react --workspace=@faustjs/next",
     "wpe-build": "exit 1",
     "changeset": "changeset",

--- a/packages/blocks/.gitignore
+++ b/packages/blocks/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+dist
+coverage

--- a/packages/blocks/package.json
+++ b/packages/blocks/package.json
@@ -26,7 +26,7 @@
     "postbuild": "npm run package",
     "clean": "rimraf dist",
     "package": "node ../../scripts/package.js",
-    "test": "npm test",
+    "test": "jest",
     "build": "npm run build-esm && npm run build-cjs",
     "build-esm": "tsc -p .",
     "build-cjs": "tsc -p tsconfig.cjs.json",

--- a/packages/blocks/package.json
+++ b/packages/blocks/package.json
@@ -6,9 +6,9 @@
   "module": "dist/mjs/index.js",
   "types": "dist/mjs/index.d.ts",
   "peerDependencies": {
+    "@faustwp/core": ">=0.2.10",
     "react": ">=17.0.2",
-    "react-dom": ">=17.0.2",
-    "@faustwp/core": ">=0.2.10"
+    "react-dom": ">=17.0.2"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^5.15.0",

--- a/packages/blocks/src/components/WordPressBlocksProvider.tsx
+++ b/packages/blocks/src/components/WordPressBlocksProvider.tsx
@@ -1,4 +1,5 @@
 import React, { FC } from 'react';
+import get from 'lodash/get.js';
 import { ThemeJson } from '../theme.js';
 
 export type WordPressBlockBase = React.FC & {
@@ -16,11 +17,13 @@ export type WordPressBlockBase = React.FC & {
 export type WordPressBlock<P = Record<string, any>> = FC<P> &
   Partial<Pick<WordPressBlockBase, 'config' | 'displayName' | 'name'>>;
 
-export type BlocksContextType = WordPressBlock[] | undefined;
-export type ThemeContextType = ThemeJson | undefined;
+export type WordPressBlocksContextType = WordPressBlock[] | undefined;
+export type WordPressThemeContextType = ThemeJson | undefined;
 
-export const BlocksContext = React.createContext<BlocksContextType>(undefined);
-export const ThemeContext = React.createContext<ThemeContextType>(undefined);
+export const WordPressBlocksContext =
+  React.createContext<WordPressBlocksContextType>(undefined);
+export const WordPressThemeContext =
+  React.createContext<WordPressThemeContextType>(undefined);
 
 export type WordPressBlocksProviderConfig = {
   blocks: WordPressBlock[];
@@ -40,9 +43,11 @@ export function WordPressBlocksProvider(props: {
   const { blocks, theme } = config;
 
   return (
-    <BlocksContext.Provider value={blocks}>
-      <ThemeContext.Provider value={theme}>{children}</ThemeContext.Provider>
-    </BlocksContext.Provider>
+    <WordPressBlocksContext.Provider value={blocks}>
+      <WordPressThemeContext.Provider value={theme}>
+        {children}
+      </WordPressThemeContext.Provider>
+    </WordPressBlocksContext.Provider>
   );
 }
 
@@ -55,14 +60,20 @@ export function WordPressBlocksProvider(props: {
  * const theme = useBlocksTheme();
  * ```
  */
-export function useBlocksTheme() {
-  const themeContext = React.useContext(ThemeContext);
+export function useBlocksTheme(): ThemeJson;
+export function useBlocksTheme(path: string): unknown;
+export function useBlocksTheme(path?: string): ThemeJson | unknown {
+  const themeContext = React.useContext(WordPressThemeContext);
 
   // If it's an empty object, the provider hasn't been initialized.
   if (themeContext === undefined) {
     throw new Error(
       'useBlocksTheme hook was called outside of context, make sure your app is wrapped with WordPressBlocksProvider',
     );
+  }
+
+  if (path) {
+    return get(themeContext, path, undefined);
   }
 
   return themeContext;

--- a/packages/blocks/src/components/WordPressBlocksProvider.tsx
+++ b/packages/blocks/src/components/WordPressBlocksProvider.tsx
@@ -61,8 +61,8 @@ export function WordPressBlocksProvider(props: {
  * ```
  */
 export function useBlocksTheme(): ThemeJson;
-export function useBlocksTheme(path: string): unknown;
-export function useBlocksTheme(path?: string): ThemeJson | unknown {
+export function useBlocksTheme(path: string): ReturnType<typeof get>;
+export function useBlocksTheme(path?: string) {
   const themeContext = React.useContext(WordPressThemeContext);
 
   // If it's an empty object, the provider hasn't been initialized.

--- a/packages/blocks/src/components/WordPressBlocksProvider.tsx
+++ b/packages/blocks/src/components/WordPressBlocksProvider.tsx
@@ -1,4 +1,5 @@
 import React, { FC } from 'react';
+import { ThemeJson } from '../theme.js';
 
 export type WordPressBlockBase = React.FC & {
   displayName: string;
@@ -20,6 +21,7 @@ export const WordPressBlocksContext =
 
 export interface WordPressBlocksContextType {
   blocks?: WordPressBlock[];
+  theme?: ThemeJson;
 }
 
 /**
@@ -38,4 +40,25 @@ export function WordPressBlocksProvider(props: {
       {children}
     </WordPressBlocksContext.Provider>
   );
+}
+
+/**
+ * useBlocksTheme can be used to retrieve the theme
+ * from within the WordPressBlocksProvider.
+ *
+ * @example
+ * ```
+ * const theme = useBlocksTheme();
+ * ```
+ */
+export function useBlocksTheme() {
+  const context = React.useContext(WordPressBlocksContext);
+
+  if (context === undefined) {
+    throw new Error(
+      'useBlocksTheme() must be used within a WordPressBlocksProvider',
+    );
+  }
+
+  return context.theme;
 }

--- a/packages/blocks/src/components/WordPressBlocksProvider.tsx
+++ b/packages/blocks/src/components/WordPressBlocksProvider.tsx
@@ -54,7 +54,8 @@ export function WordPressBlocksProvider(props: {
 export function useBlocksTheme() {
   const context = React.useContext(WordPressBlocksContext);
 
-  if (context === undefined) {
+  // If it's an empty object, the provider hasn't been initialized.
+  if (Object.keys(context).length === 0) {
     throw new Error(
       'useBlocksTheme() must be used within a WordPressBlocksProvider',
     );

--- a/packages/blocks/src/components/WordPressBlocksProvider.tsx
+++ b/packages/blocks/src/components/WordPressBlocksProvider.tsx
@@ -16,13 +16,16 @@ export type WordPressBlockBase = React.FC & {
 export type WordPressBlock<P = Record<string, any>> = FC<P> &
   Partial<Pick<WordPressBlockBase, 'config' | 'displayName' | 'name'>>;
 
-export const WordPressBlocksContext =
-  React.createContext<WordPressBlocksContextType>({});
+export type BlocksContextType = WordPressBlock[] | undefined;
+export type ThemeContextType = ThemeJson | undefined;
 
-export interface WordPressBlocksContextType {
-  blocks?: WordPressBlock[];
+export const BlocksContext = React.createContext<BlocksContextType>(undefined);
+export const ThemeContext = React.createContext<ThemeContextType>(undefined);
+
+export type WordPressBlocksProviderConfig = {
+  blocks: WordPressBlock[];
   theme?: ThemeJson;
-}
+};
 
 /**
  * WordPressBlocksProvider is used as a central store for the available list of WordPressBlock types.
@@ -31,14 +34,15 @@ export interface WordPressBlocksContextType {
  */
 export function WordPressBlocksProvider(props: {
   children: React.ReactNode;
-  config: WordPressBlocksContextType;
+  config: WordPressBlocksProviderConfig;
 }) {
   const { children, config } = props;
+  const { blocks, theme } = config;
 
   return (
-    <WordPressBlocksContext.Provider value={config}>
-      {children}
-    </WordPressBlocksContext.Provider>
+    <BlocksContext.Provider value={blocks}>
+      <ThemeContext.Provider value={theme}>{children}</ThemeContext.Provider>
+    </BlocksContext.Provider>
   );
 }
 
@@ -52,14 +56,14 @@ export function WordPressBlocksProvider(props: {
  * ```
  */
 export function useBlocksTheme() {
-  const context = React.useContext(WordPressBlocksContext);
+  const themeContext = React.useContext(ThemeContext);
 
   // If it's an empty object, the provider hasn't been initialized.
-  if (Object.keys(context).length === 0) {
+  if (themeContext === undefined) {
     throw new Error(
-      'useBlocksTheme() must be used within a WordPressBlocksProvider',
+      'useBlocksTheme hook was called outside of context, make sure your app is wrapped with WordPressBlocksProvider',
     );
   }
 
-  return context.theme;
+  return themeContext;
 }

--- a/packages/blocks/src/components/WordPressBlocksViewer.tsx
+++ b/packages/blocks/src/components/WordPressBlocksViewer.tsx
@@ -59,7 +59,7 @@ export interface ContentBlock {
  * @returns JSX.Component that renders the block tree.
  */
 export function WordPressBlocksViewer(props: WordpressBlocksViewerProps) {
-  const { blocks } = React.useContext(WordPressBlocksContext);
+  const blocks = React.useContext(WordPressBlocksContext);
 
   if (!blocks) {
     throw new Error('Blocks are required. Please add them to your config.');

--- a/packages/blocks/src/index.ts
+++ b/packages/blocks/src/index.ts
@@ -2,6 +2,7 @@ import {
   WordPressBlocksContext,
   WordPressBlock,
   WordPressBlocksProvider,
+  useBlocksTheme,
 } from './components/WordPressBlocksProvider.js';
 import {
   useBlockData,
@@ -16,4 +17,5 @@ export {
   useBlockData,
   WordpressBlocksViewerProps,
   WordPressBlocksViewer,
+  useBlocksTheme,
 };

--- a/packages/blocks/src/index.ts
+++ b/packages/blocks/src/index.ts
@@ -1,5 +1,6 @@
 import {
   WordPressBlocksContext,
+  WordPressThemeContext,
   WordPressBlock,
   WordPressBlocksProvider,
   useBlocksTheme,
@@ -12,6 +13,7 @@ import {
 
 export {
   WordPressBlocksContext,
+  WordPressThemeContext,
   WordPressBlock,
   WordPressBlocksProvider,
   useBlockData,

--- a/packages/blocks/src/theme.ts
+++ b/packages/blocks/src/theme.ts
@@ -1,6 +1,6 @@
 type Keys = string | number;
 
-export type Theme = {
+export type ThemeJson = {
   colors: ThemePropertiesColor;
   spacing: ThemePropertiesSpacing;
   blocks?: ThemePropertiesBlocks;

--- a/packages/blocks/tests/components/WordPressBlocksProvider.test.tsx
+++ b/packages/blocks/tests/components/WordPressBlocksProvider.test.tsx
@@ -15,7 +15,7 @@ describe('useBlocksTheme', () => {
     const { result } = renderHook(() => useBlocksTheme());
 
     expect(result.error?.message).toBe(
-      'useBlocksTheme() must be used within a WordPressBlocksProvider',
+      'useBlocksTheme hook was called outside of context, make sure your app is wrapped with WordPressBlocksProvider',
     );
   });
 
@@ -45,5 +45,31 @@ describe('useBlocksTheme', () => {
 
     expect(result.error).toBeUndefined();
     expect(theme?.colors.palette).toStrictEqual({ primary: 'black' });
+  });
+
+  it('uses the path param', async () => {
+    const wrapper = ({ children }: PropsWithChildren<{}>) => {
+      const theme: ThemeJson = {
+        colors: {
+          palette: {
+            primary: 'black',
+          },
+        },
+        spacing: {},
+      };
+
+      return (
+        <WordPressBlocksProvider config={{ blocks: [], theme }}>
+          {children}
+        </WordPressBlocksProvider>
+      );
+    };
+
+    const { result } = renderHook(() => useBlocksTheme('colors.palette'), {
+      wrapper,
+    });
+
+    expect(result.error).toBeUndefined();
+    expect(result.current).toStrictEqual({ primary: 'black' });
   });
 });

--- a/packages/blocks/tests/components/WordPressBlocksProvider.test.tsx
+++ b/packages/blocks/tests/components/WordPressBlocksProvider.test.tsx
@@ -1,0 +1,49 @@
+/**
+ * @jest-environment jsdom
+ */
+import React from 'react';
+import { PropsWithChildren } from 'react';
+import {
+  WordPressBlocksProvider,
+  useBlocksTheme,
+} from '../../src/components/WordPressBlocksProvider';
+import type { ThemeJson } from '../../src/theme';
+import { renderHook } from '@testing-library/react-hooks';
+
+describe('useBlocksTheme', () => {
+  it('Throws an error if not used within WordPressBlocksProvider', async () => {
+    const { result } = renderHook(() => useBlocksTheme());
+
+    expect(result.error?.message).toBe(
+      'useBlocksTheme() must be used within a WordPressBlocksProvider',
+    );
+  });
+
+  it('returns the passed in theme from WordPressBlocksProvider', async () => {
+    const wrapper = ({ children }: PropsWithChildren<{}>) => {
+      const theme: ThemeJson = {
+        colors: {
+          palette: {
+            primary: 'black',
+          },
+        },
+        spacing: {},
+      };
+
+      return (
+        <WordPressBlocksProvider config={{ blocks: [], theme }}>
+          {children}
+        </WordPressBlocksProvider>
+      );
+    };
+
+    const { result } = renderHook(() => useBlocksTheme(), {
+      wrapper,
+    });
+
+    const theme = result.current;
+
+    expect(result.error).toBeUndefined();
+    expect(theme?.colors.palette).toStrictEqual({ primary: 'black' });
+  });
+});


### PR DESCRIPTION
## Tasks

- [x] I have signed a [Contributor License Agreement (CLA)](https://github.com/wpengine/faustjs#contributor-license-agreement) with WP Engine.

## Description

This PR adds the `theme` property to the `WordPressBlocksProvider` config object that can then be retrieved with the `useBlocksTheme()` hook.

<!--
Include a summary of the change and some contextual information.
-->

## Related Issue(s):

<!--
Provide the GitHub issue(s) number for issue tracking purposes, use the following syntax:

- #1234
-->

## Testing

Unit tests have been provided.

<!--
Describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Also list any relevant details for your test configuration such as how to test the changes locally or in staging.
-->

## Screenshots

<!--
If this is a visual change include relevant screenshots about the behavior of the application before and after this change.
-->

## Documentation Changes

<!--
List corresponding changes to the documentation.
-->

## Dependant PRs

<!--
List any dependent PR's that are awaiting review. Use the following syntax:

- #1234
-->
