### PR TITLE
CI/CD: Run Bundle Analysis only on canary branch.

### DIFF
--- a/.github/workflows/nextjs-bundle-analysis.yml
+++ b/.github/workflows/nextjs-bundle-analysis.yml
@@ -9,9 +9,7 @@ on:
   pull_request:
   push:
     branches:
-      - canary
-    branches-ignore:
-      - main
+      - 'canary'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Tasks

- [ ] I have signed a [Contributor License Agreement (CLA)](https://github.com/wpengine/faustjs#contributor-license-agreement) with WP Engine.
- [ ] If a code change, I have written testing instructions that the whole team & outside contributors can understand.
- [ ] I have written and included a comprehensive [changeset](https://github.com/wpengine/faustjs/blob/canary/DEVELOPMENT.md#deployment) to properly document the changes I've made.

## Description

<!--
Include a summary of the change and some contextual information.
-->
- Next.js Bundle Analysis job runs only on canary branch and uses correct job syntax.
- Remove `branches-ignore` since it cannot used with `branches` in the same declaration.

## Related Issue(s):

<!--
Provide the GitHub issue(s) number for issue tracking purposes, use the following syntax:

- #1234
-->

## Testing

<!--
Describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Also list any relevant details for your test configuration such as how to test the changes locally or in staging.
-->

## Screenshots

<!--
If this is a visual change include relevant screenshots about the behavior of the application before and after this change.
-->

## Documentation Changes

<!--
List corresponding changes to the documentation.
-->

## Dependant PRs

<!--
List any dependent PR's that are awaiting review. Use the following syntax:

- #1234
-->
