### PR TITLE
Remove `template-Default` from possible template list

### DIFF
--- a/packages/faustwp-core/src/getTemplate.ts
+++ b/packages/faustwp-core/src/getTemplate.ts
@@ -5,7 +5,7 @@ import { hooks } from './wpHooks/index.js';
 export function getPossibleTemplates(node: SeedNode) {
   let possibleTemplates: string[] = [];
 
-  if (node.template?.templateName) {
+  if (node.template?.templateName && node.template.templateName !== 'Default') {
     possibleTemplates.push(`template-${node.template.templateName}`);
   }
 

--- a/packages/faustwp-core/tests/getTemplate.test.ts
+++ b/packages/faustwp-core/tests/getTemplate.test.ts
@@ -20,7 +20,6 @@ describe('getPossibleTemplates', () => {
     };
 
     expect(getTemplate.getPossibleTemplates(seedNode)).toStrictEqual([
-      'template-Default',
       'front-page',
       'page-home',
       'page-361',
@@ -68,7 +67,6 @@ describe('getPossibleTemplates', () => {
     };
 
     expect(getTemplate.getPossibleTemplates(seedNode)).toStrictEqual([
-      'template-Default',
       'single-movies-the-dark-knight',
       'single-movies',
       'singular',


### PR DESCRIPTION
## Tasks

- [x] I have signed a [Contributor License Agreement (CLA)](https://github.com/wpengine/faustjs#contributor-license-agreement) with WP Engine.

## Description

We should not include `template-Default` in the possible template list. Since templates have the highest priority, if the default template is specified, it will override every single page. Take for instance the home page (`front-page`). If they have a template for the default, it would be used over `front-page`, which you wouldn't expect.

Instead, only add WordPress templates to the possible templates list if they are not default.

<!--
Include a summary of the change and some contextual information.
-->

## Related Issue(s):

<!--
Provide the GitHub issue(s) number for issue tracking purposes, use the following syntax:

- #1234
-->

## Testing

<!--
Describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Also list any relevant details for your test configuration such as how to test the changes locally or in staging.
-->

## Screenshots

<!--
If this is a visual change include relevant screenshots about the behavior of the application before and after this change.
-->

## Documentation Changes

<!--
List corresponding changes to the documentation.
-->

## Dependant PRs

<!--
List any dependent PR's that are awaiting review. Use the following syntax:

- #1234
-->
