### PR TITLE
Fix/get config in fetch access token

### DIFF
--- a/.changeset/lucky-carpets-appear.md
+++ b/.changeset/lucky-carpets-appear.md
@@ -1,0 +1,5 @@
+---
+'@faustwp/core': patch
+---
+
+Prefix all api routes with the basePath from faust config when available. Fixes issue with preview tokens and logout with the toolbar.

--- a/packages/faustwp-core/src/auth/client/accessToken.ts
+++ b/packages/faustwp-core/src/auth/client/accessToken.ts
@@ -3,10 +3,8 @@ import {
   FAUST_API_BASE_PATH,
   TOKEN_ENDPOINT_PARTIAL_PATH,
 } from '../../lib/constants.js';
-import { getConfig } from '../../config/index.js';
+import { getGlobalBasePath } from '../../lib/getGlobalBasePath.js';
 import { isServerSide } from '../../utils/index.js';
-
-const { basePath } = getConfig();
 
 export interface AccessToken {
   /**
@@ -134,9 +132,7 @@ export function clearAccessTokenRefreshTimer(): void {
  * @param {string} code An authorization code to fetch an access token
  */
 export async function fetchAccessToken(code?: string): Promise<string | null> {
-  let url = `${
-    basePath ?? ''
-  }${FAUST_API_BASE_PATH}/${TOKEN_ENDPOINT_PARTIAL_PATH}`;
+  let url = `${getGlobalBasePath()}${FAUST_API_BASE_PATH}/${TOKEN_ENDPOINT_PARTIAL_PATH}`;
 
   // Add the code to the url if it exists
   if (isString(code) && code.length > 0) {

--- a/packages/faustwp-core/src/hooks/useLogout.tsx
+++ b/packages/faustwp-core/src/hooks/useLogout.tsx
@@ -3,6 +3,7 @@ import {
   FAUST_API_BASE_PATH,
   LOGOUT_ENDPOINT_PARTIAL_PATH,
 } from '../lib/constants.js';
+import { getGlobalBasePath } from '../lib/getGlobalBasePath.js';
 
 export function useLogout() {
   const [error, setError] = useState<Response | undefined>(undefined);
@@ -10,8 +11,7 @@ export function useLogout() {
 
   async function logout(redirectUrl?: string) {
     setLoading(true);
-
-    const logoutUrl = `${FAUST_API_BASE_PATH}/${LOGOUT_ENDPOINT_PARTIAL_PATH}`;
+    const logoutUrl = `${getGlobalBasePath()}${FAUST_API_BASE_PATH}/${LOGOUT_ENDPOINT_PARTIAL_PATH}`;
 
     // Clear the refresh token from the cookie.
     const res = await fetch(logoutUrl, {

--- a/packages/faustwp-core/src/lib/getGlobalBasePath.ts
+++ b/packages/faustwp-core/src/lib/getGlobalBasePath.ts
@@ -1,0 +1,7 @@
+import { getConfig } from '../config/index.js';
+
+export function getGlobalBasePath() {
+  const { basePath } = getConfig();
+
+  return basePath ?? '';
+}

--- a/packages/faustwp-core/src/server/router/index.ts
+++ b/packages/faustwp-core/src/server/router/index.ts
@@ -7,6 +7,7 @@ import {
   TOKEN_ENDPOINT_PARTIAL_PATH,
   FAUST_API_BASE_PATH,
 } from '../../lib/constants.js';
+import { getGlobalBasePath } from '../../lib/getGlobalBasePath.js';
 
 /**
  * A node handler for processing all incoming Faust API requests.
@@ -31,9 +32,9 @@ export async function apiRouter(
   const pathname = trimEnd(parsedUrl?.pathname, '/');
 
   switch (pathname) {
-    case `${FAUST_API_BASE_PATH}/${TOKEN_ENDPOINT_PARTIAL_PATH}`:
+    case `${getGlobalBasePath()}${FAUST_API_BASE_PATH}/${TOKEN_ENDPOINT_PARTIAL_PATH}`:
       return authorizeHandler(req, res);
-    case `${FAUST_API_BASE_PATH}/${LOGOUT_ENDPOINT_PARTIAL_PATH}`:
+    case `${getGlobalBasePath()}${FAUST_API_BASE_PATH}/${LOGOUT_ENDPOINT_PARTIAL_PATH}`:
       return logoutHandler(req, res);
     default:
       res.statusCode = 404;


### PR DESCRIPTION
## Tasks

- [x] I have signed a [Contributor License Agreement (CLA)](https://github.com/wpengine/faustjs#contributor-license-agreement) with WP Engine.
- [x] If a code change, I have written testing instructions that the whole team & outside contributors can understand.
- [x] I have written and included a comprehensive [changeset](https://github.com/wpengine/faustjs/blob/canary/DEVELOPMENT.md#deployment) to properly document the changes I've made.

## Description

This PR is a follow up to #1290 

Looks like we are calling getConfig and destructuring basePath at the top of packages/faustwp-core/src/auth/client/accessToken.ts before the config actually has a chance to load. Because of that basePath will be undefined since we will be using the defaults from normalizeConfig in packages/faustwp-core/src/config/index.ts.

To prevent this from happening, we can just move the call to getConfig and ref to basePath inside of fetchAccessToken

UPDATE: I was playing around with the experimental toolbar locally and noticed that the logout feature was 404ing. Seemed related to the basePath issue so I went ahead and prefixed all instances of api routes with the basePath and it fixed this issue as well. It's also possible that [this issue](https://github.com/wpengine/faustjs/issues/1429) might be related and solved by this fix.

## Related Issue(s):

- #1287  

## Testing

Tests were done locally by configuring `basePath` in `next.config.js` and `faust.config.js`.

## Screenshots

<!--
If this is a visual change include relevant screenshots about the behavior of the application before and after this change.
-->

## Documentation Changes

<!--
List corresponding changes to the documentation.
-->

## Dependant PRs

<!--
List any dependent PR's that are awaiting review. Use the following syntax:

- #1234
-->
