### PR TITLE
Admin should have to opt-in to disabling theme pages

### DIFF
--- a/.changeset/hungry-fans-end.md
+++ b/.changeset/hungry-fans-end.md
@@ -1,0 +1,5 @@
+---
+'@faustwp/wordpress-plugin': patch
+---
+
+The default plugin setting for "Disable WordPress Theme Admin Pages" is now unchecked, requiring a user to opt-in after initial activation.

--- a/internal/faustjs.org/docs/faustwp/settings.mdx
+++ b/internal/faustjs.org/docs/faustwp/settings.mdx
@@ -25,8 +25,6 @@ For example, it will remove the following menu items:
 It will also remove any features that require the `Customizer` which means that the
 `Appearance` tab will only contain the menu options.
 
-If you still want to have access to those pages then, you can disable this setting.
-
 ### Enabling Post and Category URL Rewrites
 
 This option is controlled by the `Enable Post and Category URL rewrites` checkbox. When enabled it will

--- a/plugins/faustwp/includes/settings/functions.php
+++ b/plugins/faustwp/includes/settings/functions.php
@@ -126,7 +126,7 @@ function maybe_set_default_settings() {
 	$settings   = faustwp_get_settings();
 
 	if ( empty( $settings ) ) {
-		faustwp_update_setting( 'disable_theme', '1' );
+		faustwp_update_setting( 'disable_theme', '0' );
 		faustwp_update_setting( 'enable_rewrites', '1' );
 		faustwp_update_setting( 'enable_redirects', '1' );
 

--- a/plugins/faustwp/tests/acceptance/SettingsCest.php
+++ b/plugins/faustwp/tests/acceptance/SettingsCest.php
@@ -34,7 +34,7 @@ class SettingsCest
         $I->seeInField('faustwp_settings[frontend_uri]', '');
         $I->seeInField('faustwp_settings[secret_key]', $settings['secret_key']);
         $I->seeInField('faustwp_settings[menu_locations]', 'Primary, Footer');
-        $I->seeCheckboxIsChecked('#disable_theme');
+        $I->dontSeeCheckboxIsChecked('#disable_theme');
         $I->seeCheckboxIsChecked('#enable_rewrites');
         $I->seeCheckboxIsChecked('#enable_redirects');
         $I->dontSeeCheckboxIsChecked('#enable_image_source');


### PR DESCRIPTION
## Tasks

- [X] I have signed a [Contributor License Agreement (CLA)](https://github.com/wpengine/faustjs#contributor-license-agreement) with WP Engine.

## Description

The default plugin setting for "Disable WordPress Theme Admin Pages" is now unchecked, requiring a user to opt-in after initial activation.

## Testing

1. Create a new WordPress site (or deactivate faustwp in an existing site & run `wp option delete faustwp_settings` within the site shell to mock a fresh install)
2. Activate faustwp
3. Observe that the setting "Disable WordPress Theme Admin Pages" is unchecked. See screenshot.

## Screenshots

<img width="758" alt="Screenshot 2023-05-09 at 5 19 11 PM" src="https://github.com/wpengine/faustjs/assets/6676674/a4832e5c-fe44-4565-a95c-31449d9edb49">
