### PR TITLE
Bug: Fix preview link button crushes browser.

### DIFF
--- a/.changeset/popular-poets-lick.md
+++ b/.changeset/popular-poets-lick.md
@@ -2,4 +2,4 @@
 '@faustwp/wordpress-plugin': patch
 ---
 
-Bug: Fixed preview button crashes browser.
+Bug: Fixed issue when preview button crashes browser when clicked 10-12 times.

--- a/.changeset/popular-poets-lick.md
+++ b/.changeset/popular-poets-lick.md
@@ -1,0 +1,5 @@
+---
+'@faustwp/wordpress-plugin': patch
+---
+
+Bug: Fixed preview button crashes browser.

--- a/plugins/faustwp/includes/replacement/callbacks.php
+++ b/plugins/faustwp/includes/replacement/callbacks.php
@@ -231,7 +231,7 @@ add_action( 'enqueue_block_editor_assets', __NAMESPACE__ . '\\enqueue_preview_sc
  * XXX: Please remove this once this issue is resolved: https://github.com/WordPress/gutenberg/issues/13998
  */
 function enqueue_preview_scripts() {
-	wp_enqueue_script( 'faustwp-gutenberg-filters', plugins_url( '/previewlinks.js', __FILE__ ), array(), '1.0.0', true );
+	wp_enqueue_script( 'faustwp-gutenberg-filters', plugins_url( '/previewlinks.js', __FILE__ ), array( 'jquery' ), '1.0.0', true );
 	wp_localize_script( 'faustwp-gutenberg-filters', '_faustwp_preview_link', array( '_preview_link' => get_preview_post_link() ) );
 }
 

--- a/plugins/faustwp/includes/replacement/previewlinks.js
+++ b/plugins/faustwp/includes/replacement/previewlinks.js
@@ -3,10 +3,10 @@
  */
 
 window.addEventListener('DOMContentLoaded', function () {
-  wp.domReady(function () {
+  jQuery(document).ready(function () {
     // Get the correct preview link via wp_localize_script
     const previewLink = window._faustwp_preview_link
-		? window._faustwp_preview_link._preview_link
+      ? window._faustwp_preview_link._preview_link
       : undefined;
 
     /**
@@ -18,7 +18,7 @@ window.addEventListener('DOMContentLoaded', function () {
     }
 
     const intervalId = setInterval(function () {
-      const previewButton = document.querySelectorAll(
+      const previewButton = jQuery(
         'button[class~="block-editor-post-preview__button-toggle"]',
       );
 
@@ -27,19 +27,19 @@ window.addEventListener('DOMContentLoaded', function () {
       }
 
       clearInterval(intervalId);
-      previewButton[0].addEventListener('click', function () {
+      previewButton.first().one('click', function () {
         setTimeout(function () {
-          const links = document.querySelectorAll('a[target*="wp-preview"]');
+          const links = jQuery('a[target*="wp-preview"]');
 
           if (!links.length) {
             return;
           }
 
-          links.forEach((link) => {
+          links.each((i, link) => {
             link.href = previewLink;
 
             var copy = link.cloneNode(true);
-            copy.addEventListener('click', function (ev) {
+            copy.addEventListener('click', function () {
               previewButton[0].click();
 
               wp.data.dispatch('core/editor').autosave();


### PR DESCRIPTION
## Tasks

- [ ] I have signed a [Contributor License Agreement (CLA)](https://github.com/wpengine/faustjs#contributor-license-agreement) with WP Engine.
- [x] If a code change, I have written testing instructions that the whole team & outside contributors can understand.
- [x] I have written and included a comprehensive [changeset](https://github.com/wpengine/faustjs/blob/canary/DEVELOPMENT.md#deployment) to properly document the changes I've made.

## Description

Fixes issue when clicking multiple times the preview button crushes the browser.


## Related Issue(s):

<!--
Provide the GitHub issue(s) number for issue tracking purposes, use the following syntax:

- #1234
-->

https://github.com/wpengine/faustjs/issues/1491

## Testing

<!--
Describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Also list any relevant details for your test configuration such as how to test the changes locally or in staging.
-->

1. Make or edit a new page
2.. Click on the "Preview in new tab" button
3. Once the new tab opens get back to the editor and click the button again
4 Repeat step 2 approximately 10 - 15 times
5 Browser should not become unresponsive.

## Screenshots

<!--
If this is a visual change include relevant screenshots about the behavior of the application before and after this change.
-->

## Documentation Changes

<!--
List corresponding changes to the documentation.
-->

## Dependant PRs

<!--
List any dependent PR's that are awaiting review. Use the following syntax:

- #1234
-->
