### PR TITLE
[MERL-907]Feat: Add CoreSeparator block

### DIFF
--- a/.changeset/brown-fans-attack.md
+++ b/.changeset/brown-fans-attack.md
@@ -1,0 +1,5 @@
+---
+'@faustwp/blocks': patch
+---
+
+Add CoreSeparator

--- a/packages/blocks/src/blocks/CoreSeparator.tsx
+++ b/packages/blocks/src/blocks/CoreSeparator.tsx
@@ -1,0 +1,58 @@
+import { gql } from '@apollo/client';
+import React from 'react';
+import { useBlocksTheme } from '../components/WordPressBlocksProvider.js';
+import {
+  BlockWithAttributes,
+  ContentBlock,
+} from '../components/WordPressBlocksViewer.js';
+import { getStyles } from '../utils/index.js';
+
+export type CoreSeparatorFragmentProps = ContentBlock & {
+  attributes: {
+    align?: string;
+    anchor?: string;
+    backgroundColor?: string;
+    cssClassName?: string;
+    gradient?: string;
+    opacity?: string;
+    style?: string;
+  };
+};
+
+export function CoreSeparator(
+  props: BlockWithAttributes<CoreSeparatorFragmentProps>,
+) {
+  const theme = useBlocksTheme();
+  const style = getStyles(theme, { ...props });
+  const { attributes } = props;
+
+  return (
+    <hr
+      style={style}
+      className={attributes?.cssClassName}
+      id={attributes?.anchor}
+    />
+  );
+}
+
+CoreSeparator.fragments = {
+  key: `CoreSeparatorBlockFragment`,
+  entry: gql`
+    fragment CoreSeparatorBlockFragment on CoreSeparator {
+      attributes {
+        align
+        anchor
+        opacity
+        gradient
+        backgroundColor
+        style
+        cssClassName
+      }
+    }
+  `,
+};
+
+CoreSeparator.config = {
+  name: 'CoreSeparator',
+};
+CoreSeparator.displayName = 'CoreSeparator';

--- a/packages/blocks/src/blocks/index.ts
+++ b/packages/blocks/src/blocks/index.ts
@@ -4,6 +4,7 @@ import { CoreColumns } from './CoreColumns.js';
 import { CoreColumn } from './CoreColumn.js';
 import { CoreCode } from './CoreCode.js';
 import { CoreQuote } from './CoreQuote.js';
+import { CoreSeparator } from './CoreSeparator.js';
 
 export default {
   CoreParagraph: CoreParagraph,
@@ -11,4 +12,5 @@ export default {
   CoreColumn: CoreColumn,
   CoreCode: CoreCode,
   CoreQuote: CoreQuote,
+  CoreSeparator: CoreSeparator,
 };

--- a/packages/blocks/tests/blocks/CoreSeparator.test.tsx
+++ b/packages/blocks/tests/blocks/CoreSeparator.test.tsx
@@ -1,0 +1,42 @@
+/** @jest-environment jsdom */
+import * as React from 'react';
+import '@testing-library/jest-dom';
+import { render } from '@testing-library/react';
+import { WordPressBlocksProvider } from '../../src/components/WordPressBlocksProvider';
+import {
+  CoreSeparator,
+  CoreSeparatorFragmentProps,
+} from '../../src/blocks/CoreSeparator.js';
+import { BlockWithAttributes } from '../../src/components/WordPressBlocksViewer';
+
+function renderProvider(
+  props: BlockWithAttributes<CoreSeparatorFragmentProps>,
+) {
+  return render(
+    <WordPressBlocksProvider config={{ blocks: [], theme: {} }}>
+      <CoreSeparator {...props} />
+    </WordPressBlocksProvider>,
+  );
+}
+
+describe('<CoreSeparator />', () => {
+  test('renders the component correctly', () => {
+    const tree = renderProvider({
+      attributes: {
+        backgroundColor: 'luminous-vivid-orange',
+        cssClassName:
+          'wp-block-separator has-text-color has-luminous-vivid-orange-color has-alpha-channel-opacity has-luminous-vivid-orange-background-color has-background',
+        style: '{"border":{"radius":"37px","width":"27px"}}',
+      },
+    });
+
+    expect(tree.container).toMatchInlineSnapshot(`
+      <div>
+        <hr
+          class="wp-block-separator has-text-color has-luminous-vivid-orange-color has-alpha-channel-opacity has-luminous-vivid-orange-background-color has-background"
+          style="border-width: 27px; border-radius: 37px;"
+        />
+      </div>
+    `);
+  });
+});

--- a/packages/blocks/tests/blocks/__snapshots__/CoreCode.test.tsx.snap
+++ b/packages/blocks/tests/blocks/__snapshots__/CoreCode.test.tsx.snap
@@ -1,0 +1,25 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<CoreCode /> applies the correct styles: 
+    <div>
+      <pre
+        class="wp-block-code has-border-color has-pale-cyan-blue-border-color has-background-color has-vivid-red-background-color has-text-color has-background has-medium-font-size"
+        style="border-width: 27px; border-radius: 37px;"
+      >
+        <code>
+          &lt;div&gt;My code block&lt;/div&gt;
+        </code>
+      </pre>
+    </div>    
+     1`] = `
+<div>
+  <pre
+    class="wp-block-code has-border-color has-pale-cyan-blue-border-color has-background-color has-vivid-red-background-color has-text-color has-background has-medium-font-size"
+    style="border-width: 27px; border-radius: 37px;"
+  >
+    <code>
+      &lt;div&gt;My code block&lt;/div&gt;
+    </code>
+  </pre>
+</div>
+`;


### PR DESCRIPTION
## Tasks

## Description

<!--
Include a summary of the change and some contextual information.
-->

* Provides reference implementation of CoreSeparator block. 
* Uses `getStyles` helper/
* Added `getLayoutStyles` to handle layout block styles.
* Adds Unit tests.

## Related Issue(s):

<!--
Provide the GitHub issue(s) number for issue tracking purposes, use the following syntax:

- #1234
-->

## Testing

<!--
Describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Also list any relevant details for your test configuration such as how to test the changes locally or in staging.
-->
* Follow instructions to configure the `blocks` package in the example project. https://faustjs.org/docs/gutenberg/getting-started
* Generate the global stylesheet and import it into the project. `faust generateGlobalStylesheet`.
```_app.js
import { WordPressBlocksProvider, fromThemeJson } from '@faustwp/blocks';
import '../globalStylesheet.css';

export default function MyApp({ Component, pageProps }) {
  const router = useRouter();
  return (
    <FaustProvider pageProps={pageProps}>
      <WordPressBlocksProvider
        config={{
          blocks,
          theme: {},
        }}>
        <Component {...pageProps} key={router.asPath} />
      </WordPressBlocksProvider>
    </FaustProvider>
  );
}
```
* Comment out all the styles in the `examples/next/faustwp-getting-started/styles/_blocks.scss` since they will interfere with the global stylesheet.
* Import the blocks:
```js
import { coreBlocks } from '@faustwp/blocks';

export default {
  ...coreBlocks,
};
```
* Make sure you use the block fragment in the page query:

```js
import components from '../wp-blocks';
import { flatListToHierarchical } from '@faustwp/core';
import { WordPressBlocksViewer } from '@faustwp/blocks';

...
const { title, content, featuredImage, date, author, editorBlocks } = props.data.post;
const blocks = flatListToHierarchical(editorBlocks);
```

```graphql
${components.CoreSeparator.fragments.entry}
...
editorBlocks {
        name
        __typename
        renderedHtml
        id: clientId
        parentId: parentClientId
        ...${components.CoreSeparator.fragments.key}
      }
```
* Use the `WordPressBlocksViewer`:
```
<Container className="wp-block-group is-layout-flow">
            <ContentWrapper className="entry-content wp-block-post-content has-global-padding is-layout-constrained">
              <WordPressBlocksViewer blocks={blocks}/>
            </ContentWrapper>
          </Container>
```
* Go to WordPress site and create several separtors combining different column sizes, widths and layout. All changes should reflect in the decoupled site when updating the post.


## Screenshots

<!--
If this is a visual change include relevant screenshots about the behavior of the application before and after this change.
-->

<img width="1788" alt="Screenshot 2023-06-12 at 12 32 12" src="https://github.com/wpengine/faustjs/assets/328805/fea14e99-b402-467f-83b8-89f94d1027bd">



## Documentation Changes

<!--
List corresponding changes to the documentation.
-->

## Dependant PRs

<!--
List any dependent PR's that are awaiting review. Use the following syntax:

- #1234
-->
