### PR TITLE
Create e2e nightly build action

### DIFF
--- a/.github/workflows/e2e-nightly-build.yml
+++ b/.github/workflows/e2e-nightly-build.yml
@@ -1,0 +1,56 @@
+name: E2E Nightly Test
+
+on:
+  workflow_run:
+    workflows: ["Nightly Releases"]
+    types:
+      - completed
+
+jobs:
+  e2e-nightly-test:
+    name: E2E app on Node ${{ matrix.node }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node: ['16', '18']
+    defaults:
+      run:
+        working-directory: ./
+    steps:
+      - name: checkout
+        uses: actions/checkout@v3
+
+      - name: setup node
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node }}
+
+      # Install faust-scaffold-ts via npx create next app
+      - name: npx create next app
+        run: |
+          npx create-next-app \
+            -e https://github.com/wpengine/faust-scaffold-ts/tree/main \
+            --use-npm \
+            e2e-app
+        
+      - name: Install nightly versions
+        working-directory: e2e-app
+        run: |
+          npm install @faustwp/core@canary
+          npm install @faustwp/cli@canary
+
+      - name: copy env
+        working-directory: e2e-app
+        run: |
+          cp .env.local.sample .env.local
+
+      # Generate the schema to ensure no type collisions
+      - name: Generate Schema
+        working-directory: e2e-app
+        run: |
+          npm run generate
+
+      - name: Build
+        working-directory: e2e-app
+        run: |
+          npm run build


### PR DESCRIPTION
## Tasks

- [x] I have signed a [Contributor License Agreement (CLA)](https://github.com/wpengine/faustjs#contributor-license-agreement) with WP Engine.

## Description

This PR invokes a new action after successfully releasing the nightly builds to then do a production build with the [`faust-scaffold-ts`](https://github.com/wpengine/faust-scaffold-ts) project while updating the dependencies to use the newly released nightly packages.

<!--
Include a summary of the change and some contextual information.
-->

## Related Issue(s):

<!--
Provide the GitHub issue(s) number for issue tracking purposes, use the following syntax:

- #1234
-->

## Testing

<!--
Describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Also list any relevant details for your test configuration such as how to test the changes locally or in staging.
-->

## Screenshots

<!--
If this is a visual change include relevant screenshots about the behavior of the application before and after this change.
-->

## Documentation Changes

<!--
List corresponding changes to the documentation.
-->

## Dependant PRs

<!--
List any dependent PR's that are awaiting review. Use the following syntax:

- #1234
-->
