### PR TITLE
Prevent base URL replacement in GraphQL response when `url` & `href` key values contain file extensions

### DIFF
--- a/.changeset/polite-dolphins-cover.md
+++ b/.changeset/polite-dolphins-cover.md
@@ -1,0 +1,5 @@
+---
+'@faustwp/wordpress-plugin': patch
+---
+
+Image URLs (and any URLs with file extensions) are now excluded from the replacement that Faust does in the GraphQL query results.

--- a/plugins/faustwp/includes/replacement/functions.php
+++ b/plugins/faustwp/includes/replacement/functions.php
@@ -98,16 +98,16 @@ function normalize_sitemap_entry( $sitemap_entry ) {
 /**
  * Check if a string has a file extension.
  *
- * @param string $string
+ * @param string $string The string to check.
  * @return boolean
  */
 function has_file_extension( $string ) {
-    $file_extension_pattern = '/\.[a-zA-Z0-9]+$/';
+	$file_extension_pattern = '/\.[a-zA-Z0-9]+$/';
 
-    if ( preg_match( $file_extension_pattern, $string ) ) {
-        return true; 
-    } else {
-        return false; // String does not have a file extension.
-    }
+	if ( preg_match( $file_extension_pattern, $string ) ) {
+		return true;
+	} else {
+		return false; // String does not have a file extension.
+	}
 }
 

--- a/plugins/faustwp/includes/replacement/functions.php
+++ b/plugins/faustwp/includes/replacement/functions.php
@@ -102,7 +102,7 @@ function normalize_sitemap_entry( $sitemap_entry ) {
  * @return array An array of GraphQL response keys.
  */
 function graphql_rewrite_keys() {
-	$graphql_rewrite_keys = [ 'url', 'href' ];
+	$graphql_rewrite_keys = array( 'url', 'href' );
 
 	/**
 	 * Filter 'faustwp_graphql_rewrite_keys'.

--- a/plugins/faustwp/includes/replacement/functions.php
+++ b/plugins/faustwp/includes/replacement/functions.php
@@ -96,18 +96,18 @@ function normalize_sitemap_entry( $sitemap_entry ) {
 }
 
 /**
- * Determine what keys within a GraphQL response should have
- * their values rewritten when rewrites are enabled.
+ * Check if a string has a file extension.
  *
- * @return array An array of GraphQL response keys.
+ * @param string $string
+ * @return boolean
  */
-function graphql_rewrite_keys() {
-	$graphql_rewrite_keys = array( 'url', 'href' );
+function has_file_extension( $string ) {
+    $file_extension_pattern = '/\.[a-zA-Z0-9]+$/';
 
-	/**
-	 * Filter 'faustwp_graphql_rewrite_keys'.
-	 *
-	 * Used to override or extend the response keys targeted to have their values rewritten.
-	 */
-	return apply_filters( 'faustwp_graphql_rewrite_keys', $graphql_rewrite_keys );
+    if ( preg_match( $file_extension_pattern, $string ) ) {
+        return true; 
+    } else {
+        return false; // String does not have a file extension.
+    }
 }
+

--- a/plugins/faustwp/includes/replacement/functions.php
+++ b/plugins/faustwp/includes/replacement/functions.php
@@ -94,3 +94,20 @@ function normalize_sitemap_entry( $sitemap_entry ) {
 
 	return $sitemap_entry;
 }
+
+/**
+ * Determine what keys within a GraphQL response should have
+ * their values rewritten when rewrites are enabled.
+ *
+ * @return array An array of GraphQL response keys.
+ */
+function graphql_rewrite_keys() {
+	$graphql_rewrite_keys = [ 'url', 'href' ];
+
+	/**
+	 * Filter 'faustwp_graphql_rewrite_keys'.
+	 *
+	 * Used to override or extend the response keys targeted to have their values rewritten.
+	 */
+	return apply_filters( 'faustwp_graphql_rewrite_keys', $graphql_rewrite_keys );
+}

--- a/plugins/faustwp/includes/replacement/graphql-callbacks.php
+++ b/plugins/faustwp/includes/replacement/graphql-callbacks.php
@@ -8,7 +8,7 @@
 namespace WPE\FaustWP\Replacement;
 
 use function WPE\FaustWP\Settings\faustwp_get_setting;
-use function WPE\FaustWP\Replacement\graphql_rewrite_keys;
+use function WPE\FaustWP\Replacement\has_file_extension;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -43,8 +43,8 @@ function url_replacement( $response ) {
 }
 
 /**
- * Replaces the WordPress Site URL with the replacement domain in 'url' and
- * 'href' fields.
+ * Replaces the WordPress Site URL with the replacement domain
+ * in 'url' and 'href' fields, skipping over values with file extensions.
  *
  * @param array $data The response data.
  */
@@ -55,7 +55,11 @@ function url_replace_recursive( &$data ) {
 			continue;
 		}
 
-		if ( in_array( $key, graphql_rewrite_keys(), true ) && is_string( $value ) ) {
+		if (
+			( 'url' === $key || 'href' === $key ) && 
+			is_string( $value ) &&
+			! has_file_extension( $value )
+		) {
 			$replacement = faustwp_get_setting( 'frontend_uri', '/' );
 			$value       = str_replace( site_url(), $replacement, $value );
 		} elseif ( ( 'path' === $key && is_multisite() ) && is_string( $value ) ) {

--- a/plugins/faustwp/includes/replacement/graphql-callbacks.php
+++ b/plugins/faustwp/includes/replacement/graphql-callbacks.php
@@ -55,23 +55,13 @@ function url_replace_recursive( &$data ) {
 			continue;
 		}
 
-		if (
-			in_array( $key, graphql_rewrite_keys(), true ) &&
-			is_string( $value )
-		) {
-			// Handle URI replacements.
+		if ( in_array( $key, graphql_rewrite_keys(), true ) && is_string( $value ) ) {
 			$replacement = faustwp_get_setting( 'frontend_uri', '/' );
 			$value       = str_replace( site_url(), $replacement, $value );
-
-		} elseif (
-			( 'path' === $key && is_multisite() ) &&
-			is_string( $value )
-		) {
-			// Remove subdirectory from the path if multisite.
+		} elseif ( ( 'path' === $key && is_multisite() ) && is_string( $value ) ) {
 			$site         = get_site();
 			$subdirectory = untrailingslashit( $site->path );
 			$value        = str_replace( $subdirectory, '', $value );
-
 		} elseif ( is_array( $value ) ) {
 			url_replace_recursive( $value );
 		}

--- a/plugins/faustwp/includes/replacement/graphql-callbacks.php
+++ b/plugins/faustwp/includes/replacement/graphql-callbacks.php
@@ -56,7 +56,7 @@ function url_replace_recursive( &$data ) {
 		}
 
 		if (
-			( 'url' === $key || 'href' === $key ) && 
+			( 'url' === $key || 'href' === $key ) &&
 			is_string( $value ) &&
 			! has_file_extension( $value )
 		) {

--- a/plugins/faustwp/tests/integration/ReplacementFunctionsTests.php
+++ b/plugins/faustwp/tests/integration/ReplacementFunctionsTests.php
@@ -12,7 +12,8 @@ use function WPE\FaustWP\Replacement\{
 	normalize_url,
 	equivalent_wp_url,
 	equivalent_frontend_url,
-	normalize_sitemap_entry
+	normalize_sitemap_entry,
+	has_file_extension
 };
 
 class ReplacementFunctionsTests extends \WP_UnitTestCase {
@@ -90,4 +91,14 @@ class ReplacementFunctionsTests extends \WP_UnitTestCase {
 
 		$this->assertStringContainsString( get_home_url(), $normalized_sitemap_entry['loc'] );
 	}
+
+	public function test_has_file_extension() {
+        $this->assertTrue( has_file_extension( 'file.txt' ) );
+        $this->assertTrue( has_file_extension( 'document.pdf' ) );
+        $this->assertTrue( has_file_extension( 'image.jpg' ) );
+        $this->assertFalse( has_file_extension( 'file' ) );
+        $this->assertFalse( has_file_extension( 'no_extension.' ) );
+        $this->assertFalse( has_file_extension( 'no_extension' ) );
+        $this->assertFalse( has_file_extension( 'file.with.multiple.extensions' ) );
+    }
 }

--- a/plugins/faustwp/tests/integration/ReplacementFunctionsTests.php
+++ b/plugins/faustwp/tests/integration/ReplacementFunctionsTests.php
@@ -99,6 +99,5 @@ class ReplacementFunctionsTests extends \WP_UnitTestCase {
         $this->assertFalse( has_file_extension( 'file' ) );
         $this->assertFalse( has_file_extension( 'no_extension.' ) );
         $this->assertFalse( has_file_extension( 'no_extension' ) );
-        $this->assertFalse( has_file_extension( 'file.with.multiple.extensions' ) );
     }
 }


### PR DESCRIPTION
## Tasks

- [X] I have signed a [Contributor License Agreement (CLA)](https://github.com/wpengine/faustjs#contributor-license-agreement) with WP Engine.
- [X] If a code change, I have written testing instructions that the whole team & outside contributors can understand.
- [X] I have written and included a comprehensive [changeset](https://github.com/wpengine/faustjs/blob/canary/DEVELOPMENT.md#deployment) to properly document the changes I've made.

## Description

When using ‘url’ as an alias for a featured image’s sourceUrl, Faust is mistaking that image url as one that it should replace. These changes check if those replacement key values contain file extensions, and to skip replacement if true.

## Testing

Use the following query to test that image URL's are no longer being replaced when using the `url` or `href` key.

```graphql
{
  generalSettings {
    url # never rewritten
  }
  posts {
    nodes {
      title
      featuredImage {
        node {
          normal: sourceUrl # control
          url: sourceUrl # url is replaced by faustwp
          href: sourceUrl # href is replaced by faustwp
        }
      }
    }
  }
}

```

Observe that the 3 alias' for the featured image sourceUrl are not replacing the base url with the frontend uri. 

## Screenshots

<img width="1889" alt="Screenshot 2023-07-19 at 12 50 50 PM" src="https://github.com/wpengine/faustjs/assets/6676674/e791ceb1-a9f4-4887-b979-9f251b7fb33d">
