### PR TITLE
fix: GetSeedNode `id` and `uri` GraphQL params are required.

### DIFF
--- a/internal/faustjs.org/docs/faustwp/seed-query.mdx
+++ b/internal/faustjs.org/docs/faustwp/seed-query.mdx
@@ -43,8 +43,8 @@ export interface SeedNode {
 
 export const SEED_QUERY = gql`
   query GetSeedNode(
-    $id: ID = 0
-    $uri: String = ""
+    $id: ID! = 0
+    $uri: String! = ""
     $asPreview: Boolean = false
   ) {
     ... on RootQuery @skip(if: $asPreview) {

--- a/packages/faustwp-core/src/queries/seedQuery.ts
+++ b/packages/faustwp-core/src/queries/seedQuery.ts
@@ -27,7 +27,7 @@ export interface SeedNode {
 export const SEED_QUERY = gql`
   query GetSeedNode(
     $id: ID! = 0
-    $uri: String = ""
+    $uri: String! = ""
     $asPreview: Boolean = false
   ) {
     ... on RootQuery @skip(if: $asPreview) {

--- a/packages/faustwp-core/src/queries/seedQuery.ts
+++ b/packages/faustwp-core/src/queries/seedQuery.ts
@@ -26,7 +26,7 @@ export interface SeedNode {
 
 export const SEED_QUERY = gql`
   query GetSeedNode(
-    $id: ID = 0
+    $id: ID! = 0
     $uri: String = ""
     $asPreview: Boolean = false
   ) {


### PR DESCRIPTION
## Tasks

- [x] I have signed a [Contributor License Agreement (CLA)](https://github.com/wpengine/faustjs#contributor-license-agreement) with WP Engine.

## Description
This PR fixes a bug in the updated `GetSeedNode()` GraphQL query, where the `$id` and `$uri` parameters are given the wrong type (they must be non-null).

While this doesn't trigger any errors on a regular GraphQL requests (since a default value means the parameter is non-null), it does throw a `GraphQLError` when used with WPGraphQL Smart Cache's persisted queries, as the default value gets stripped from the stored query.

**Note:** I was lazy and made this changes on the GH browser. I recommend a `squash` merge to cleanup the unnecessary individual commits. Similarly there's no changeset. This branch is open to commits from maintainers, so go wild.

## Related Issue(s):

<!--
Provide the GitHub issue(s) number for issue tracking purposes, use the following syntax:

- #1234
-->

## Testing

<!--
Describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Also list any relevant details for your test configuration such as how to test the changes locally or in staging.
-->

## Screenshots

<!--
If this is a visual change include relevant screenshots about the behavior of the application before and after this change.
-->

## Documentation Changes

<!--
List corresponding changes to the documentation.
-->

## Dependant PRs

<!--
List any dependent PR's that are awaiting review. Use the following syntax:

- #1234
-->
