### PR TITLE
Feat: CoreParagraph Block

### DIFF
--- a/.changeset/tall-files-sort.md
+++ b/.changeset/tall-files-sort.md
@@ -1,0 +1,5 @@
+---
+'@faustwp/blocks': patch
+---
+
+Add reference implementation of CoreParagraph block

--- a/examples/next/faustwp-getting-started/package.json
+++ b/examples/next/faustwp-getting-started/package.json
@@ -6,6 +6,7 @@
     "dev": "faust dev",
     "build": "faust build",
     "generate": "faust generatePossibleTypes",
+    "stylesheet": "faust generateGlobalStylesheet",
     "start": "faust start"
   },
   "dependencies": {

--- a/packages/blocks/package.json
+++ b/packages/blocks/package.json
@@ -9,7 +9,8 @@
     "@faustwp/core": ">=0.2.10",
     "react": ">=17.0.2",
     "react-dom": ">=17.0.2",
-    "@wordpress/style-engine": ">=1.15.0"
+    "@wordpress/style-engine": ">=1.15.0",
+    "@apollo/client": ">=3.6.6"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^5.15.0",

--- a/packages/blocks/src/blocks/CoreParagraph.tsx
+++ b/packages/blocks/src/blocks/CoreParagraph.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { gql } from '@apollo/client';
+
+import { getStyles } from '../utils/get-styles/getStyles.js';
+import { useBlocksTheme } from '../components/WordPressBlocksProvider.js';
+
+import {
+  BlockWithAttributes,
+  ContentBlock,
+} from '../components/WordPressBlocksViewer.js';
+
+export type CoreParagraphFragmentProps = ContentBlock & {
+  attributes: {
+    cssClassName: string;
+    backgroundColor: string;
+    content: string;
+    style: string;
+    textColor: string;
+    fontSize: string;
+    fontFamily: string;
+    direction: string;
+    dropCap: string;
+    gradient: string;
+    align: string;
+  };
+};
+
+export function CoreParagraph(
+  props: BlockWithAttributes<CoreParagraphFragmentProps>,
+) {
+  const theme = useBlocksTheme();
+  const style = getStyles(theme, { ...props });
+  const { attributes } = props;
+  return (
+    <p
+      style={style}
+      className={attributes?.cssClassName}
+      // eslint-disable-next-line react/no-danger
+      dangerouslySetInnerHTML={{ __html: attributes.content }}
+    />
+  );
+}
+
+CoreParagraph.fragments = {
+  key: `CoreParagraphBlockFragment`,
+  entry: gql`
+    fragment CoreParagraphBlockFragment on CoreParagraph {
+      attributes {
+        cssClassName
+        backgroundColor
+        content
+        style
+        textColor
+        fontSize
+        fontFamily
+        direction
+        dropCap
+        gradient
+        align
+      }
+    }
+  `,
+};

--- a/packages/blocks/src/blocks/CoreParagraph.tsx
+++ b/packages/blocks/src/blocks/CoreParagraph.tsx
@@ -11,17 +11,17 @@ import {
 
 export type CoreParagraphFragmentProps = ContentBlock & {
   attributes: {
-    cssClassName: string;
-    backgroundColor: string;
-    content: string;
-    style: string;
-    textColor: string;
-    fontSize: string;
-    fontFamily: string;
-    direction: string;
-    dropCap: string;
-    gradient: string;
-    align: string;
+    cssClassName?: string;
+    backgroundColor?: string;
+    content?: string;
+    style?: string;
+    textColor?: string;
+    fontSize?: string;
+    fontFamily?: string;
+    direction?: string;
+    dropCap?: string;
+    gradient?: string;
+    align?: string;
   };
 };
 
@@ -36,7 +36,7 @@ export function CoreParagraph(
       style={style}
       className={attributes?.cssClassName}
       // eslint-disable-next-line react/no-danger
-      dangerouslySetInnerHTML={{ __html: attributes.content }}
+      dangerouslySetInnerHTML={{ __html: attributes?.content ?? '' }}
     />
   );
 }

--- a/packages/blocks/src/blocks/index.ts
+++ b/packages/blocks/src/blocks/index.ts
@@ -1,0 +1,6 @@
+/* eslint-disable object-shorthand */
+import { CoreParagraph } from './CoreParagraph.js';
+
+export default {
+  CoreParagraph: CoreParagraph,
+};

--- a/packages/blocks/src/components/WordPressBlocksProvider.tsx
+++ b/packages/blocks/src/components/WordPressBlocksProvider.tsx
@@ -3,6 +3,7 @@ import get from 'lodash/get.js';
 import { BlocksTheme } from '../types/theme.js';
 
 export type WordPressBlockBase = React.FC & {
+  fragments?: string;
   displayName: string;
   name: string;
   config: {
@@ -15,7 +16,9 @@ export type WordPressBlockBase = React.FC & {
  * used to match it with equivalent block data from the API
  */
 export type WordPressBlock<P = Record<string, any>> = FC<P> &
-  Partial<Pick<WordPressBlockBase, 'config' | 'displayName' | 'name'>>;
+  Partial<
+    Pick<WordPressBlockBase, 'config' | 'displayName' | 'name' | 'fragments'>
+  >;
 
 export type WordPressBlocksContextType = WordPressBlock[] | undefined;
 export type WordPressThemeContextType = BlocksTheme | undefined;

--- a/packages/blocks/src/index.ts
+++ b/packages/blocks/src/index.ts
@@ -15,6 +15,7 @@ import {
 import { fromThemeJson } from './utils/from-theme-json/fromThemeJson.js';
 import { getStyles } from './utils/get-styles/getStyles.js';
 import { BlocksTheme } from './types/theme.js';
+import coreBlocks from './blocks/index.js';
 
 export {
   WordPressBlocksContext,
@@ -29,4 +30,5 @@ export {
   BlocksTheme,
   BlockWithAttributes,
   fromThemeJson,
+  coreBlocks,
 };

--- a/packages/blocks/tests/blocks/CoreParagraph.test.tsx
+++ b/packages/blocks/tests/blocks/CoreParagraph.test.tsx
@@ -1,0 +1,46 @@
+/** @jest-environment jsdom */
+import * as React from 'react';
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import { WordPressBlocksProvider } from '../../src/components/WordPressBlocksProvider';
+import {
+  CoreParagraph,
+  CoreParagraphFragmentProps,
+} from '../../src/blocks/CoreParagraph.js';
+import { BlockWithAttributes } from '../../src/components/WordPressBlocksViewer';
+
+function renderProvider(
+  props: BlockWithAttributes<CoreParagraphFragmentProps>,
+) {
+  return render(
+    <WordPressBlocksProvider config={{ blocks: [], theme: {} }}>
+      <CoreParagraph {...props} />
+    </WordPressBlocksProvider>,
+  );
+}
+
+describe('<CoreParagraph />', () => {
+  test('renders the component correctly', () => {
+    renderProvider({ attributes: { content: 'Hello World' } });
+    expect(screen.queryByText('Hello World')).toBeInTheDocument();
+  });
+
+  test('applies the correct styles', () => {
+    renderProvider({
+      attributes: {
+        cssClassName: 'has-background-color',
+        style:
+          '{"color":{"background":"#602929"},"typography":{"fontSize":"53px"}}',
+        content: 'Hello World',
+      },
+    });
+    expect(screen.queryByText('Hello World')).toMatchInlineSnapshot(`
+      <p
+        class="has-background-color"
+        style="background-color: rgb(96, 41, 41); font-size: 53px;"
+      >
+        Hello World
+      </p>
+    `);
+  });
+});


### PR DESCRIPTION
## Tasks

- [ ] I have signed a [Contributor License Agreement (CLA)](https://github.com/wpengine/faustjs#contributor-license-agreement) with WP Engine.

## Description

<!--
Include a summary of the change and some contextual information.
-->

* Provides reference implementation of CoreParagraph block. 
* Uses `getStyles` helper/
* Adds Unit tests.

## Related Issue(s):

<!--
Provide the GitHub issue(s) number for issue tracking purposes, use the following syntax:

- #1234
-->

## Testing

<!--
Describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Also list any relevant details for your test configuration such as how to test the changes locally or in staging.
-->
* Follow instructions to configure the `blocks` package in the example project. https://faustjs.org/docs/gutenberg/getting-started
* Generate the global stylessheet and import it into the project. `faust generateGlobalStylesheet`.
```_app.js
import { WordPressBlocksProvider, fromThemeJson } from '@faustwp/blocks';
import themeJson from '../theme.json';
import '../globalStylesheet.css';

export default function MyApp({ Component, pageProps }) {
  const router = useRouter();
  return (
    <FaustProvider pageProps={pageProps}>
      <WordPressBlocksProvider
        config={{
          blocks,
          theme: fromThemeJson(themeJson),
        }}>
        <Component {...pageProps} key={router.asPath} />
      </WordPressBlocksProvider>
    </FaustProvider>
  );
}
```
* Comment out all the styles in the `examples/next/faustwp-getting-started/styles/_blocks.scss` since they will interfere with the global stylesheet.
* Import the blocks:
```js
import { coreBlocks } from '@faustwp/blocks';

export default {
  ...coreBlocks,
};
```
* Make sure you use the block fragment in the page query:

```graphql
${components.CoreParagraph.fragments.entry}
...
editorBlocks {
        __typename
        renderedHtml
        id: clientId
        parentClientId
        ...${components.CoreParagraph.fragments.key}
      }
```
* Use the `WordPressBlocksViewer`:
```
<Container>
            <ContentWrapper>
              <WordPressBlocksViewer blocks={blocks}/>
            </ContentWrapper>
          </Container>
```
* Go to WordPress site and create several paragraphs combining styles and colors. All changes should reflect in the decoupled site when updating the post.

## Screenshots

<!--
If this is a visual change include relevant screenshots about the behavior of the application before and after this change.
-->
<img width="1079" alt="Screenshot 2023-05-24 at 12 05 57" src="https://github.com/wpengine/faustjs/assets/328805/d472b95a-0303-4eb9-819c-157898733f4a">

## Documentation Changes

<!--
List corresponding changes to the documentation.
-->

## Dependant PRs

<!--
List any dependent PR's that are awaiting review. Use the following syntax:

- #1234
-->
