### PR TITLE
Fix `flatListToHierarchical` typescript types

### DIFF
--- a/packages/faustwp-core/src/utils/flatListToHierarchical.ts
+++ b/packages/faustwp-core/src/utils/flatListToHierarchical.ts
@@ -1,35 +1,38 @@
-export interface ListNode {
-  id: number | string;
-  parentId?: number | string;
-  [key: string]: any;
-}
-
 export interface Params {
   idKey?: string;
   parentKey?: string;
   childrenKey?: string;
 }
 
+type Data = Record<string | number, unknown>;
+
 /**
  * Converts a flat list to hierarchical.
- * @param data The ListNode items.
- * @param param1 The ListNode parameters.
- * @returns ListNode Array
+ *
+ * @param data The data items as an array.
+ * @param param1 The data item property keys.
+ * @returns Data Array
  */
 export function flatListToHierarchical(
-  data: ListNode[] = [],
+  data: Data[] = [],
   {
     idKey = 'id',
     parentKey = 'parentId',
     childrenKey = 'children',
   }: Params = {},
-): ListNode[] {
-  const tree: ListNode[] = [];
-  const childrenOf: { [key: number]: ListNode[] } = {};
+) {
+  const tree: Data[] = [];
+  const childrenOf: { [key: string | number]: Data[] } = {};
 
   data.forEach((item) => {
     const newItem = { ...item };
-    const { [idKey]: id, [parentKey]: parentId = 0 } = newItem;
+
+    const id = newItem?.[idKey] as string | number | undefined;
+    const parentId = (newItem?.[parentKey] ?? 0) as string | undefined;
+
+    if (!id) {
+      return;
+    }
 
     childrenOf[id] = childrenOf[id] || [];
     newItem[childrenKey] = childrenOf[id];

--- a/packages/faustwp-core/tests/utils/flatListToHierarchical.test.ts
+++ b/packages/faustwp-core/tests/utils/flatListToHierarchical.test.ts
@@ -1,11 +1,12 @@
-import { flatListToHierarchical, ListNode } from '../../src/utils/flatListToHierarchical';
+import { flatListToHierarchical } from '../../src/utils/flatListToHierarchical';
 
-const items: ListNode[] = [
+const items = [
   { id: '1', name: 'abc', parentId: '2' },
   { id: '2', name: 'abc', parentId: '' },
   { id: '3', name: 'abc', parentId: '5' },
   { id: '4', name: 'abc', parentId: '2' },
   { id: '5', name: 'abc', parentId: '' },
+  { name: 'abc', parentId: '' },
   { id: '6', name: 'abc', parentId: '2' },
   { id: '7', name: 'abc', parentId: '6' },
   { id: '8', name: 'abc', parentId: '6' },


### PR DESCRIPTION
## Tasks

- [x] I have signed a [Contributor License Agreement (CLA)](https://github.com/wpengine/faustjs#contributor-license-agreement) with WP Engine.

## Description

This PR updates the input and return type of `flatListToHierarchical` to a more generic object.

<!--
Include a summary of the change and some contextual information.
-->

## Related Issue(s):

<!--
Provide the GitHub issue(s) number for issue tracking purposes, use the following syntax:

- #1234
-->

## Testing

<!--
Describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Also list any relevant details for your test configuration such as how to test the changes locally or in staging.
-->

## Screenshots

<!--
If this is a visual change include relevant screenshots about the behavior of the application before and after this change.
-->

## Documentation Changes

<!--
List corresponding changes to the documentation.
-->

## Dependant PRs

<!--
List any dependent PR's that are awaiting review. Use the following syntax:

- #1234
-->
