### PR TITLE
Adds the `faust` property to the page props

### DIFF
--- a/packages/faustwp-core/src/getProps.ts
+++ b/packages/faustwp-core/src/getProps.ts
@@ -84,6 +84,8 @@ export async function getNextStaticProps<Props>(
     returnedProps = { ...returnedProps, __PAGE_VARIABLES__: pageVariables };
   }
 
+  returnedProps = { ...returnedProps, __FAUST__: {} };
+
   const pageProps = addApolloState(apolloClient, { props: returnedProps });
   pageProps.revalidate = revalidate ?? DEFAULT_ISR_REVALIDATE;
   return pageProps as GetStaticPropsResult<Props>;
@@ -136,6 +138,8 @@ export async function getNextServerSideProps<Props>(
   if (pageVariables) {
     returnedProps = { ...returnedProps, __PAGE_VARIABLES__: pageVariables };
   }
+
+  returnedProps = { ...returnedProps, __FAUST__: {} };
 
   return addApolloState(apolloClient, {
     props: returnedProps,

--- a/packages/faustwp-core/src/getWordPressProps.tsx
+++ b/packages/faustwp-core/src/getWordPressProps.tsx
@@ -134,6 +134,7 @@ export async function getWordPressProps(
       __SEED_NODE__: seedNode ?? null,
       __TEMPLATE_QUERY_DATA__: templateQueryRes?.data ?? null,
       __TEMPLATE_VARIABLES__: templateVariables ?? null,
+      __FAUST__: {},
       ...props,
     },
   });


### PR DESCRIPTION
## Tasks

- [x] I have signed a [Contributor License Agreement (CLA)](https://github.com/wpengine/faustjs#contributor-license-agreement) with WP Engine.

## Description

This PR adds a `Faust` property to the page props. This can help us identify if a site is using Faust or not via the template system or the ssg/ssr helper functions. Additionally, we could put more Faust specific properties in this object as needed.

This property gets added to the page source, so doing a command+f for `__FAUST__` will make this determination.

<!--
Include a summary of the change and some contextual information.
-->

## Related Issue(s):

<!--
Provide the GitHub issue(s) number for issue tracking purposes, use the following syntax:

- #1234
-->

## Testing

<!--
Describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Also list any relevant details for your test configuration such as how to test the changes locally or in staging.
-->

## Screenshots

<!--
If this is a visual change include relevant screenshots about the behavior of the application before and after this change.
-->

## Documentation Changes

<!--
List corresponding changes to the documentation.
-->

## Dependant PRs

<!--
List any dependent PR's that are awaiting review. Use the following syntax:

- #1234
-->
