### PR TITLE
Update _blocks.scss

### DIFF
--- a/examples/next/faustwp-getting-started/styles/_blocks.scss
+++ b/examples/next/faustwp-getting-started/styles/_blocks.scss
@@ -5,6 +5,7 @@
 
 @import '@wordpress/base-styles/mixins';
 @import '@wordpress/base-styles/colors.native';
+@import '@wordpress/base-styles/z-index';
 @import '@wordpress/base-styles/default-custom-properties';
 @import '@wordpress/base-styles/colors';
 @import '@wordpress/base-styles/variables';


### PR DESCRIPTION
## Tasks

- [x] I have signed a [Contributor License Agreement (CLA)](https://github.com/wpengine/faustjs#contributor-license-agreement) with WP Engine.

## Description

Add z-index so it is properly compiled. Without it, it adds the z-index function to the stylesheet creating an invalid value. This can be reproduced by adding a cover block with some text and then inspect it. 
