### PR TITLE
Feat: (registerFaustBlock) Add Edit Function (Preview mode)

### DIFF
--- a/.changeset/rich-rice-mix.md
+++ b/.changeset/rich-rice-mix.md
@@ -8,6 +8,6 @@ Feat: Added a default EditFunction.
 import metadata from './block.json';
 
 import MyFirstBlock from './MyFirstBlock';
-import registerFaustBlock from '@faustwp/block-editor-utils';
+import {registerFaustBlock} from '@faustwp/block-editor-utils';
 registerFaustBlock(MyFirstBlock, {blockJson: metadata})
 ```

--- a/.changeset/rich-rice-mix.md
+++ b/.changeset/rich-rice-mix.md
@@ -1,0 +1,13 @@
+---
+'@faustwp/block-editor-utils': patch
+---
+
+Feat: Added a default EditFunction.
+
+```js
+import metadata from './block.json';
+
+import MyFirstBlock from './MyFirstBlock';
+import registerFaustBlock from '@faustwp/block-editor-utils';
+registerFaustBlock(MyFirstBlock, {blockJson: metadata})
+```

--- a/packages/block-editor-utils/src/components/Edit.tsx
+++ b/packages/block-editor-utils/src/components/Edit.tsx
@@ -1,0 +1,20 @@
+import * as React from 'react';
+import { useBlockProps } from '@wordpress/block-editor';
+import { EditFnContext } from '../registerFaustBlock.js';
+import Preview from './Preview.js';
+
+export default function Edit<T extends Record<string, any>>(
+  ctx: EditFnContext<T>,
+) {
+  const blockProps = useBlockProps();
+  const { block, props } = ctx;
+  return (
+    <div {...blockProps}>
+      {props.isSelected ? (
+        <div>Edit mode</div>
+      ) : (
+        <Preview block={block} props={props} />
+      )}
+    </div>
+  );
+}

--- a/packages/block-editor-utils/src/components/Preview.tsx
+++ b/packages/block-editor-utils/src/components/Preview.tsx
@@ -1,0 +1,40 @@
+import * as React from 'react';
+import { BlockEditProps } from '@wordpress/blocks';
+import { useBlockProps, InnerBlocks } from '@wordpress/block-editor';
+import { BlockFC } from '../types/index.js';
+
+const overlayStyle: React.CSSProperties = {
+  height: '100%',
+  left: 0,
+  position: 'absolute',
+  top: 0,
+  width: '100%',
+};
+
+interface PreviewProps<T extends Record<string, any>> {
+  block: BlockFC;
+  props: BlockEditProps<T>;
+}
+
+function Preview<T extends Record<string, any>>({
+  block: Block,
+  props,
+}: PreviewProps<T>) {
+  const blockProps = useBlockProps();
+  const allBlockProps: React.Attributes = {
+    key: null,
+    ...blockProps,
+    ...props,
+  };
+  return (
+    <>
+      {/* eslint-disable-next-line react/jsx-props-no-spreading */}
+      <Block {...allBlockProps}>
+        <InnerBlocks />
+      </Block>
+      <div style={overlayStyle} />
+    </>
+  );
+}
+
+export default Preview;

--- a/packages/block-editor-utils/src/registerFaustBlock.ts
+++ b/packages/block-editor-utils/src/registerFaustBlock.ts
@@ -5,23 +5,24 @@ import {
   BlockSaveProps,
 } from '@wordpress/blocks';
 import DefaultSaveFn from './components/Save.js';
+import DefaultEditFn from './components/Edit.js';
 import { BlockFC, ConfigType } from './types/index.js';
 
 export interface RegisterFaustBlockMetadata<P, T extends Record<string, any>> {
   // The block.json metadata object
   blockJson: BlockConfiguration;
   // A custom edit function
-  editFn: (ctx: EditFnContext<P, T>) => React.ReactNode | null;
+  editFn: (ctx: EditFnContext<T>) => React.ReactNode | null;
   // A custom save function
   saveFn: (ctx: SaveFnContext<T>) => React.ReactNode | null;
 }
 
-export interface EditFnContext<P, T extends Record<string, any>> {
+export interface EditFnContext<T extends Record<string, any>> {
   block: BlockFC;
   props: BlockEditProps<T>;
   wp: unknown;
   config: ConfigType;
-  blockJson: RegisterFaustBlockMetadata<P, T>['blockJson'];
+  blockJson: BlockConfiguration;
 }
 
 export interface SaveFnContext<T extends Record<string, unknown>> {
@@ -45,7 +46,7 @@ export default function registerFaustBlock<P, T extends Record<string, any>>(
   block: BlockFC,
   {
     blockJson,
-    editFn,
+    editFn = DefaultEditFn,
     saveFn = DefaultSaveFn,
   }: RegisterFaustBlockMetadata<P, T>,
 ): ReturnType<typeof registerBlockType> {

--- a/packages/block-editor-utils/tests/components/Edit.test.tsx
+++ b/packages/block-editor-utils/tests/components/Edit.test.tsx
@@ -1,0 +1,98 @@
+import * as React from 'react';
+import { render, screen } from '@testing-library/react';
+import Edit from '../../src/components/Edit.js';
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+jest.mock('@wordpress/block-editor', () => {
+  const originalModule = jest.requireActual('@wordpress/block-editor');
+  return {
+    ...originalModule,
+    useBlockProps: jest.fn(),
+  };
+});
+
+interface BlockProps {
+  className?: string;
+  attributes?: {
+    message: string;
+  };
+}
+
+const SimpleBlock = (props: BlockProps) => (
+  <div className={props.className}>{props?.attributes?.message}</div>
+);
+SimpleBlock.config = {
+  name: 'SimpleBlock',
+};
+
+const blockJson = {
+  title: 'SimpleBlock',
+  attributes: {
+    message: {
+      type: 'string',
+      default: 'Hello World',
+    },
+  },
+  category: '',
+};
+
+describe('<Edit />', () => {
+  it('renders the Block Component Preview if `isSelected=false`', () => {
+    const blockProps = {
+      clientId: '1',
+      setAttributes: () => null,
+      context: {},
+      attributes: {
+        message: 'Hello',
+      },
+      isSelected: false,
+      className: 'SimpleBlock',
+    };
+    render(
+      <Edit
+        config={{}}
+        blockJson={blockJson}
+        block={SimpleBlock}
+        props={blockProps}
+        wp={null}
+      />,
+    );
+    expect(screen.getByText(blockProps.attributes.message))
+      .toMatchInlineSnapshot(`
+      <div
+        class="SimpleBlock"
+      >
+        Hello
+      </div>
+    `);
+  });
+  it('renders the Edit Form Component if `isSelected=true`', () => {
+    const blockProps = {
+      clientId: '1',
+      setAttributes: () => null,
+      context: {},
+      isSelected: true,
+      attributes: {
+        message: 'Hello',
+      },
+      className: 'SimpleBlock',
+    };
+    render(
+      <Edit
+        config={{}}
+        blockJson={blockJson}
+        block={SimpleBlock}
+        props={blockProps}
+        wp={null}
+      />,
+    );
+    expect(screen.getByText('Edit mode')).toMatchInlineSnapshot(`
+      <div>
+        Edit mode
+      </div>
+    `);
+  });
+});

--- a/packages/block-editor-utils/tests/components/Preview.test.tsx
+++ b/packages/block-editor-utils/tests/components/Preview.test.tsx
@@ -1,0 +1,52 @@
+import * as React from 'react';
+import { render, screen } from '@testing-library/react';
+import Preview from '../../src/components/Preview.js';
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+jest.mock('@wordpress/block-editor', () => {
+  const originalModule = jest.requireActual('@wordpress/block-editor');
+  return {
+    ...originalModule,
+    useBlockProps: jest.fn()
+  };
+});
+
+interface BlockProps {
+  className?: string;
+  attributes?: {
+    message: string;
+  };
+}
+
+const SimpleBlock = (props: BlockProps) => (
+  <div className={props.className}>{props?.attributes?.message}</div>
+);
+SimpleBlock.config = {
+  name: 'SimpleBlock',
+};
+describe('<Preview />', () => {
+  it('renders the Block Component Preview successfully', () => {
+    const blockProps = {
+      clientId: '1',
+      setAttributes: () => null,
+      context: {},
+      isSelected: false,
+      attributes: {
+        message: 'Hello',
+      },
+      className: 'SimpleBlock',
+    };
+    render(<Preview block={SimpleBlock} props={blockProps} />);
+    expect(screen.getByText(blockProps.attributes.message))
+      .toMatchInlineSnapshot(`
+      <div
+        class="SimpleBlock"
+      >
+        Hello
+      </div>
+    `);
+  });
+});


### PR DESCRIPTION
## Tasks

- [ ] I have signed a [Contributor License Agreement (CLA)](https://github.com/wpengine/faustjs#contributor-license-agreement) with WP Engine.
- [ ] If a code change, I have written testing instructions that the whole team & outside contributors can understand.
- [ ] I have written and included a comprehensive [changeset](https://github.com/wpengine/faustjs/blob/canary/DEVELOPMENT.md#deployment) to properly document the changes I've made.

## Description

<!--
Include a summary of the change and some contextual information.
-->

* Adds default Edit function when using registerFaustBlock.
* Implements only Preview mode for now.
* Unit tests.

## Related Issue(s):

https://github.com/wpengine/faustjs/issues/1522

<!--
Provide the GitHub issue(s) number for issue tracking purposes, use the following syntax:

- #1234
-->

## Testing

1. run `npm install`
2. Build the project 
3. cd inside the project folder:
   `cd packages/block-editor-utils`
5. run `npm link`
6. On your WordPress instance create a new block plugin using [@wordpress/create-block](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-create-block/)
7. Inside the plugin folder run `npm link @faustwp/block-editor-utils ` to add a reference to the package.
8. Rewrite the genenated `index.js` editor script to use the `registerFaustBlock` helper function instead. 
```js
// index.js
import "./style.scss";
// import block.json
import metadata from "./block.json";

// import Pure React Component
import HelloWorld from "./HelloWorld";

// Register React Component in Gutenberg
import { registerFaustBlock } from "@faustwp/block-editor-utils";

registerFaustBlock(HelloWorld, { blockJson: metadata });
```
Here `HelloWorld` is a simple Div Component:

```jsx
// HelloWorld.js
function HelloWorld({ style, className, attributes, children, ...props }) {
	const styles = {
		...style,
		backgroundColor: attributes.bg_color,
		color: attributes.text_color,
	};
	return (
		<div
			{...props}
			style={styles}
			className={className}
			dangerouslySetInnerHTML={{ __html: attributes.message }}
		/>
	);
}

HelloWorld.config = {
	name: "HelloWorld",
};
export default HelloWorld;

```

```json
// block.json
{
	"$schema": "https://schemas.wp.org/trunk/block.json",
	"apiVersion": 2,
	"name": "create-block/hello-world-block",
	"version": "0.1.0",
	"title": "Hello World Block",
	"category": "widgets",
	"icon": "smiley",
	"description": "Example block scaffolded with Create Block tool.",
	"supports": {
		"html": false
	},
	"attributes": {
		"message": {
		"type": "string",
                 "default": "Hello World"
	},
	"bg_color": { "type": "string", "default": "#000000" },
        "text_color": { "type": "string", "default": "#ffffff" }
	},
	"textdomain": "hello-world-block",
	"editorScript": "file:./index.js",
	"editorStyle": "file:./index.css",
	"style": "file:./style-index.css"
}

```

7) Run `npm start` to build the compiled js

8) Now go into the editor and try to create a new block. You should be able to see the Edit mode component. When clicking on the component this should switch to the Preview component instead. When clicking outside, you should be seeing the Edit mode again. You can configure the default message by changing the `default` attribute.

<img width="1367" alt="Screenshot 2023-08-21 at 13 57 24" src="https://github.com/wpengine/faustjs/assets/328805/a183d6e0-8c37-4f87-9a17-9928a9887066">


## Screenshots

<!--
If this is a visual change include relevant screenshots about the behavior of the application before and after this change.
-->

## Documentation Changes

<!--
List corresponding changes to the documentation.
-->

## Dependant PRs

<!--
List any dependent PR's that are awaiting review. Use the following syntax:

- #1234
-->
