### PR TITLE
Remove unnecessary `P` TypeScript variable

### DIFF
--- a/packages/block-editor-utils/src/registerFaustBlock.ts
+++ b/packages/block-editor-utils/src/registerFaustBlock.ts
@@ -8,7 +8,7 @@ import DefaultSaveFn from './components/Save.js';
 import DefaultEditFn from './components/Edit.js';
 import { BlockFC, ConfigType } from './types/index.js';
 
-export interface RegisterFaustBlockMetadata<P, T extends Record<string, any>> {
+export interface RegisterFaustBlockMetadata<T extends Record<string, any>> {
   // The block.json metadata object
   blockJson: BlockConfiguration;
   // A custom edit function
@@ -42,13 +42,13 @@ export interface SaveFnContext<T extends Record<string, unknown>> {
  * @param block The React component to register as Gutenberg Block.
  * @param ctx  The metadata object that contains the block.json.
  */
-export default function registerFaustBlock<P, T extends Record<string, any>>(
+export default function registerFaustBlock<T extends Record<string, any>>(
   block: BlockFC,
   {
     blockJson,
     editFn = DefaultEditFn,
     saveFn = DefaultSaveFn,
-  }: RegisterFaustBlockMetadata<P, T>,
+  }: RegisterFaustBlockMetadata<T>,
 ): ReturnType<typeof registerBlockType> {
   // Pass the block config as a separate argument
   const { config } = block;


### PR DESCRIPTION
## Tasks

- [ ] I have signed a [Contributor License Agreement (CLA)](https://github.com/wpengine/faustjs#contributor-license-agreement) with WP Engine.
- [ ] If a code change, I have written testing instructions that the whole team & outside contributors can understand.
- [ ] I have written and included a comprehensive [changeset](https://github.com/wpengine/faustjs/blob/canary/DEVELOPMENT.md#deployment) to properly document the changes I've made.

## Description

This PR removes the unnecessary `P` TypeScript variable in `registerFaustBlock`

<!--
Include a summary of the change and some contextual information.
-->

## Related Issue(s):

<!--
Provide the GitHub issue(s) number for issue tracking purposes, use the following syntax:

- #1234
-->

## Testing

<!--
Describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Also list any relevant details for your test configuration such as how to test the changes locally or in staging.
-->

## Screenshots

<!--
If this is a visual change include relevant screenshots about the behavior of the application before and after this change.
-->

## Documentation Changes

<!--
List corresponding changes to the documentation.
-->

## Dependant PRs

<!--
List any dependent PR's that are awaiting review. Use the following syntax:

- #1234
-->
