### PR TITLE
Add `@faustwp/blocks` package version & `wp-graphql-content-blocks` plugin version to Faust.js telemetry

### DIFF
--- a/.changeset/tidy-pandas-live.md
+++ b/.changeset/tidy-pandas-live.md
@@ -1,0 +1,5 @@
+---
+'@faustwp/cli': patch
+---
+
+Added `@faustwp/blocks` version to telemetry data and include `wp-graphql-content-blocks` version from the WordPress telemetry endpoint.

--- a/.changeset/tidy-pandas-live.md
+++ b/.changeset/tidy-pandas-live.md
@@ -2,4 +2,4 @@
 '@faustwp/cli': patch
 ---
 
-Added `@faustwp/blocks` version to telemetry data and include `wp-graphql-content-blocks` version from the WordPress telemetry endpoint.
+Added `@faustwp/blocks` version to telemetry data.

--- a/.changeset/tough-mice-pretend.md
+++ b/.changeset/tough-mice-pretend.md
@@ -1,0 +1,5 @@
+---
+'@faustwp/wordpress-plugin': patch
+---
+
+Added `wp-graphql-content-blocks` version to the telemetry endpoint.

--- a/internal/faustjs.org/docs/telemetry.mdx
+++ b/internal/faustjs.org/docs/telemetry.mdx
@@ -13,6 +13,7 @@ Faust collects completely anonymous telemetry data about general usage. Particip
 - WordPress version
 - PHP version
 - Faust plugin version & settings (frontend_uri is not collected)
+- [WPGraphQL Content Blocks](https://github.com/wpengine/wp-graphql-content-blocks) version
 - WordPress Multisite
 - If site is hosted on WP Engine
 
@@ -20,6 +21,7 @@ Faust collects completely anonymous telemetry data about general usage. Particip
 
 - `@faustwp/core` version
 - `@faustwp/cli` version
+- `@faustwp/blocks` version
 - `@apollo/client` version
 - Node version
 - Next.js Version

--- a/packages/faustwp-cli/src/telemetry/marshallTelemetryData.ts
+++ b/packages/faustwp-cli/src/telemetry/marshallTelemetryData.ts
@@ -10,6 +10,7 @@ export interface TelemetryData {
   setting_themes_disabled?: boolean;
   setting_img_src_replacement_enabled?: boolean;
   faustwp_version?: string;
+  wpgraphql_content_blocks_version?: string;
   is_wpe?: boolean;
   multisite?: boolean;
   php_version?: string;
@@ -17,6 +18,7 @@ export interface TelemetryData {
   platform?: string;
   node_faustwp_core_version?: string;
   node_faustwp_cli_version?: string;
+  node_faustwp_blocks_version?: string;
   node_apollo_client_version?: string;
   node_version?: string;
   node_next_version?: string;
@@ -69,6 +71,9 @@ export const marshallTelemetryData = (
     node_faustwp_cli_version: sanitizePackageJsonVersion(
       packageJson?.dependencies?.['@faustwp/cli'] as string | undefined,
     ),
+    node_faustwp_blocks_version: sanitizePackageJsonVersion(
+      packageJson?.dependencies?.['@faustwp/blocks'] as string | undefined,
+    ),
     node_apollo_client_version: sanitizePackageJsonVersion(
       packageJson?.dependencies?.['@apollo/client'] as string | undefined,
     ),
@@ -85,6 +90,8 @@ export const marshallTelemetryData = (
     setting_img_src_replacement_enabled:
       wpTelemetryData?.faustwp?.image_source_replacement_enabled,
     faustwp_version: wpTelemetryData?.faustwp?.version,
+    wpgraphql_content_blocks_version:
+      wpTelemetryData?.wpgraphql_content_blocks?.version,
     is_wpe: wpTelemetryData?.is_wpe,
     multisite: wpTelemetryData?.multisite,
     php_version: wpTelemetryData?.php_version,

--- a/packages/faustwp-cli/src/telemetry/requestWPTelemetryData.ts
+++ b/packages/faustwp-cli/src/telemetry/requestWPTelemetryData.ts
@@ -11,6 +11,9 @@ export interface WPTelemetryResponseData {
     themes_disabled: boolean;
     image_source_replacement_enabled: boolean;
   };
+  wpgraphql_content_blocks: {
+    version: string;
+  };
   is_wpe: boolean;
   multisite: boolean;
   php_version: string;

--- a/plugins/faustwp/includes/rest/callbacks.php
+++ b/plugins/faustwp/includes/rest/callbacks.php
@@ -20,6 +20,7 @@ use function WPE\FaustWP\Telemetry\{
 	get_wp_version,
 	is_wpe,
 	get_anonymous_faustwp_data,
+	get_anonymous_wpgraphql_content_blocks_data,
 };
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -124,11 +125,12 @@ function register_rest_routes() {
  */
 function handle_rest_telemetry_callback( \WP_REST_Request $request ) {
 	$data = array(
-		'faustwp'     => get_anonymous_faustwp_data(),
-		'is_wpe'      => is_wpe(),
-		'multisite'   => is_multisite(),
-		'php_version' => PHP_VERSION,
-		'wp_version'  => get_wp_version(),
+		'faustwp'                  => get_anonymous_faustwp_data(),
+		'wpgraphql_content_blocks' => get_anonymous_wpgraphql_content_blocks_data(),
+		'is_wpe'                   => is_wpe(),
+		'multisite'                => is_multisite(),
+		'php_version'              => PHP_VERSION,
+		'wp_version'               => get_wp_version(),
 	);
 
 	return new \WP_REST_Response( $data );

--- a/plugins/faustwp/includes/telemetry/functions.php
+++ b/plugins/faustwp/includes/telemetry/functions.php
@@ -101,14 +101,5 @@ function get_plugin_version() {
  * @return null|string
  */
 function get_wpgraphql_content_blocks_plugin_version() {
-	$plugin_file = 'wp-graphql-content-blocks/wp-graphql-content-blocks.php';
-
-	if ( is_plugin_active( $plugin_file ) ) {
-		$file_data = get_file_data( trailingslashit( WP_PLUGIN_DIR ) . $plugin_file, array( 'Version' ) );
-		$version   = $file_data[0];
-
-		return $version;
-	}
-
-	return null;
+	return defined( 'WPGRAPHQL_CONTENT_BLOCKS_VERSION' ) ? WPGRAPHQL_CONTENT_BLOCKS_VERSION : null;
 }

--- a/plugins/faustwp/includes/telemetry/functions.php
+++ b/plugins/faustwp/includes/telemetry/functions.php
@@ -56,6 +56,19 @@ function get_anonymous_faustwp_data() {
 }
 
 /**
+ * Returns the current WPGraphQL Content Blocks settings while keeping identifiable information private.
+ *
+ * @return array
+ */
+function get_anonymous_wpgraphql_content_blocks_data() {
+	$anonymous_data = array(
+		'version' => get_wpgraphql_content_blocks_plugin_version(),
+	);
+
+	return $anonymous_data;
+}
+
+/**
  * Checks if the frontend_uri FaustWP setting has been set.
  *
  * @return boolean
@@ -80,4 +93,22 @@ function get_plugin_version() {
 	$version   = $file_data[0];
 
 	return $version;
+}
+
+/**
+ * Returns the WPGraphql Content Blocks plugin version.
+ *
+ * @return null|string
+ */
+function get_wpgraphql_content_blocks_plugin_version() {
+	$plugin_file = 'wp-graphql-content-blocks/wp-graphql-content-blocks.php';
+
+	if ( is_plugin_active( $plugin_file ) ) {
+		$file_data = get_file_data( trailingslashit( WP_PLUGIN_DIR ) . $plugin_file, array( 'Version' ) );
+		$version   = $file_data[0];
+
+		return $version;
+	}
+
+	return null;
 }


### PR DESCRIPTION
## Tasks

- [X] I have signed a [Contributor License Agreement (CLA)](https://github.com/wpengine/faustjs#contributor-license-agreement) with WP Engine.

## Description

These changes add 2 new fields to GA

- `wpgraphql_content_blocks_version`
- `node_faustwp_blocks_version`

## Documentation Changes

- See the latest [Atlas Preview Environment](https://h9p8ppf6bszrcx4mrayge0wfy.js.wpenginepowered.com/docs/telemetry)