### PR TITLE
[Merl-904] Feat CoreColumns, CoreColumn, getLayoutStyles

### DIFF
--- a/.changeset/tall-cougars-sit.md
+++ b/.changeset/tall-cougars-sit.md
@@ -1,0 +1,5 @@
+---
+'@faustwp/blocks': patch
+---
+
+Add reference implementation of CoreColums and CoreColumn block

--- a/examples/next/faustwp-getting-started/components/Container/Container.js
+++ b/examples/next/faustwp-getting-started/components/Container/Container.js
@@ -1,8 +1,11 @@
 import styles from './Container.module.scss';
+import className from 'classnames/bind';
 
-export default function Container({ children }) {
+let cx = className.bind(styles);
+
+export default function Container({ children, className }) {
   return (
-    <div className={styles.component}>
+    <div className={cx(['component', className])}>
       {children}
     </div>
   );

--- a/examples/next/faustwp-getting-started/components/ContentWrapper/ContentWrapper.js
+++ b/examples/next/faustwp-getting-started/components/ContentWrapper/ContentWrapper.js
@@ -3,9 +3,9 @@ import styles from './ContentWrapper.module.scss';
 
 let cx = className.bind(styles);
 
-export default function ContentWrapper({ content, children }) {
+export default function ContentWrapper({ content, children, className }) {
   return (
-    <article className={cx('component')}>
+    <article className={cx(['component', className])}>
       <div dangerouslySetInnerHTML={{ __html: content ?? '' }} />
       {children}
     </article>

--- a/examples/next/faustwp-getting-started/styles/_blocks.scss
+++ b/examples/next/faustwp-getting-started/styles/_blocks.scss
@@ -11,3 +11,4 @@
 @import '@wordpress/base-styles/variables';
 @import '@wordpress/base-styles/breakpoints';
 @import '@wordpress/block-library/src/style';
+@import '@wordpress/block-library/src/theme';

--- a/packages/blocks/src/blocks/CoreColumn.tsx
+++ b/packages/blocks/src/blocks/CoreColumn.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { gql } from '@apollo/client';
+
+import { getStyles } from '../utils/get-styles/getStyles.js';
+import { useBlocksTheme } from '../components/WordPressBlocksProvider.js';
+
+import {
+  BlockWithAttributes,
+  ContentBlock,
+  WordPressBlocksViewer,
+} from '../components/WordPressBlocksViewer.js';
+
+export type CoreColumnFragmentProps = ContentBlock & {
+  attributes: {
+    cssClassName?: string;
+    align?: string;
+    anchor?: string;
+    layout?: string;
+    verticalAlignment?: string;
+    borderColor?: string;
+    backgroundColor?: string;
+    fontSize?: string;
+    fontFamily?: string;
+    style?: string;
+    textColor?: string;
+    gradient?: string;
+  };
+};
+
+export function CoreColumn(
+  props: BlockWithAttributes<CoreColumnFragmentProps>,
+) {
+  const theme = useBlocksTheme();
+  const style = getStyles(theme, { ...props });
+  const { attributes, innerBlocks } = props;
+  return (
+    <div style={style} className={attributes?.cssClassName}>
+      <WordPressBlocksViewer blocks={innerBlocks ?? []} />
+    </div>
+  );
+}
+
+CoreColumn.fragments = {
+  key: `CoreColumnBlockFragment`,
+  entry: gql`
+    fragment CoreColumnBlockFragment on CoreColumn {
+      attributes {
+        anchor
+        borderColor
+        backgroundColor
+        cssClassName
+        fontSize
+        fontFamily
+        gradient
+        layout
+        style
+        textColor
+        verticalAlignment
+        width
+      }
+    }
+  `,
+};

--- a/packages/blocks/src/blocks/CoreColumns.tsx
+++ b/packages/blocks/src/blocks/CoreColumns.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import { gql } from '@apollo/client';
+
+import { getStyles } from '../utils/get-styles/getStyles.js';
+import { useBlocksTheme } from '../components/WordPressBlocksProvider.js';
+
+import {
+  BlockWithAttributes,
+  ContentBlock,
+  WordPressBlocksViewer,
+} from '../components/WordPressBlocksViewer.js';
+
+export type CoreColumnsFragmentProps = ContentBlock & {
+  attributes: {
+    cssClassName?: string;
+    align?: string;
+    anchor?: string;
+    layout?: string;
+    isStackedOnMobile?: boolean;
+    verticalAlignment?: string;
+    borderColor?: string;
+    backgroundColor?: string;
+    fontSize?: string;
+    fontFamily?: string;
+    style?: string;
+    textColor?: string;
+    gradient?: string;
+  };
+};
+
+export function CoreColumns(
+  props: BlockWithAttributes<CoreColumnsFragmentProps>,
+) {
+  const theme = useBlocksTheme();
+  const style = getStyles(theme, { ...props });
+  const { attributes, innerBlocks } = props;
+  return (
+    <div style={style} className={attributes?.cssClassName}>
+      <WordPressBlocksViewer blocks={innerBlocks ?? []} />
+    </div>
+  );
+}
+
+CoreColumns.fragments = {
+  key: `CoreColumnsBlockFragment`,
+  entry: gql`
+    fragment CoreColumnsBlockFragment on CoreColumns {
+      attributes {
+        align
+        anchor
+        layout
+        cssClassName
+        isStackedOnMobile
+        verticalAlignment
+        borderColor
+        backgroundColor
+        fontSize
+        fontFamily
+        style
+        textColor
+        gradient
+      }
+    }
+  `,
+};

--- a/packages/blocks/src/blocks/CoreParagraph.tsx
+++ b/packages/blocks/src/blocks/CoreParagraph.tsx
@@ -11,17 +11,17 @@ import {
 
 export type CoreParagraphFragmentProps = ContentBlock & {
   attributes: {
-    cssClassName?: string;
-    backgroundColor?: string;
-    content?: string;
-    style?: string;
-    textColor?: string;
-    fontSize?: string;
-    fontFamily?: string;
-    direction?: string;
-    dropCap?: string;
-    gradient?: string;
-    align?: string;
+    cssClassName: string;
+    backgroundColor: string;
+    content: string;
+    style: string;
+    textColor: string;
+    fontSize: string;
+    fontFamily: string;
+    direction: string;
+    dropCap: string;
+    gradient: string;
+    align: string;
   };
 };
 

--- a/packages/blocks/src/blocks/CoreParagraph.tsx
+++ b/packages/blocks/src/blocks/CoreParagraph.tsx
@@ -11,17 +11,17 @@ import {
 
 export type CoreParagraphFragmentProps = ContentBlock & {
   attributes: {
-    cssClassName: string;
-    backgroundColor: string;
-    content: string;
-    style: string;
-    textColor: string;
-    fontSize: string;
-    fontFamily: string;
-    direction: string;
-    dropCap: string;
-    gradient: string;
-    align: string;
+    cssClassName?: string;
+    backgroundColor?: string;
+    content?: string;
+    style?: string;
+    textColor?: string;
+    fontSize?: string;
+    fontFamily?: string;
+    direction?: string;
+    dropCap?: string;
+    gradient?: string;
+    align?: string;
   };
 };
 

--- a/packages/blocks/src/blocks/index.ts
+++ b/packages/blocks/src/blocks/index.ts
@@ -1,6 +1,10 @@
 /* eslint-disable object-shorthand */
 import { CoreParagraph } from './CoreParagraph.js';
+import { CoreColumns } from './CoreColumns.js';
+import { CoreColumn } from './CoreColumn.js';
 
 export default {
   CoreParagraph: CoreParagraph,
+  CoreColumns: CoreColumns,
+  CoreColumn: CoreColumn,
 };

--- a/packages/blocks/src/components/WordPressBlocksViewer.tsx
+++ b/packages/blocks/src/components/WordPressBlocksViewer.tsx
@@ -41,7 +41,7 @@ export interface WordpressBlocksViewerProps {
    * <WordPressBlocksViewer fallbackBlock={MyFallbackComponent} />
    * ```
    */
-  fallbackBlock: React.FC<ContentBlock>;
+  fallbackBlock?: React.FC<ContentBlock>;
 }
 
 export interface ContentBlock {

--- a/packages/blocks/src/utils/get-styles/getLayoutStyles.ts
+++ b/packages/blocks/src/utils/get-styles/getLayoutStyles.ts
@@ -1,0 +1,53 @@
+import { BlocksTheme } from '../../types/theme.js';
+import { BlockWithAttributes } from '../../components/WordPressBlocksViewer.js';
+
+/**
+ *
+ * Returns the specified block Layout Styles
+ * @param theme Block Theme object
+ * @returns React CSS Properties object
+ */
+export default function getLayoutStyles<T extends BlockWithAttributes>(
+  theme: BlocksTheme,
+  block: T,
+): React.CSSProperties {
+  const { attributes } = block;
+  const styles: React.CSSProperties = {};
+  if (attributes?.width) {
+    styles.flexBasis = attributes.width as string;
+  }
+  if (attributes?.height) {
+    styles.height = attributes.height as string;
+  }
+  if (attributes?.layout) {
+    let layout: {
+      inherit?: string;
+      contentSize?: string;
+      wideSize?: string;
+      justifyContent?: string;
+    } = {};
+    try {
+      layout = JSON.parse(attributes.layout as string);
+    } catch (e) {
+      return styles;
+    }
+    const contentSize = layout?.contentSize ? layout.contentSize : null;
+    const wideSize = layout?.wideSize ? layout.wideSize : null;
+    const justifyContent = layout?.justifyContent
+      ? layout.justifyContent
+      : 'center';
+    const allMaxWidthValue = contentSize || wideSize;
+    const marginLeft =
+      justifyContent === 'left' ? '0 !important' : 'auto !important';
+    const marginRight =
+      justifyContent === 'right' ? '0 !important' : 'auto !important';
+
+    if (contentSize || wideSize) {
+      styles.maxWidth = allMaxWidthValue as string;
+      styles.marginLeft = marginLeft as string;
+      styles.marginRight = marginRight as string;
+    }
+  }
+
+  return styles;
+}

--- a/packages/blocks/src/utils/get-styles/getStyles.ts
+++ b/packages/blocks/src/utils/get-styles/getStyles.ts
@@ -5,6 +5,7 @@ import getTypographyStyles from './getTypographyStyles.js';
 import getBackgroundStyles from './getBackgroundStyles.js';
 import getTextStyles from './getTextStyles.js';
 import getBorderStyles from './getBorderStyles.js';
+import getLayoutStyles from './getLayoutStyles.js';
 
 export function getStyles<T extends BlockWithAttributes>(
   theme: BlocksTheme,
@@ -16,5 +17,6 @@ export function getStyles<T extends BlockWithAttributes>(
     ...getBackgroundStyles(theme, block),
     ...getTextStyles(theme, block),
     ...getBorderStyles(theme, block),
+    ...getLayoutStyles(theme, block),
   };
 }

--- a/packages/blocks/tests/blocks/CoreColumns.test.tsx
+++ b/packages/blocks/tests/blocks/CoreColumns.test.tsx
@@ -37,12 +37,27 @@ describe('<CoreColumns />', () => {
 
   test('applies the correct styles', () => {
     renderProvider({
+      innerBlocks: [
+        {
+          name: 'CoreParagraph',
+        },
+      ],
       attributes: {
         cssClassName: 'has-background-color',
         style:
           '{"color":{"background":"#602929"},"typography":{"fontSize":"53px"}}',
       },
     });
-    expect(screen.queryByText('Hello World')).toMatchInlineSnapshot(`null`);
+    expect(screen.queryByText('Hello World')?.parentNode)
+      .toMatchInlineSnapshot(`
+      <div
+        class="has-background-color"
+        style="background-color: rgb(96, 41, 41); font-size: 53px;"
+      >
+        <div>
+          Hello World
+        </div>
+      </div>
+    `);
   });
 });

--- a/packages/blocks/tests/blocks/CoreColumns.test.tsx
+++ b/packages/blocks/tests/blocks/CoreColumns.test.tsx
@@ -1,0 +1,48 @@
+/** @jest-environment jsdom */
+import * as React from 'react';
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import { WordPressBlocksProvider } from '../../src/components/WordPressBlocksProvider';
+import {
+  CoreColumns,
+  CoreColumnsFragmentProps,
+} from '../../src/blocks/CoreColumns.js';
+import { BlockWithAttributes } from '../../src/components/WordPressBlocksViewer';
+
+function renderProvider(props: BlockWithAttributes<CoreColumnsFragmentProps>) {
+  const blocks: any = {
+    CoreParagraph: () => {
+      return <div>Hello World</div>;
+    },
+  };
+  return render(
+    <WordPressBlocksProvider config={{ blocks, theme: {} }}>
+      <CoreColumns {...props} />
+    </WordPressBlocksProvider>,
+  );
+}
+
+describe('<CoreColumns />', () => {
+  test('renders the component correctly', () => {
+    renderProvider({
+      innerBlocks: [
+        {
+          name: 'CoreParagraph',
+        },
+      ],
+      attributes: {},
+    });
+    expect(screen.queryByText('Hello World')).toBeInTheDocument();
+  });
+
+  test('applies the correct styles', () => {
+    renderProvider({
+      attributes: {
+        cssClassName: 'has-background-color',
+        style:
+          '{"color":{"background":"#602929"},"typography":{"fontSize":"53px"}}',
+      },
+    });
+    expect(screen.queryByText('Hello World')).toMatchInlineSnapshot(`null`);
+  });
+});

--- a/packages/blocks/tests/utils/get-styles/getLayoutStyles.test.ts
+++ b/packages/blocks/tests/utils/get-styles/getLayoutStyles.test.ts
@@ -1,0 +1,68 @@
+import getLayoutStyles from '../../../src/utils/get-styles/getLayoutStyles';
+import { BlockWithAttributes } from '../../../src/components/WordPressBlocksViewer.js';
+import { BlocksTheme } from '../../../src/types/theme.js';
+
+describe('getLayoutStyles()', () => {
+  const theme = {};
+  it.each([
+    [theme, { attributes: {} }, {}],
+    [
+      theme,
+      { attributes: { width: '50%', height: '200px' } },
+      { flexBasis: '50%', height: '200px' },
+    ],
+    [
+      theme,
+      {
+        attributes: {
+          width: '50%',
+          height: '200px',
+          layout: JSON.stringify({
+            inherit: 'no',
+            contentSize: '800px',
+            wideSize: '1000px',
+            justifyContent: 'left',
+          }),
+        },
+      },
+      {
+        flexBasis: "50%",
+        height: "200px",
+        maxWidth: "800px",
+        marginLeft: '0 !important',
+        marginRight: 'auto !important',
+      },
+    ],
+    [
+      theme,
+      {
+        attributes: {
+          width: '50%',
+          height: '200px',
+          layout: JSON.stringify({
+            inherit: 'no',
+            contentSize: '800px',
+            wideSize: '1000px',
+            justifyContent: 'right',
+          }),
+        },
+      },
+      {
+        flexBasis: "50%",
+        height: "200px",
+        maxWidth: '800px',
+        marginLeft: 'auto !important',
+        marginRight: '0 !important',
+      },
+    ],
+  ])(
+    'theme %p and block %p expecting layout Styles %p',
+    (
+      theme: BlocksTheme,
+      block: BlockWithAttributes,
+      result: React.CSSProperties | undefined,
+    ) => {
+      expect(getLayoutStyles(theme, block)).toEqual(result);
+    },
+  );
+});


### PR DESCRIPTION
## Tasks

- [ ] I have signed a [Contributor License Agreement (CLA)](https://github.com/wpengine/faustjs#contributor-license-agreement) with WP Engine.

## Description

<!--
Include a summary of the change and some contextual information.
-->

* Provides reference implementation of CoreColums and CoreColumn block. 
* Uses `getStyles` helper/
* Added `getLayoutStyles` to handle layout block styles.
* Adds Unit tests.

## Related Issue(s):

<!--
Provide the GitHub issue(s) number for issue tracking purposes, use the following syntax:

- #1234
-->

## Testing

<!--
Describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Also list any relevant details for your test configuration such as how to test the changes locally or in staging.
-->
* Follow instructions to configure the `blocks` package in the example project. https://faustjs.org/docs/gutenberg/getting-started
* Generate the global stylessheet and import it into the project. `faust generateGlobalStylesheet`.
```_app.js
import { WordPressBlocksProvider, fromThemeJson } from '@faustwp/blocks';
import '../globalStylesheet.css';

export default function MyApp({ Component, pageProps }) {
  const router = useRouter();
  return (
    <FaustProvider pageProps={pageProps}>
      <WordPressBlocksProvider
        config={{
          blocks,
          theme: {},
        }}>
        <Component {...pageProps} key={router.asPath} />
      </WordPressBlocksProvider>
    </FaustProvider>
  );
}
```
* Comment out all the styles in the `examples/next/faustwp-getting-started/styles/_blocks.scss` since they will interfere with the global stylesheet.
* Import the blocks:
```js
import { coreBlocks } from '@faustwp/blocks';

export default {
  ...coreBlocks,
};
```
* Make sure you use the block fragment in the page query:

```js
import components from '../wp-blocks';
import { flatListToHierarchical } from '@faustwp/core';
import { WordPressBlocksViewer } from '@faustwp/blocks';

...
const { title, content, featuredImage, date, author, editorBlocks } = props.data.post;
const blocks = flatListToHierarchical(editorBlocks);
```

```graphql
${components.CoreParagraph.fragments.entry}
  ${components.CoreColumn.fragments.entry}
  ${components.CoreColumns.fragments.entry}
...
editorBlocks {
        name
        __typename
        renderedHtml
        id: clientId
        parentId: parentClientId
        ...${components.CoreParagraph.fragments.key}
        ...${components.CoreColumns.fragments.key}
        ...${components.CoreColumn.fragments.key}
      }
```
* Use the `WordPressBlocksViewer`:
```
<Container className="wp-block-group is-layout-flow">
            <ContentWrapper className="entry-content wp-block-post-content has-global-padding is-layout-constrained">
              <WordPressBlocksViewer blocks={blocks}/>
            </ContentWrapper>
          </Container>
```
* Go to WordPress site and create several columns combining different column sizes, widths and layout. All changes should reflect in the decoupled site when updating the post.


## Screenshots

<!--
If this is a visual change include relevant screenshots about the behavior of the application before and after this change.
-->

**Editor View**
<img width="1395" alt="Screenshot 2023-06-01 at 14 20 27" src="https://github.com/wpengine/faustjs/assets/328805/692c83e4-1f74-400c-83ac-4303178bea00">

**Headless View**
<img width="1257" alt="Screenshot 2023-06-01 at 14 20 17" src="https://github.com/wpengine/faustjs/assets/328805/11eb5b83-3ae5-437f-a90d-2533877e8199">


<!--
List corresponding changes to the documentation.
-->

## Dependant PRs

<!--
List any dependent PR's that are awaiting review. Use the following syntax:

- #1234
-->
