### PR TITLE
MERL-1168 - ci: update checkout and setup-node actions to v3

### DIFF
--- a/.github/workflows/audit-dependencies.yml
+++ b/.github/workflows/audit-dependencies.yml
@@ -3,7 +3,7 @@ name: Audit Dependencies
 on: pull_request
 
 jobs:
-  audit_depedencies:
+  audit_dependencies:
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/e2e-test-plugin.yml
+++ b/.github/workflows/e2e-test-plugin.yml
@@ -11,9 +11,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup Node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: '16'
       - name: Install NPM Deps

--- a/.github/workflows/nightly-releases.yml
+++ b/.github/workflows/nightly-releases.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
## Tasks

- [ ] I have signed a [Contributor License Agreement (CLA)](https://github.com/wpengine/faustjs#contributor-license-agreement) with WP Engine.
- [ ] If a code change, I have written testing instructions that the whole team & outside contributors can understand.
- [ ] I have written and included a comprehensive [changeset](https://github.com/wpengine/faustjs/blob/canary/DEVELOPMENT.md#deployment) to properly document the changes I've made.

## Description

Updates the GitHub Actions workflows to use the newer versions of `checkout` and `setup-node`, to address the warnings as seen on PRs like this: https://github.com/wpengine/faustjs/actions/runs/5786911890.

Also fixes a misspelling.

