### PR TITLE
Remove the broken faust plugin release step

### DIFF
--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -42,18 +42,3 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-
-      - name: Possibly deploy WordPress plugin
-        # Checks the changesets publishedPackages output
-        # If there is a published package named "@faustwp/wordpress-plugin"
-        # Then deploy the WordPress plugin
-        # https://github.com/changesets/action#outputs
-        if: contains(fromJSON(steps.changesets.outputs.publishedPackages).*.name, '@faustwp/wordpress-plugin')
-        # Use a variant of 10up/action-wordpress-plugin-deploy that allows us to specify a PLUGIN_DIR
-        # to support our monorepo structure.
-        uses: ./.github/actions/release-plugin
-        env:
-          SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
-          SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
-          PLUGIN_DIR: plugins/faustwp
-          SLUG: faustwp


### PR DESCRIPTION
We can still rely on the manual release-plugin action do deploy the plugin to the WP repo

## Tasks

- [x] I have signed a [Contributor License Agreement (CLA)](https://github.com/wpengine/faustjs#contributor-license-agreement) with WP Engine.
- [ ] If a code change, I have written testing instructions that the whole team & outside contributors can understand.
- [ ] I have written and included a comprehensive [changeset](https://github.com/wpengine/faustjs/blob/canary/DEVELOPMENT.md#deployment) to properly document the changes I've made.

## Description

This PR removes the automatic deploy step to WordPress.org. This step was broken since it was not executed in a workflow with a proper new tag, the script didn't know what the latest version was to deploy.

This PR removes this step until it's resolved/we come up with a different solution. For now, we can still manually invoke a plugin release via the `release-plugin` action.

<!--
Include a summary of the change and some contextual information.
-->

## Related Issue(s):

<!--
Provide the GitHub issue(s) number for issue tracking purposes, use the following syntax:

- #1234
-->

## Testing

<!--
Describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Also list any relevant details for your test configuration such as how to test the changes locally or in staging.
-->

## Screenshots

<!--
If this is a visual change include relevant screenshots about the behavior of the application before and after this change.
-->

## Documentation Changes

<!--
List corresponding changes to the documentation.
-->

## Dependant PRs

<!--
List any dependent PR's that are awaiting review. Use the following syntax:

- #1234
-->
