### PR TITLE
[Merl 1023] Bug Fix: `useLogin` access token `code` is now properly escaped.

### DIFF
--- a/.changeset/angry-papayas-applaud.md
+++ b/.changeset/angry-papayas-applaud.md
@@ -1,0 +1,5 @@
+---
+'@faustwp/core': patch
+---
+
+Bug Fix: useLogin access token `code` is now properly escaped.

--- a/.changeset/angry-papayas-applaud.md
+++ b/.changeset/angry-papayas-applaud.md
@@ -2,4 +2,4 @@
 '@faustwp/core': patch
 ---
 
-Bug Fix: useLogin access token `code` is now properly escaped.
+Bug Fix: `useLogin` and `fetchAccessToken` access token `code` parameter is now properly escaped. Fixes bug with authentication not workin on Vercel.

--- a/packages/faustwp-core/src/auth/client/accessToken.ts
+++ b/packages/faustwp-core/src/auth/client/accessToken.ts
@@ -140,7 +140,7 @@ export async function fetchAccessToken(code?: string): Promise<string | null> {
 
   // Add the code to the url if it exists
   if (isString(code) && code.length > 0) {
-    url += `?code=${code}`;
+    url += `?code=${encodeURIComponent(code)}`;
   }
 
   try {

--- a/packages/faustwp-core/tests/auth/client/accessToken.test.ts
+++ b/packages/faustwp-core/tests/auth/client/accessToken.test.ts
@@ -95,6 +95,20 @@ describe('auth/client/accessToken', () => {
     expect(accessToken.getAccessToken()).toBe('test');
   });
 
+  test('fetchAccessToken() should url encode the code parameter if provided', async () => {
+    const code = "//+\\==asdasdadasd:*&^%$))!£!";
+    fetchMock.get(`/api/faust/auth/token?code=${encodeURIComponent(code)}`, {
+      status: 200,
+      body: JSON.stringify({
+        accessToken: 'test',
+      }),
+    });
+    const token = await accessToken.fetchAccessToken(code);
+
+    expect(token).toBe('test');
+    expect(accessToken.getAccessToken()).toBe('test');
+  });
+
   test('A refresh timer is set after calling fetchAccessToken()', async () => {
     jest.spyOn(accessToken, 'getRefreshTimer');
 


### PR DESCRIPTION
## Tasks

- [x] I have signed a [Contributor License Agreement (CLA)](https://github.com/wpengine/faustjs#contributor-license-agreement) with WP Engine.
- [ ] If a code change, I have written testing instructions that the whole team & outside contributors can understand.
- [ ] I have written and included a comprehensive [changeset](https://github.com/wpengine/faustjs/blob/canary/DEVELOPMENT.md#deployment) to properly document the changes I've made.

## Description

<!--
Include a summary of the change and some contextual information.
-->

 - Fixes: https://github.com/wpengine/faustjs/issues/1471
 - Adds relevant test cases.

## Related Issue(s):

<!--
Provide the GitHub issue(s) number for issue tracking purposes, use the following syntax:

- #1234
-->

## Testing

<!--
Describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Also list any relevant details for your test configuration such as how to test the changes locally or in staging.
-->
1. Deploy this repo to vercel: https://github.com/theodesp/faust-middleware-basepath-breaks-next-link
2. Make sure you setup Front-end site URL to point to your WP Instance.
3. Navigate to the `/login` path and try to authenticate with WP.
4. Authentication should succeed all the times and you should not see any 500 errors.

**Note** The repo contains a patch-package that contains the fix in order to test on Vercel

https://github.com/theodesp/faust-middleware-basepath-breaks-next-link/blob/main/patches/%40faustwp%2Bcore%2B1.0.1.patch

## Screenshots

<!--
If this is a visual change include relevant screenshots about the behavior of the application before and after this change.
-->

## Documentation Changes

<!--
List corresponding changes to the documentation.
-->

## Dependant PRs

<!--
List any dependent PR's that are awaiting review. Use the following syntax:

- #1234
-->
