### PR TITLE
Exclude `main` from running the Next.js Bundle Analysis workflow

### DIFF
--- a/.github/workflows/nextjs-bundle-analysis.yml
+++ b/.github/workflows/nextjs-bundle-analysis.yml
@@ -10,6 +10,8 @@ on:
   push:
     branches:
       - canary
+    branches-ignore:
+      - main
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Tasks

- [X] I have signed a [Contributor License Agreement (CLA)](https://github.com/wpengine/faustjs#contributor-license-agreement) with WP Engine.
- [X] If a code change, I have written testing instructions that the whole team & outside contributors can understand.
- [X] I have written and included a comprehensive [changeset](https://github.com/wpengine/faustjs/blob/canary/DEVELOPMENT.md#deployment) to properly document the changes I've made.

## Description

This change prevents the Next.js Bundle Analysis job from running when syncing canary with main.

## Links

- https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-excluding-branches
- https://github.com/wpengine/faustjs/actions/runs/5523789313/jobs/10075190857
