### PR TITLE
Run Nightly Builds Monday through Friday

### DIFF
--- a/.github/workflows/nightly-releases.yml
+++ b/.github/workflows/nightly-releases.yml
@@ -13,12 +13,12 @@ name: Nightly Releases
 
 on:
   schedule:
-    # Every day at 8:35pm UTC / 3:35pm CST
+    # Monday-Friday at 8:35pm UTC / 3:35pm CST
     
     # Uses the 35th minute because GitHub Workflow load is significantly
     # increased at the start of the hour. By invoking the workflow in the
     # middle of the hour, there is less chance of delay.
-    - cron: '35 20 * * *'
+    - cron: '35 20 * * 1-5'
 
 jobs:
   release_nightly_canary:


### PR DESCRIPTION
## Tasks

- [x] I have signed a [Contributor License Agreement (CLA)](https://github.com/wpengine/faustjs#contributor-license-agreement) with WP Engine.

## Description

Updates the nightly cron to only run nightly builds Monday-Friday.

<!--
Include a summary of the change and some contextual information.
-->

## Related Issue(s):

<!--
Provide the GitHub issue(s) number for issue tracking purposes, use the following syntax:

- #1234
-->

## Testing

<!--
Describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Also list any relevant details for your test configuration such as how to test the changes locally or in staging.
-->

## Screenshots

<!--
If this is a visual change include relevant screenshots about the behavior of the application before and after this change.
-->

## Documentation Changes

<!--
List corresponding changes to the documentation.
-->

## Dependant PRs

<!--
List any dependent PR's that are awaiting review. Use the following syntax:

- #1234
-->
