### PR TITLE
[Merl 1018] Allow passing extra arguments in `Page.variables`.

### DIFF
--- a/.changeset/brown-swans-pretend.md
+++ b/.changeset/brown-swans-pretend.md
@@ -1,0 +1,18 @@
+---
+'@faustwp/core': minor
+---
+
+Allow passing extra parameters in Page.variables(). This is allowed in `getNextStaticProps``, `getServerSideProps` and `getWordPressProps`:
+
+Ex:
+
+```
+export function getStaticProps(ctx) {
+  return getWordPressProps({ ctx, extra: {hello: 'world'} }); // extra parameter will be forwarded to the Template `variables` callback
+}
+
+Component.variables = ({ databaseId }, ctx, extra) => {
+  console.log(extra) // {hello: 'world'}
+  ...
+}
+```

--- a/.changeset/brown-swans-pretend.md
+++ b/.changeset/brown-swans-pretend.md
@@ -2,7 +2,7 @@
 '@faustwp/core': minor
 ---
 
-Allow passing extra parameters in Page.variables(). This is allowed in `getNextStaticProps``, `getServerSideProps` and `getWordPressProps`:
+Allow passing extra parameters in Page.variables(). This is allowed in `getNextStaticProps`, `getServerSideProps` and `getWordPressProps`:
 
 Ex:
 

--- a/packages/faustwp-core/src/getWordPressProps.tsx
+++ b/packages/faustwp-core/src/getWordPressProps.tsx
@@ -20,7 +20,11 @@ export type WordPressTemplate = React.FC & {
   query?: DocumentNode;
   variables?: (
     seedNode: SeedNode,
-    context?: { asPreview?: boolean; locale?: string },
+    context?: {
+      asPreview?: boolean;
+      locale?: string;
+    },
+    extra?: Record<string, unknown>,
   ) => { [key: string]: any };
 };
 
@@ -34,6 +38,10 @@ export interface GetWordPressPropsConfig<Props = Record<string, unknown>> {
   ctx: GetServerSidePropsContext | GetStaticPropsContext;
   props?: Props;
   revalidate?: number | boolean;
+  /**
+   * Provide extra parameters for the Page.variables function call.
+   */
+  extra?: Props;
 }
 export async function getWordPressProps(
   options: GetWordPressPropsConfig,
@@ -54,7 +62,7 @@ export async function getWordPressProps(
     throw new Error('Templates are required. Please add them to your config.');
   }
 
-  const { ctx, props, revalidate } = options;
+  const { ctx, props, revalidate, extra } = options;
 
   const client = getApolloClient();
 
@@ -116,7 +124,14 @@ export async function getWordPressProps(
 
   let templateQueryRes;
   const templateVariables = template?.variables
-    ? template?.variables(seedNode, { asPreview: false, locale: ctx.locale })
+    ? template?.variables(
+        seedNode,
+        {
+          asPreview: false,
+          locale: ctx.locale,
+        },
+        extra,
+      )
     : undefined;
 
   if (template.query) {

--- a/packages/faustwp-core/tests/getProps.test.ts
+++ b/packages/faustwp-core/tests/getProps.test.ts
@@ -83,16 +83,19 @@ describe('getProps', () => {
             }
           }
         `,
-        variables: () => ({
+        variables: (ctx: any, extra?: Record<string, unknown>) => ({
           testVar: true,
+          extra
         }),
       };
 
-      expect(await getNextStaticProps({}, { Page })).toStrictEqual({
+      expect(
+        await getNextStaticProps({}, { Page, extra: { custom: 'data' } }),
+      ).toStrictEqual({
         props: {
           __APOLLO_STATE__: { testing: true },
           data: { generalSettings: { title: 'My test site' } },
-          __PAGE_VARIABLES__: { testVar: true },
+          __PAGE_VARIABLES__: { testVar: true,  extra: { custom: 'data' } },
         },
         revalidate: 900,
       });
@@ -120,8 +123,9 @@ describe('getProps', () => {
             }
           }
         `,
-        variables: () => ({
+        variables: (ctx: any, extra?: Record<string, unknown>) => ({
           testVar: true,
+          extra
         }),
       };
 
@@ -134,13 +138,13 @@ describe('getProps', () => {
               end() {},
             },
           } as any,
-          { Page },
+          { Page, extra: { custom: 'data' } },
         ),
       ).toStrictEqual({
         props: {
           __APOLLO_STATE__: { testing: true },
           data: { generalSettings: { title: 'My test site' } },
-          __PAGE_VARIABLES__: { testVar: true },
+          __PAGE_VARIABLES__: { testVar: true, extra: { custom: 'data' } },
         },
       });
     });


### PR DESCRIPTION
## Tasks

- [ ] I have signed a [Contributor License Agreement (CLA)](https://github.com/wpengine/faustjs#contributor-license-agreement) with WP Engine.
- [x] If a code change, I have written testing instructions that the whole team & outside contributors can understand.
- [x] I have written and included a comprehensive [changeset](https://github.com/wpengine/faustjs/blob/canary/DEVELOPMENT.md#deployment) to properly document the changes I've made.

## Description

This PR allows passing extra arguments in `Page.variables()`. This is exposed in `getNextStaticProps`, `getServerSideProps` and `getWordPressProps`.

```
export function getStaticProps(ctx) {
  return getWordPressProps({ ctx, extra: {hello: 'world'} }); // extra argument will be forwarded to the Template `variables` callback
}
Component.variables = ({ databaseId }, ctx, extra) => {
  console.log(extra) // {hello: 'world'}
  ...
}
```


<!--
Include a summary of the change and some contextual information.
-->

## Related Issue(s):

<!--
Provide the GitHub issue(s) number for issue tracking purposes, use the following syntax:

- #1234
-->

## Testing

<!--
Describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Also list any relevant details for your test configuration such as how to test the changes locally or in staging.
-->

* Use the `extra`  field and pass custom parameters in the `getNextStaticProps`, `getServerSideProps` and `getWordPressProps` helpers. There should be passed verbatim as an extra argument to the `variables()` callback.

## Screenshots

<!--
If this is a visual change include relevant screenshots about the behavior of the application before and after this change.
-->

## Documentation Changes

<!--
List corresponding changes to the documentation.
-->

## Dependant PRs

<!--
List any dependent PR's that are awaiting review. Use the following syntax:

- #1234
-->
