### PR TITLE
chore: fix changelog link

### DIFF
--- a/scripts/versionPlugin.js
+++ b/scripts/versionPlugin.js
@@ -156,7 +156,7 @@ async function generateReadmeChangelog(readmeTxtFile, changelog) {
     const changelogStart = readmeTxt.indexOf('== Changelog ==');
 
     output = readmeTxt.substring(0, changelogStart) + changelog;
-    output += "\n[View the full changelog](https://faustjs.org/docs/changelog/faustwp)";
+    output += "\n[View the full changelog](https://github.com/wpengine/faustjs/blob/canary/plugins/faustwp/CHANGELOG.md)";
 
     return writeFile(readmeTxtFile, output);
   } catch(e) {


### PR DESCRIPTION
Existing link is broken. This updates the link to point to the changelog here in GitHub. I linked to `canary` because `main` is not always up to date with what is deployed (though maybe it should be, separate concern).

