### PR TITLE
ci: configure Code Coverage action to not comment

### DIFF
--- a/.github/actions/run-coverage/action.yml
+++ b/.github/actions/run-coverage/action.yml
@@ -13,6 +13,8 @@ runs:
     # Remove this when the issue has been resolved.
     - uses: ArtiomTr/jest-coverage-report-action@v2.1.2
       with:
+        # tell to the action to not attach comment.
+        output: report-markdown
         test-script: npm run test:coverage:ci
         working-directory: ${{ inputs.working-directory }}
         annotations: none


### PR DESCRIPTION
## Description

This configures Code Coverage to just generate the report and not comment on PRs. We're not currently actioning these reports, and they're generating a lot of noise. We will revisit in the future. These reports should still be available in the actions output.

See readme for config options: https://github.com/ArtiomTr/jest-coverage-report-action
