### PR TITLE
Update plugin tests to use MySQL 8

### DIFF
--- a/plugins/faustwp/docker-compose.yml
+++ b/plugins/faustwp/docker-compose.yml
@@ -24,7 +24,7 @@ services:
       - ./:/var/www/html/wp-content/plugins/faustwp
 
   db:
-    image: mysql:5.7
+    image: mysql:8
     restart: always
     ports:
       - 33066:3306


### PR DESCRIPTION
## Tasks

- [x] I have signed a [Contributor License Agreement (CLA)](https://github.com/wpengine/faustjs#contributor-license-agreement) with WP Engine.
- [x] If a code change, I have written testing instructions that the whole team & outside contributors can understand.
- [x] I have written and included a comprehensive [changeset](https://github.com/wpengine/faustjs/blob/canary/DEVELOPMENT.md#deployment) to properly document the changes I've made.

## Description

This changes updates the docker database within the faustwp to use MySQL 8.

## Testing

Observe that the updated workflow is still passing.
