### PR TITLE
Only update peer deps when out of range

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -13,5 +13,6 @@
   "access": "public",
   "baseBranch": "canary",
   "updateInternalDependencies": "patch",
-  "ignore": ["@faustjs/next-headless-getting-started", "@faustwp/getting-started-example"]
+  "ignore": ["@faustjs/next-headless-getting-started", "@faustwp/getting-started-example"],
+  "onlyUpdatePeerDependentsWhenOutOfRange": true
 }


### PR DESCRIPTION
## Tasks

- [x] I have signed a [Contributor License Agreement (CLA)](https://github.com/wpengine/faustjs#contributor-license-agreement) with WP Engine.

## Description

For the `@faustwp/blocks` package, we have a peer dep of `@faustwp/core` for the plugin system. Every time a "release packages" PR comes up, [the peer dep is bumped to the latest version](https://github.com/wpengine/faustjs/pull/1404/files#diff-c2bb4b0e39839a40c8cbea9d0168a7b644e742760ec8a73fe4cdef6ce144cc0fR9), even though that's not always true. This PR adds the [`onlyUpdatePeerDependentsWhenOutOfRange` option to only update peer deps when the new version is out of range.](https://github.com/changesets/changesets/blob/main/docs/experimental-options.md#onlyupdatepeerdependentswhenoutofrange-type-boolean)

<!--
Include a summary of the change and some contextual information.
-->

## Related Issue(s):

<!--
Provide the GitHub issue(s) number for issue tracking purposes, use the following syntax:

- #1234
-->

## Testing

<!--
Describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Also list any relevant details for your test configuration such as how to test the changes locally or in staging.
-->

## Screenshots

<!--
If this is a visual change include relevant screenshots about the behavior of the application before and after this change.
-->

## Documentation Changes

<!--
List corresponding changes to the documentation.
-->

## Dependant PRs

<!--
List any dependent PR's that are awaiting review. Use the following syntax:

- #1234
-->
