### PR TITLE
Fix Faust.js WordPress Plugin Preview

### DIFF
--- a/.changeset/soft-cooks-peel.md
+++ b/.changeset/soft-cooks-peel.md
@@ -1,0 +1,5 @@
+---
+'@faustwp/wordpress-plugin': patch
+---
+
+Fixed a bug in the block editor screen where the preview link was missing the `p` and `previewPathName` query arguments after saving a draft.

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,8 +51,8 @@
         "@apollo/client": "^3.8.0",
         "@apollo/experimental-nextjs-app-support": "^0.4.1",
         "@faustwp/cli": "1.1.1",
-        "@faustwp/core": "1.1.1",
-        "@faustwp/experimental-app-router": "^0.0.2",
+        "@faustwp/core": "1.1.2",
+        "@faustwp/experimental-app-router": "^0.0.3",
         "graphql": "^16.7.1",
         "next": "^13.4.20-canary.18",
         "react": "^18.2.0",
@@ -290,7 +290,7 @@
       "dependencies": {
         "@apollo/client": "^3.6.6",
         "@faustwp/cli": "1.1.1",
-        "@faustwp/core": "1.1.1",
+        "@faustwp/core": "1.1.2",
         "@wordpress/base-styles": "^4.26.0",
         "@wordpress/block-library": "^7.19.0",
         "classnames": "^2.3.1",
@@ -1398,6 +1398,11 @@
         "react-dom": ">=16.8.0"
       }
     },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.1.2.tgz",
+      "integrity": "sha512-ou3elfqG/hZsbmF4bxeJhPHIf3G2pm0ujc39hYEZrfVqt7Vk/Zji6CXc3W0pmYM8BW1g40U+akTl9DKZhFhInQ=="
+    },
     "node_modules/@gqty/cli": {
       "version": "3.3.0",
       "dev": true,
@@ -1798,52 +1803,56 @@
       }
     },
     "node_modules/@jest/expect": {
-      "version": "29.6.2",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-29.7.0.tgz",
+      "integrity": "sha512-8uMeAMycttpva3P1lBHB8VciS9V0XAr3GymPpipdyQXbBcuhkLQOSe8E/p92RyAdToS6ZD1tFkX+CkhoECE0dQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "expect": "^29.6.2",
-        "jest-snapshot": "^29.6.2"
+        "expect": "^29.7.0",
+        "jest-snapshot": "^29.7.0"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/@jest/expect-utils": {
-      "version": "29.6.2",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-29.7.0.tgz",
+      "integrity": "sha512-GlsNBWiFQFCVi9QVSx7f5AgMeLxe9YCCs5PuP2O2LdjDAA8Jh9eX7lA1Jq/xdXw3Wb3hyvlFNfZIfcRetSzYcA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "jest-get-type": "^29.4.3"
+        "jest-get-type": "^29.6.3"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/@jest/expect-utils/node_modules/jest-get-type": {
-      "version": "29.4.3",
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.6.3.tgz",
+      "integrity": "sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/@jest/expect/node_modules/@jest/transform": {
-      "version": "29.6.2",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.7.0.tgz",
+      "integrity": "sha512-ok/BTPFzFKVMwO5eOHRrvnBVHdRy9IrsrW1GpMaQ9MCnilNLXQKmAX8s1YXDFaai9xJpac2ySzV0YeRRECr2Vw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.11.6",
-        "@jest/types": "^29.6.1",
+        "@jest/types": "^29.6.3",
         "@jridgewell/trace-mapping": "^0.3.18",
         "babel-plugin-istanbul": "^6.1.1",
         "chalk": "^4.0.0",
         "convert-source-map": "^2.0.0",
         "fast-json-stable-stringify": "^2.1.0",
         "graceful-fs": "^4.2.9",
-        "jest-haste-map": "^29.6.2",
-        "jest-regex-util": "^29.4.3",
-        "jest-util": "^29.6.2",
+        "jest-haste-map": "^29.7.0",
+        "jest-regex-util": "^29.6.3",
+        "jest-util": "^29.7.0",
         "micromatch": "^4.0.4",
         "pirates": "^4.0.4",
         "slash": "^3.0.0",
@@ -1854,11 +1863,12 @@
       }
     },
     "node_modules/@jest/expect/node_modules/@jest/types": {
-      "version": "29.6.1",
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
+      "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@jest/schemas": "^29.6.0",
+        "@jest/schemas": "^29.6.3",
         "@types/istanbul-lib-coverage": "^2.0.0",
         "@types/istanbul-reports": "^3.0.0",
         "@types/node": "*",
@@ -1871,16 +1881,18 @@
     },
     "node_modules/@jest/expect/node_modules/@types/yargs": {
       "version": "17.0.24",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.24.tgz",
+      "integrity": "sha512-6i0aC7jV6QzQB8ne1joVZ0eSFIstHsCrobmOtghM11yGlH0j43FKL2UhWdELkyps0zuf7qVTUVCCR+tgSlyLLw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@types/yargs-parser": "*"
       }
     },
     "node_modules/@jest/expect/node_modules/ansi-styles": {
       "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -1893,8 +1905,9 @@
     },
     "node_modules/@jest/expect/node_modules/chalk": {
       "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -1908,8 +1921,9 @@
     },
     "node_modules/@jest/expect/node_modules/color-convert": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -1919,33 +1933,36 @@
     },
     "node_modules/@jest/expect/node_modules/color-name": {
       "version": "1.1.4",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
     },
     "node_modules/@jest/expect/node_modules/convert-source-map": {
       "version": "2.0.0",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true
     },
     "node_modules/@jest/expect/node_modules/diff-sequences": {
-      "version": "29.4.3",
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
+      "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/@jest/expect/node_modules/expect": {
-      "version": "29.6.2",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-29.7.0.tgz",
+      "integrity": "sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@jest/expect-utils": "^29.6.2",
-        "@types/node": "*",
-        "jest-get-type": "^29.4.3",
-        "jest-matcher-utils": "^29.6.2",
-        "jest-message-util": "^29.6.2",
-        "jest-util": "^29.6.2"
+        "@jest/expect-utils": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "jest-matcher-utils": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -1953,48 +1970,52 @@
     },
     "node_modules/@jest/expect/node_modules/has-flag": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@jest/expect/node_modules/jest-diff": {
-      "version": "29.6.2",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.7.0.tgz",
+      "integrity": "sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "chalk": "^4.0.0",
-        "diff-sequences": "^29.4.3",
-        "jest-get-type": "^29.4.3",
-        "pretty-format": "^29.6.2"
+        "diff-sequences": "^29.6.3",
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/@jest/expect/node_modules/jest-get-type": {
-      "version": "29.4.3",
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.6.3.tgz",
+      "integrity": "sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/@jest/expect/node_modules/jest-haste-map": {
-      "version": "29.6.2",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-29.7.0.tgz",
+      "integrity": "sha512-fP8u2pyfqx0K1rGn1R9pyE0/KTn+G7PxktWidOBTqFPLYX0b9ksaMFkhK5vrS3DVun09pckLdlx90QthlW7AmA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@jest/types": "^29.6.1",
+        "@jest/types": "^29.6.3",
         "@types/graceful-fs": "^4.1.3",
         "@types/node": "*",
         "anymatch": "^3.0.3",
         "fb-watchman": "^2.0.0",
         "graceful-fs": "^4.2.9",
-        "jest-regex-util": "^29.4.3",
-        "jest-util": "^29.6.2",
-        "jest-worker": "^29.6.2",
+        "jest-regex-util": "^29.6.3",
+        "jest-util": "^29.7.0",
+        "jest-worker": "^29.7.0",
         "micromatch": "^4.0.4",
         "walker": "^1.0.8"
       },
@@ -2006,31 +2027,33 @@
       }
     },
     "node_modules/@jest/expect/node_modules/jest-matcher-utils": {
-      "version": "29.6.2",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.7.0.tgz",
+      "integrity": "sha512-sBkD+Xi9DtcChsI3L3u0+N0opgPYnCRPtGcQYrgXmR+hmt/fYfWAL0xRXYU8eWOdfuLgBe0YCW3AFtnRLagq/g==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "chalk": "^4.0.0",
-        "jest-diff": "^29.6.2",
-        "jest-get-type": "^29.4.3",
-        "pretty-format": "^29.6.2"
+        "jest-diff": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/@jest/expect/node_modules/jest-message-util": {
-      "version": "29.6.2",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.7.0.tgz",
+      "integrity": "sha512-GBEV4GRADeP+qtB2+6u61stea8mGcOT4mCtrYISZwfu9/ISHFJ/5zOMXYbpBE9RsS5+Gb63DW4FgmnKJ79Kf6w==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.12.13",
-        "@jest/types": "^29.6.1",
+        "@jest/types": "^29.6.3",
         "@types/stack-utils": "^2.0.0",
         "chalk": "^4.0.0",
         "graceful-fs": "^4.2.9",
         "micromatch": "^4.0.4",
-        "pretty-format": "^29.6.2",
+        "pretty-format": "^29.7.0",
         "slash": "^3.0.0",
         "stack-utils": "^2.0.3"
       },
@@ -2039,37 +2062,39 @@
       }
     },
     "node_modules/@jest/expect/node_modules/jest-regex-util": {
-      "version": "29.4.3",
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-29.6.3.tgz",
+      "integrity": "sha512-KJJBsRCyyLNWCNBOvZyRDnAIfUiRJ8v+hOBQYGn8gDyF3UegwiP4gwRR3/SDa42g1YbVycTidUF3rKjyLFDWbg==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/@jest/expect/node_modules/jest-snapshot": {
-      "version": "29.6.2",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-29.7.0.tgz",
+      "integrity": "sha512-Rm0BMWtxBcioHr1/OX5YCP8Uov4riHvKPknOGs804Zg9JGZgmIBkbtlxJC/7Z4msKYVbIJtfU+tKb8xlYNfdkw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.11.6",
         "@babel/generator": "^7.7.2",
         "@babel/plugin-syntax-jsx": "^7.7.2",
         "@babel/plugin-syntax-typescript": "^7.7.2",
         "@babel/types": "^7.3.3",
-        "@jest/expect-utils": "^29.6.2",
-        "@jest/transform": "^29.6.2",
-        "@jest/types": "^29.6.1",
+        "@jest/expect-utils": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
         "babel-preset-current-node-syntax": "^1.0.0",
         "chalk": "^4.0.0",
-        "expect": "^29.6.2",
+        "expect": "^29.7.0",
         "graceful-fs": "^4.2.9",
-        "jest-diff": "^29.6.2",
-        "jest-get-type": "^29.4.3",
-        "jest-matcher-utils": "^29.6.2",
-        "jest-message-util": "^29.6.2",
-        "jest-util": "^29.6.2",
+        "jest-diff": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "jest-matcher-utils": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0",
         "natural-compare": "^1.4.0",
-        "pretty-format": "^29.6.2",
+        "pretty-format": "^29.7.0",
         "semver": "^7.5.3"
       },
       "engines": {
@@ -2077,11 +2102,12 @@
       }
     },
     "node_modules/@jest/expect/node_modules/jest-util": {
-      "version": "29.6.2",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
+      "integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@jest/types": "^29.6.1",
+        "@jest/types": "^29.6.3",
         "@types/node": "*",
         "chalk": "^4.0.0",
         "ci-info": "^3.2.0",
@@ -2093,12 +2119,13 @@
       }
     },
     "node_modules/@jest/expect/node_modules/jest-worker": {
-      "version": "29.6.2",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.7.0.tgz",
+      "integrity": "sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@types/node": "*",
-        "jest-util": "^29.6.2",
+        "jest-util": "^29.7.0",
         "merge-stream": "^2.0.0",
         "supports-color": "^8.0.0"
       },
@@ -2108,8 +2135,9 @@
     },
     "node_modules/@jest/expect/node_modules/jest-worker/node_modules/supports-color": {
       "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -2121,11 +2149,12 @@
       }
     },
     "node_modules/@jest/expect/node_modules/pretty-format": {
-      "version": "29.6.2",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@jest/schemas": "^29.6.0",
+        "@jest/schemas": "^29.6.3",
         "ansi-styles": "^5.0.0",
         "react-is": "^18.0.0"
       },
@@ -2135,8 +2164,9 @@
     },
     "node_modules/@jest/expect/node_modules/pretty-format/node_modules/ansi-styles": {
       "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
@@ -2146,13 +2176,15 @@
     },
     "node_modules/@jest/expect/node_modules/react-is": {
       "version": "18.2.0",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
+      "dev": true
     },
     "node_modules/@jest/expect/node_modules/supports-color": {
       "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -2162,8 +2194,9 @@
     },
     "node_modules/@jest/expect/node_modules/write-file-atomic": {
       "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.2.tgz",
+      "integrity": "sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "imurmurhash": "^0.1.4",
         "signal-exit": "^3.0.7"
@@ -2309,9 +2342,10 @@
       }
     },
     "node_modules/@jest/schemas": {
-      "version": "29.6.0",
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
+      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@sinclair/typebox": "^0.27.8"
       },
@@ -5018,22 +5052,24 @@
       }
     },
     "node_modules/@wordpress/deprecated": {
-      "version": "3.39.0",
-      "license": "GPL-2.0-or-later",
+      "version": "3.41.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-3.41.0.tgz",
+      "integrity": "sha512-8so9fJC6MvMeMxaRqEJYtzXm1RP2i+nq3NXG9DW4fbo8ICEIe1QqBpCFqV4FbkHs8PRqyJ8IJ7C6NnAvL3BWKw==",
       "dependencies": {
         "@babel/runtime": "^7.16.0",
-        "@wordpress/hooks": "^3.39.0"
+        "@wordpress/hooks": "^3.41.0"
       },
       "engines": {
         "node": ">=12"
       }
     },
     "node_modules/@wordpress/dom": {
-      "version": "3.39.0",
-      "license": "GPL-2.0-or-later",
+      "version": "3.41.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-3.41.0.tgz",
+      "integrity": "sha512-0FKG4c33G7jOElzy1adqgNjowYBaWX98Q99X9WjpjtF+AY7/Sljq4zOGh5iZXSM/1dpKLPs4f/frFEqueq6MGg==",
       "dependencies": {
         "@babel/runtime": "^7.16.0",
-        "@wordpress/deprecated": "^3.39.0"
+        "@wordpress/deprecated": "^3.41.0"
       },
       "engines": {
         "node": ">=12"
@@ -5067,8 +5103,9 @@
       }
     },
     "node_modules/@wordpress/escape-html": {
-      "version": "2.39.0",
-      "license": "GPL-2.0-or-later",
+      "version": "2.41.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-2.41.0.tgz",
+      "integrity": "sha512-fFDuAO/csLVemQrJKTrwxjmR7d2a6zEuDVCKi2jUt7j9rpLpz9IZnEVD2q/icOj2+u6joeDwvCyyPyTreqEZHA==",
       "dependencies": {
         "@babel/runtime": "^7.16.0"
       },
@@ -5077,8 +5114,9 @@
       }
     },
     "node_modules/@wordpress/hooks": {
-      "version": "3.39.0",
-      "license": "GPL-2.0-or-later",
+      "version": "3.41.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-3.41.0.tgz",
+      "integrity": "sha512-o3fC6Z0kCLzZNFUT5W7C1d2mR+qjVwLaWjrwuJngJG92wly4IzKgAUDs/iJZojxtePFMP8JOFCg4FMuzG/VhWw==",
       "dependencies": {
         "@babel/runtime": "^7.16.0"
       },
@@ -5097,11 +5135,12 @@
       }
     },
     "node_modules/@wordpress/i18n": {
-      "version": "4.39.0",
-      "license": "GPL-2.0-or-later",
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-4.41.0.tgz",
+      "integrity": "sha512-MXA+DiVSF2CS0ZhFEBq/eJjfHuKMcu3FUuiF/Dpc1YZRD1X7N6xPlfo4xKJZVUWIAsfgpc8oA2YMLw1VTFzrRA==",
       "dependencies": {
         "@babel/runtime": "^7.16.0",
-        "@wordpress/hooks": "^3.39.0",
+        "@wordpress/hooks": "^3.41.0",
         "gettext-parser": "^1.3.1",
         "memize": "^2.1.0",
         "sprintf-js": "^1.1.1",
@@ -5196,8 +5235,9 @@
       }
     },
     "node_modules/@wordpress/is-shallow-equal": {
-      "version": "4.39.0",
-      "license": "GPL-2.0-or-later",
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-4.41.0.tgz",
+      "integrity": "sha512-z0+bdJvjOcbPf7vGiC0Zfoff+2WyFRFwsJex9d9N9CTVvr87kaVHBZuZlPX6iFmS22RzM2tLeppBKlOSRtSI4w==",
       "dependencies": {
         "@babel/runtime": "^7.16.0"
       },
@@ -5223,11 +5263,12 @@
       }
     },
     "node_modules/@wordpress/keycodes": {
-      "version": "3.39.0",
-      "license": "GPL-2.0-or-later",
+      "version": "3.41.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-3.41.0.tgz",
+      "integrity": "sha512-0DY07PV5qATrvWLc5jWgrgUGpeFrqvY+K0qF0gLDw1rpIZBxLre+N3K7ANC/iZzSsPLbYxxVF0SSFDIVI23Pug==",
       "dependencies": {
         "@babel/runtime": "^7.16.0",
-        "@wordpress/i18n": "^4.39.0",
+        "@wordpress/i18n": "^4.41.0",
         "change-case": "^4.1.2"
       },
       "engines": {
@@ -5432,8 +5473,9 @@
       }
     },
     "node_modules/@wordpress/priority-queue": {
-      "version": "2.39.0",
-      "license": "GPL-2.0-or-later",
+      "version": "2.41.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-2.41.0.tgz",
+      "integrity": "sha512-OntRPhdybFO5da+MO0/pvnRYG+D+c1kU0KRPDuEa+ArZmmQ/lQC+z+/du9nP/cgvQCAzLHJo2/VKCSQZVyewKw==",
       "dependencies": {
         "@babel/runtime": "^7.16.0",
         "requestidlecallback": "^0.3.0"
@@ -6791,6 +6833,915 @@
         "node": ">=10"
       }
     },
+    "node_modules/create-jest": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/create-jest/-/create-jest-29.7.0.tgz",
+      "integrity": "sha512-Adz2bdH0Vq3F53KEMJOoftQFutWCukm6J24wbPWRO4k1kMY7gS7ds/uoJkNuV8wDCtWWnuwGcJwpWcih+zEW1Q==",
+      "dev": true,
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "chalk": "^4.0.0",
+        "exit": "^0.1.2",
+        "graceful-fs": "^4.2.9",
+        "jest-config": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "prompts": "^2.0.1"
+      },
+      "bin": {
+        "create-jest": "bin/create-jest.js"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/create-jest/node_modules/@jest/console": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/console/-/console-29.7.0.tgz",
+      "integrity": "sha512-5Ni4CU7XHQi32IJ398EEP4RrB8eV09sXP2ROqD4bksHrnTree52PsxvX8tpL8LvTZ3pFzXyPbNQReSN41CAhOg==",
+      "dev": true,
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/create-jest/node_modules/@jest/environment": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.7.0.tgz",
+      "integrity": "sha512-aQIfHDq33ExsN4jP1NWGXhxgQ/wixs60gDiKO+XVMd8Mn0NWPWgc34ZQDTb2jKaUWQ7MuwoitXAsN2XVXNMpAw==",
+      "dev": true,
+      "dependencies": {
+        "@jest/fake-timers": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "jest-mock": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/create-jest/node_modules/@jest/fake-timers": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-29.7.0.tgz",
+      "integrity": "sha512-q4DH1Ha4TTFPdxLsqDXK1d3+ioSL7yL5oCMJZgDYm6i+6CygW5E5xVr/D1HdsGxjt1ZWSfUAs9OxSB/BNelWrQ==",
+      "dev": true,
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@sinonjs/fake-timers": "^10.0.2",
+        "@types/node": "*",
+        "jest-message-util": "^29.7.0",
+        "jest-mock": "^29.7.0",
+        "jest-util": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/create-jest/node_modules/@jest/globals": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-29.7.0.tgz",
+      "integrity": "sha512-mpiz3dutLbkW2MNFubUGUEVLkTGiqW6yLVTA+JbP6fI6J5iL9Y0Nlg8k95pcF8ctKwCS7WVxteBs29hhfAotzQ==",
+      "dev": true,
+      "dependencies": {
+        "@jest/environment": "^29.7.0",
+        "@jest/expect": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "jest-mock": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/create-jest/node_modules/@jest/source-map": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-29.6.3.tgz",
+      "integrity": "sha512-MHjT95QuipcPrpLM+8JMSzFx6eHp5Bm+4XeFDJlwsvVBjmKNiIAvasGK2fxz2WbGRlnvqehFbh07MMa7n3YJnw==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.18",
+        "callsites": "^3.0.0",
+        "graceful-fs": "^4.2.9"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/create-jest/node_modules/@jest/test-result": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-29.7.0.tgz",
+      "integrity": "sha512-Fdx+tv6x1zlkJPcWXmMDAG2HBnaR9XPSd5aDWQVsfrZmLVT3lU1cwyxLgRmXR9yrq4NBoEm9BMsfgFzTQAbJYA==",
+      "dev": true,
+      "dependencies": {
+        "@jest/console": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "collect-v8-coverage": "^1.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/create-jest/node_modules/@jest/test-sequencer": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-29.7.0.tgz",
+      "integrity": "sha512-GQwJ5WZVrKnOJuiYiAF52UNUJXgTZx1NHjFSEB0qEMmSZKAkdMoIzw/Cj6x6NF4AvV23AUqDpFzQkN/eYCYTxw==",
+      "dev": true,
+      "dependencies": {
+        "@jest/test-result": "^29.7.0",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^29.7.0",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/create-jest/node_modules/@jest/transform": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.7.0.tgz",
+      "integrity": "sha512-ok/BTPFzFKVMwO5eOHRrvnBVHdRy9IrsrW1GpMaQ9MCnilNLXQKmAX8s1YXDFaai9xJpac2ySzV0YeRRECr2Vw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/core": "^7.11.6",
+        "@jest/types": "^29.6.3",
+        "@jridgewell/trace-mapping": "^0.3.18",
+        "babel-plugin-istanbul": "^6.1.1",
+        "chalk": "^4.0.0",
+        "convert-source-map": "^2.0.0",
+        "fast-json-stable-stringify": "^2.1.0",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^29.7.0",
+        "jest-regex-util": "^29.6.3",
+        "jest-util": "^29.7.0",
+        "micromatch": "^4.0.4",
+        "pirates": "^4.0.4",
+        "slash": "^3.0.0",
+        "write-file-atomic": "^4.0.2"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/create-jest/node_modules/@jest/types": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
+      "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
+      "dev": true,
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "@types/istanbul-reports": "^3.0.0",
+        "@types/node": "*",
+        "@types/yargs": "^17.0.8",
+        "chalk": "^4.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/create-jest/node_modules/@sinonjs/commons": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.0.tgz",
+      "integrity": "sha512-jXBtWAF4vmdNmZgD5FoKsVLv3rPgDnLgPbU84LIJ3otV44vJlDRokVng5v8NFJdCf/da9legHcKaRuZs4L7faA==",
+      "dev": true,
+      "dependencies": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "node_modules/create-jest/node_modules/@sinonjs/fake-timers": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.3.0.tgz",
+      "integrity": "sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.0"
+      }
+    },
+    "node_modules/create-jest/node_modules/@types/yargs": {
+      "version": "17.0.24",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.24.tgz",
+      "integrity": "sha512-6i0aC7jV6QzQB8ne1joVZ0eSFIstHsCrobmOtghM11yGlH0j43FKL2UhWdELkyps0zuf7qVTUVCCR+tgSlyLLw==",
+      "dev": true,
+      "dependencies": {
+        "@types/yargs-parser": "*"
+      }
+    },
+    "node_modules/create-jest/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/create-jest/node_modules/babel-jest": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.7.0.tgz",
+      "integrity": "sha512-BrvGY3xZSwEcCzKvKsCi2GgHqDqsYkOP4/by5xCgIwGXQxIEh+8ew3gmrE1y7XRR6LHZIj6yLYnUi/mm2KXKBg==",
+      "dev": true,
+      "dependencies": {
+        "@jest/transform": "^29.7.0",
+        "@types/babel__core": "^7.1.14",
+        "babel-plugin-istanbul": "^6.1.1",
+        "babel-preset-jest": "^29.6.3",
+        "chalk": "^4.0.0",
+        "graceful-fs": "^4.2.9",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.8.0"
+      }
+    },
+    "node_modules/create-jest/node_modules/babel-plugin-jest-hoist": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-29.6.3.tgz",
+      "integrity": "sha512-ESAc/RJvGTFEzRwOTT4+lNDk/GNHMkKbNzsvT0qKRfDyyYTskxB5rnU2njIDYVxXCBHHEI1c0YwHob3WaYujOg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/template": "^7.3.3",
+        "@babel/types": "^7.3.3",
+        "@types/babel__core": "^7.1.14",
+        "@types/babel__traverse": "^7.0.6"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/create-jest/node_modules/babel-preset-jest": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-29.6.3.tgz",
+      "integrity": "sha512-0B3bhxR6snWXJZtR/RliHTDPRgn1sNHOR0yVtq/IiQFyuOVjFS+wuio/R4gSNkyYmKmJB4wGZv2NZanmKmTnNA==",
+      "dev": true,
+      "dependencies": {
+        "babel-plugin-jest-hoist": "^29.6.3",
+        "babel-preset-current-node-syntax": "^1.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/create-jest/node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/create-jest/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/create-jest/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/create-jest/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/create-jest/node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true
+    },
+    "node_modules/create-jest/node_modules/dedent": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.5.1.tgz",
+      "integrity": "sha512-+LxW+KLWxu3HW3M2w2ympwtqPrqYRzU8fqi6Fhd18fBALe15blJPI/I4+UHveMVG6lJqB4JNd4UG0S5cnVHwIg==",
+      "dev": true,
+      "peerDependencies": {
+        "babel-plugin-macros": "^3.1.0"
+      },
+      "peerDependenciesMeta": {
+        "babel-plugin-macros": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/create-jest/node_modules/diff-sequences": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
+      "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
+      "dev": true,
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/create-jest/node_modules/emittery": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.13.1.tgz",
+      "integrity": "sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/emittery?sponsor=1"
+      }
+    },
+    "node_modules/create-jest/node_modules/expect": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-29.7.0.tgz",
+      "integrity": "sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==",
+      "dev": true,
+      "dependencies": {
+        "@jest/expect-utils": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "jest-matcher-utils": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/create-jest/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/create-jest/node_modules/jest-circus": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-29.7.0.tgz",
+      "integrity": "sha512-3E1nCMgipcTkCocFwM90XXQab9bS+GMsjdpmPrlelaxwD93Ad8iVEjX/vvHPdLPnFf+L40u+5+iutRdA1N9myw==",
+      "dev": true,
+      "dependencies": {
+        "@jest/environment": "^29.7.0",
+        "@jest/expect": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "co": "^4.6.0",
+        "dedent": "^1.0.0",
+        "is-generator-fn": "^2.0.0",
+        "jest-each": "^29.7.0",
+        "jest-matcher-utils": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-runtime": "^29.7.0",
+        "jest-snapshot": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "p-limit": "^3.1.0",
+        "pretty-format": "^29.7.0",
+        "pure-rand": "^6.0.0",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/create-jest/node_modules/jest-config": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-29.7.0.tgz",
+      "integrity": "sha512-uXbpfeQ7R6TZBqI3/TxCU4q4ttk3u0PJeC+E0zbfSoSjq6bJ7buBPxzQPL0ifrkY4DNu4JUdk0ImlBUYi840eQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/core": "^7.11.6",
+        "@jest/test-sequencer": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "babel-jest": "^29.7.0",
+        "chalk": "^4.0.0",
+        "ci-info": "^3.2.0",
+        "deepmerge": "^4.2.2",
+        "glob": "^7.1.3",
+        "graceful-fs": "^4.2.9",
+        "jest-circus": "^29.7.0",
+        "jest-environment-node": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "jest-regex-util": "^29.6.3",
+        "jest-resolve": "^29.7.0",
+        "jest-runner": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-validate": "^29.7.0",
+        "micromatch": "^4.0.4",
+        "parse-json": "^5.2.0",
+        "pretty-format": "^29.7.0",
+        "slash": "^3.0.0",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "@types/node": "*",
+        "ts-node": ">=9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "ts-node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/create-jest/node_modules/jest-diff": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.7.0.tgz",
+      "integrity": "sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "diff-sequences": "^29.6.3",
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/create-jest/node_modules/jest-docblock": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-29.7.0.tgz",
+      "integrity": "sha512-q617Auw3A612guyaFgsbFeYpNP5t2aoUNLwBUbc/0kD1R4t9ixDbyFTHd1nok4epoVFpr7PmeWHrhvuV3XaJ4g==",
+      "dev": true,
+      "dependencies": {
+        "detect-newline": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/create-jest/node_modules/jest-each": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-29.7.0.tgz",
+      "integrity": "sha512-gns+Er14+ZrEoC5fhOfYCY1LOHHr0TI+rQUHZS8Ttw2l7gl+80eHc/gFf2Ktkw0+SIACDTeWvpFcv3B04VembQ==",
+      "dev": true,
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "chalk": "^4.0.0",
+        "jest-get-type": "^29.6.3",
+        "jest-util": "^29.7.0",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/create-jest/node_modules/jest-environment-node": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-29.7.0.tgz",
+      "integrity": "sha512-DOSwCRqXirTOyheM+4d5YZOrWcdu0LNZ87ewUoywbcb2XR4wKgqiG8vNeYwhjFMbEkfju7wx2GYH0P2gevGvFw==",
+      "dev": true,
+      "dependencies": {
+        "@jest/environment": "^29.7.0",
+        "@jest/fake-timers": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "jest-mock": "^29.7.0",
+        "jest-util": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/create-jest/node_modules/jest-get-type": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.6.3.tgz",
+      "integrity": "sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==",
+      "dev": true,
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/create-jest/node_modules/jest-haste-map": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-29.7.0.tgz",
+      "integrity": "sha512-fP8u2pyfqx0K1rGn1R9pyE0/KTn+G7PxktWidOBTqFPLYX0b9ksaMFkhK5vrS3DVun09pckLdlx90QthlW7AmA==",
+      "dev": true,
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@types/graceful-fs": "^4.1.3",
+        "@types/node": "*",
+        "anymatch": "^3.0.3",
+        "fb-watchman": "^2.0.0",
+        "graceful-fs": "^4.2.9",
+        "jest-regex-util": "^29.6.3",
+        "jest-util": "^29.7.0",
+        "jest-worker": "^29.7.0",
+        "micromatch": "^4.0.4",
+        "walker": "^1.0.8"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "^2.3.2"
+      }
+    },
+    "node_modules/create-jest/node_modules/jest-leak-detector": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-29.7.0.tgz",
+      "integrity": "sha512-kYA8IJcSYtST2BY9I+SMC32nDpBT3J2NvWJx8+JCuCdl/CR1I4EKUJROiP8XtCcxqgTTBGJNdbB1A8XRKbTetw==",
+      "dev": true,
+      "dependencies": {
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/create-jest/node_modules/jest-matcher-utils": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.7.0.tgz",
+      "integrity": "sha512-sBkD+Xi9DtcChsI3L3u0+N0opgPYnCRPtGcQYrgXmR+hmt/fYfWAL0xRXYU8eWOdfuLgBe0YCW3AFtnRLagq/g==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "jest-diff": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/create-jest/node_modules/jest-message-util": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.7.0.tgz",
+      "integrity": "sha512-GBEV4GRADeP+qtB2+6u61stea8mGcOT4mCtrYISZwfu9/ISHFJ/5zOMXYbpBE9RsS5+Gb63DW4FgmnKJ79Kf6w==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.12.13",
+        "@jest/types": "^29.6.3",
+        "@types/stack-utils": "^2.0.0",
+        "chalk": "^4.0.0",
+        "graceful-fs": "^4.2.9",
+        "micromatch": "^4.0.4",
+        "pretty-format": "^29.7.0",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/create-jest/node_modules/jest-mock": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.7.0.tgz",
+      "integrity": "sha512-ITOMZn+UkYS4ZFh83xYAOzWStloNzJFO2s8DWrE4lhtGD+AorgnbkiKERe4wQVBydIGPx059g6riW5Btp6Llnw==",
+      "dev": true,
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "jest-util": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/create-jest/node_modules/jest-regex-util": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-29.6.3.tgz",
+      "integrity": "sha512-KJJBsRCyyLNWCNBOvZyRDnAIfUiRJ8v+hOBQYGn8gDyF3UegwiP4gwRR3/SDa42g1YbVycTidUF3rKjyLFDWbg==",
+      "dev": true,
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/create-jest/node_modules/jest-resolve": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-29.7.0.tgz",
+      "integrity": "sha512-IOVhZSrg+UvVAshDSDtHyFCCBUl/Q3AAJv8iZ6ZjnZ74xzvwuzLXid9IIIPgTnY62SJjfuupMKZsZQRsCvxEgA==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^29.7.0",
+        "jest-pnp-resolver": "^1.2.2",
+        "jest-util": "^29.7.0",
+        "jest-validate": "^29.7.0",
+        "resolve": "^1.20.0",
+        "resolve.exports": "^2.0.0",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/create-jest/node_modules/jest-runner": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-29.7.0.tgz",
+      "integrity": "sha512-fsc4N6cPCAahybGBfTRcq5wFR6fpLznMg47sY5aDpsoejOcVYFb07AHuSnR0liMcPTgBsA3ZJL6kFOjPdoNipQ==",
+      "dev": true,
+      "dependencies": {
+        "@jest/console": "^29.7.0",
+        "@jest/environment": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "emittery": "^0.13.1",
+        "graceful-fs": "^4.2.9",
+        "jest-docblock": "^29.7.0",
+        "jest-environment-node": "^29.7.0",
+        "jest-haste-map": "^29.7.0",
+        "jest-leak-detector": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-resolve": "^29.7.0",
+        "jest-runtime": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-watcher": "^29.7.0",
+        "jest-worker": "^29.7.0",
+        "p-limit": "^3.1.0",
+        "source-map-support": "0.5.13"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/create-jest/node_modules/jest-runtime": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-29.7.0.tgz",
+      "integrity": "sha512-gUnLjgwdGqW7B4LvOIkbKs9WGbn+QLqRQQ9juC6HndeDiezIwhDP+mhMwHWCEcfQ5RUXa6OPnFF8BJh5xegwwQ==",
+      "dev": true,
+      "dependencies": {
+        "@jest/environment": "^29.7.0",
+        "@jest/fake-timers": "^29.7.0",
+        "@jest/globals": "^29.7.0",
+        "@jest/source-map": "^29.6.3",
+        "@jest/test-result": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "cjs-module-lexer": "^1.0.0",
+        "collect-v8-coverage": "^1.0.0",
+        "glob": "^7.1.3",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-mock": "^29.7.0",
+        "jest-regex-util": "^29.6.3",
+        "jest-resolve": "^29.7.0",
+        "jest-snapshot": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "slash": "^3.0.0",
+        "strip-bom": "^4.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/create-jest/node_modules/jest-snapshot": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-29.7.0.tgz",
+      "integrity": "sha512-Rm0BMWtxBcioHr1/OX5YCP8Uov4riHvKPknOGs804Zg9JGZgmIBkbtlxJC/7Z4msKYVbIJtfU+tKb8xlYNfdkw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/core": "^7.11.6",
+        "@babel/generator": "^7.7.2",
+        "@babel/plugin-syntax-jsx": "^7.7.2",
+        "@babel/plugin-syntax-typescript": "^7.7.2",
+        "@babel/types": "^7.3.3",
+        "@jest/expect-utils": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "babel-preset-current-node-syntax": "^1.0.0",
+        "chalk": "^4.0.0",
+        "expect": "^29.7.0",
+        "graceful-fs": "^4.2.9",
+        "jest-diff": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "jest-matcher-utils": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "natural-compare": "^1.4.0",
+        "pretty-format": "^29.7.0",
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/create-jest/node_modules/jest-util": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
+      "integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
+      "dev": true,
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "ci-info": "^3.2.0",
+        "graceful-fs": "^4.2.9",
+        "picomatch": "^2.2.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/create-jest/node_modules/jest-validate": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-29.7.0.tgz",
+      "integrity": "sha512-ZB7wHqaRGVw/9hST/OuFUReG7M8vKeq0/J2egIGLdvjHCmYqGARhzXmtgi+gVeZ5uXFF219aOc3Ls2yLg27tkw==",
+      "dev": true,
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "camelcase": "^6.2.0",
+        "chalk": "^4.0.0",
+        "jest-get-type": "^29.6.3",
+        "leven": "^3.1.0",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/create-jest/node_modules/jest-watcher": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-29.7.0.tgz",
+      "integrity": "sha512-49Fg7WXkU3Vl2h6LbLtMQ/HyB6rXSIX7SqvBLQmssRBGN9I0PNvPmAmCWSOY6SOvrjhI/F7/bGAv9RtnsPA03g==",
+      "dev": true,
+      "dependencies": {
+        "@jest/test-result": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^4.0.0",
+        "emittery": "^0.13.1",
+        "jest-util": "^29.7.0",
+        "string-length": "^4.0.1"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/create-jest/node_modules/jest-worker": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.7.0.tgz",
+      "integrity": "sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*",
+        "jest-util": "^29.7.0",
+        "merge-stream": "^2.0.0",
+        "supports-color": "^8.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/create-jest/node_modules/jest-worker/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/create-jest/node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/create-jest/node_modules/pretty-format": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "dev": true,
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/create-jest/node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/create-jest/node_modules/react-is": {
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
+      "dev": true
+    },
+    "node_modules/create-jest/node_modules/resolve.exports": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-2.0.2.tgz",
+      "integrity": "sha512-X2UW6Nw3n/aMgDVy+0rSqgHlv39WZAlZrXCdnbyEiKm17DSqHX4MmQMaST3FbeWR5FTuRcUwYAziZajji0Y7mg==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/create-jest/node_modules/source-map-support": {
+      "version": "0.5.13",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
+      "integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
+      "dev": true,
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/create-jest/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/create-jest/node_modules/write-file-atomic": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.2.tgz",
+      "integrity": "sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==",
+      "dev": true,
+      "dependencies": {
+        "imurmurhash": "^0.1.4",
+        "signal-exit": "^3.0.7"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
       "dev": true,
@@ -7013,6 +7964,35 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/deep-equal": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.2.2.tgz",
+      "integrity": "sha512-xjVyBf0w5vH0I42jdAZzOKVldmPgSulmiyPRywoyq7HXC9qdgo17kxJE+rdnif5Tz6+pIrpJI8dCpMNLIGkUiA==",
+      "dev": true,
+      "dependencies": {
+        "array-buffer-byte-length": "^1.0.0",
+        "call-bind": "^1.0.2",
+        "es-get-iterator": "^1.1.3",
+        "get-intrinsic": "^1.2.1",
+        "is-arguments": "^1.1.1",
+        "is-array-buffer": "^3.0.2",
+        "is-date-object": "^1.0.5",
+        "is-regex": "^1.1.4",
+        "is-shared-array-buffer": "^1.0.2",
+        "isarray": "^2.0.5",
+        "object-is": "^1.1.5",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.4",
+        "regexp.prototype.flags": "^1.5.0",
+        "side-channel": "^1.0.4",
+        "which-boxed-primitive": "^1.0.2",
+        "which-collection": "^1.0.1",
+        "which-typed-array": "^1.1.9"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/deep-extend": {
       "version": "0.6.0",
       "license": "MIT",
@@ -7041,9 +8021,10 @@
       }
     },
     "node_modules/define-properties": {
-      "version": "1.1.4",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.0.tgz",
+      "integrity": "sha512-xvqAVKGfT1+UAvPwKTVw/njhdQ8ZhXK4lI0bCIuCMrp2up9nPnaDftrLtmpTazqd1o+UY4zgzU+avtMbDP+ldA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "has-property-descriptors": "^1.0.0",
         "object-keys": "^1.1.1"
@@ -7420,6 +8401,26 @@
       },
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/es-get-iterator": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.3.tgz",
+      "integrity": "sha512-sPZmqHBe6JIiTfN5q2pEi//TwxmAFHwj/XEuYjTuse78i8KxaqMTTzxPoFKuzRpDpTJ+0NAbpfenkmH2rePtuw==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.1.3",
+        "has-symbols": "^1.0.3",
+        "is-arguments": "^1.1.1",
+        "is-map": "^2.0.2",
+        "is-set": "^2.0.2",
+        "is-string": "^1.0.7",
+        "isarray": "^2.0.5",
+        "stop-iteration-iterator": "^1.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -9186,6 +10187,22 @@
         "loose-envify": "^1.0.0"
       }
     },
+    "node_modules/is-arguments": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
+      "integrity": "sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-array-buffer": {
       "version": "3.0.2",
       "dev": true,
@@ -9318,6 +10335,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-map": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.2.tgz",
+      "integrity": "sha512-cOZFQQozTha1f4MxLFzlgKYPTyj26picdZTx82hbc/Xf4K/tZOOXSCkMvU4pKioRXGDLJRn0GM7Upe7kR721yg==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-negative-zero": {
       "version": "2.0.2",
       "dev": true,
@@ -9426,6 +10452,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-set": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.2.tgz",
+      "integrity": "sha512-+2cnTEZeY5z/iXGbLhPrOAaK/Mau5k5eXq9j14CpRTftq0pAJu2MwVRSZhyZWBzx3o6X795Lz6Bpb6R0GKf37g==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-shared-array-buffer": {
       "version": "1.0.2",
       "dev": true,
@@ -9514,12 +10549,34 @@
       "version": "1.0.0",
       "license": "MIT"
     },
+    "node_modules/is-weakmap": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.1.tgz",
+      "integrity": "sha512-NSBR4kH5oVj1Uwvv970ruUkCV7O1mzgVFO4/rev2cLRda9Tm9HrL70ZPut4rOHgY0FNrUu9BCbXA2sdQ+x0chA==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-weakref": {
       "version": "1.0.2",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakset": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.2.tgz",
+      "integrity": "sha512-t2yVvttHkQktwnNNmBQ98AhENLdPUTDTE21uPqAQ0ARwQfGeQKRVS0NNurH7bTf7RrvcVn1OOge45CnBeHCSmg==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.1.1"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -9542,6 +10599,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "dev": true
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -12086,6 +13149,22 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/object-is": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.5.tgz",
+      "integrity": "sha512-3cyDsyHgtmi7I7DfSSI2LDp6SK2lwvtbg0p0R1e0RvTqF5ceGx+K2dfSjm1bKDMVCFEDAQvy+o8c6a7VujOddw==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/object-keys": {
       "version": "1.1.1",
       "dev": true,
@@ -13124,13 +14203,14 @@
       "license": "MIT"
     },
     "node_modules/regexp.prototype.flags": {
-      "version": "1.4.3",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.0.tgz",
+      "integrity": "sha512-0SutC3pNudRKgquxGoRGIz946MZVHqbNfPjBdxeOhBrdgDKlRoXmYLQN9xRbrR09ZXWeGAdPuif7egofn6v5LA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3",
-        "functions-have-names": "^1.2.2"
+        "define-properties": "^1.2.0",
+        "functions-have-names": "^1.2.3"
       },
       "engines": {
         "node": ">= 0.4"
@@ -13933,6 +15013,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/stop-iteration-iterator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.0.0.tgz",
+      "integrity": "sha512-iCGQj+0l0HOdZ2AEeBADlsRC+vsnDsZsbdSiH1yNSjcfKM7fdpCMfqAL/dwF5BLiw/XhRft/Wax6zQbhq2BcjQ==",
+      "dev": true,
+      "dependencies": {
+        "internal-slot": "^1.0.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/stream-transform": {
@@ -15255,6 +16347,21 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/which-collection": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.1.tgz",
+      "integrity": "sha512-W8xeTUwaln8i3K/cY1nGXzdnVZlidBcagyNFtBdD5kxnb4TvGKR7FfSIS3mYpwWS1QUCutfKz8IY8RjftB0+1A==",
+      "dev": true,
+      "dependencies": {
+        "is-map": "^2.0.1",
+        "is-set": "^2.0.1",
+        "is-weakmap": "^2.0.1",
+        "is-weakset": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/which-module": {
       "version": "2.0.0",
       "license": "ISC"
@@ -15527,25 +16634,27 @@
       "version": "0.0.2",
       "license": "MIT",
       "dependencies": {
-        "@wordpress/block-editor": "^12.8.0",
-        "@wordpress/blocks": "^12.17.0",
-        "@wordpress/components": "^25.6.0",
-        "@wordpress/element": "5.17.0",
-        "@wordpress/hooks": "^3.40.0",
-        "@wordpress/i18n": "^4.40.0"
+        "@wordpress/block-editor": "^12.9.0",
+        "@wordpress/blocks": "^12.18.0",
+        "@wordpress/components": "^25.7.0",
+        "@wordpress/element": "5.18.0",
+        "@wordpress/hooks": "^3.41.0",
+        "@wordpress/i18n": "^4.41.0"
       },
       "devDependencies": {
         "@react-spring/web": "9.7.3",
-        "@types/jest": "^29.5.3",
+        "@testing-library/jest-dom": "^6.1.3",
+        "@testing-library/react": "^14.0.0",
+        "@types/jest": "^29.5.4",
         "@types/node": "^18.0.6",
         "@types/react": "^18.0.0",
-        "@types/wordpress__block-editor": "11.5.2",
-        "@types/wordpress__blocks": "12.5.2",
-        "@wordpress/jest-preset-default": "^11.9.0",
-        "jest": "29.6.2",
-        "jest-environment-jsdom": "29.6.2",
-        "react": ">=18.0.0",
-        "react-dom": ">=18.0.0",
+        "@types/wordpress__block-editor": "11.5.3",
+        "@types/wordpress__blocks": "12.5.3",
+        "@wordpress/jest-preset-default": "^11.12.0",
+        "jest": "29.6.4",
+        "jest-environment-jsdom": "29.6.4",
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0",
         "rimraf": "^4.4.0",
         "ts-jest": "29.1.1"
       },
@@ -15555,8 +16664,8 @@
       },
       "peerDependencies": {
         "@faustwp/blocks": ">=2.0.0",
-        "react": ">=18.0.0",
-        "react-dom": ">=18.0.0"
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
       }
     },
     "packages/block-editor-utils/node_modules/@emotion/is-prop-valid": {
@@ -15574,12 +16683,29 @@
       "integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==",
       "optional": true
     },
-    "packages/block-editor-utils/node_modules/@floating-ui/react-dom": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-1.0.0.tgz",
-      "integrity": "sha512-uiOalFKPG937UCLm42RxjESTWUVpbbatvlphQAU6bsv+ence6IoVG8JOUZcy8eW81NkU+Idiwvx10WFLmR4MIg==",
+    "packages/block-editor-utils/node_modules/@floating-ui/core": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.4.1.tgz",
+      "integrity": "sha512-jk3WqquEJRlcyu7997NtR5PibI+y5bi+LS3hPmguVClypenMsCY3CBa3LAQnozRCtCrYWSEtAdiskpamuJRFOQ==",
       "dependencies": {
-        "@floating-ui/dom": "^1.0.0"
+        "@floating-ui/utils": "^0.1.1"
+      }
+    },
+    "packages/block-editor-utils/node_modules/@floating-ui/dom": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.5.2.tgz",
+      "integrity": "sha512-6ArmenS6qJEWmwzczWyhvrXRdI/rI78poBcW0h/456+onlabit+2G+QxHx5xTOX60NBJQXjsCLFbW2CmsXpUog==",
+      "dependencies": {
+        "@floating-ui/core": "^1.4.1",
+        "@floating-ui/utils": "^0.1.1"
+      }
+    },
+    "packages/block-editor-utils/node_modules/@floating-ui/react-dom": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.0.2.tgz",
+      "integrity": "sha512-5qhlDvjaLmAst/rKb3VdlCinwTF4EYMiVxuuc/HVUjs46W0zgtbMmAZ1UTsDrRTxRmUEzl92mOtWbeeXL26lSQ==",
+      "dependencies": {
+        "@floating-ui/dom": "^1.5.1"
       },
       "peerDependencies": {
         "react": ">=16.8.0",
@@ -15587,15 +16713,16 @@
       }
     },
     "packages/block-editor-utils/node_modules/@jest/console": {
-      "version": "29.6.2",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/console/-/console-29.7.0.tgz",
+      "integrity": "sha512-5Ni4CU7XHQi32IJ398EEP4RrB8eV09sXP2ROqD4bksHrnTree52PsxvX8tpL8LvTZ3pFzXyPbNQReSN41CAhOg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@jest/types": "^29.6.1",
+        "@jest/types": "^29.6.3",
         "@types/node": "*",
         "chalk": "^4.0.0",
-        "jest-message-util": "^29.6.2",
-        "jest-util": "^29.6.2",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0",
         "slash": "^3.0.0"
       },
       "engines": {
@@ -15604,8 +16731,9 @@
     },
     "packages/block-editor-utils/node_modules/@jest/console/node_modules/chalk": {
       "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -15618,36 +16746,37 @@
       }
     },
     "packages/block-editor-utils/node_modules/@jest/core": {
-      "version": "29.6.2",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/core/-/core-29.7.0.tgz",
+      "integrity": "sha512-n7aeXWKMnGtDA48y8TLWJPJmLmmZ642Ceo78cYWEpiD7FzDgmNDV/GCVRorPABdXLJZ/9wzzgZAlHjXjxDHGsg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@jest/console": "^29.6.2",
-        "@jest/reporters": "^29.6.2",
-        "@jest/test-result": "^29.6.2",
-        "@jest/transform": "^29.6.2",
-        "@jest/types": "^29.6.1",
+        "@jest/console": "^29.7.0",
+        "@jest/reporters": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
         "@types/node": "*",
         "ansi-escapes": "^4.2.1",
         "chalk": "^4.0.0",
         "ci-info": "^3.2.0",
         "exit": "^0.1.2",
         "graceful-fs": "^4.2.9",
-        "jest-changed-files": "^29.5.0",
-        "jest-config": "^29.6.2",
-        "jest-haste-map": "^29.6.2",
-        "jest-message-util": "^29.6.2",
-        "jest-regex-util": "^29.4.3",
-        "jest-resolve": "^29.6.2",
-        "jest-resolve-dependencies": "^29.6.2",
-        "jest-runner": "^29.6.2",
-        "jest-runtime": "^29.6.2",
-        "jest-snapshot": "^29.6.2",
-        "jest-util": "^29.6.2",
-        "jest-validate": "^29.6.2",
-        "jest-watcher": "^29.6.2",
+        "jest-changed-files": "^29.7.0",
+        "jest-config": "^29.7.0",
+        "jest-haste-map": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-regex-util": "^29.6.3",
+        "jest-resolve": "^29.7.0",
+        "jest-resolve-dependencies": "^29.7.0",
+        "jest-runner": "^29.7.0",
+        "jest-runtime": "^29.7.0",
+        "jest-snapshot": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-validate": "^29.7.0",
+        "jest-watcher": "^29.7.0",
         "micromatch": "^4.0.4",
-        "pretty-format": "^29.6.2",
+        "pretty-format": "^29.7.0",
         "slash": "^3.0.0",
         "strip-ansi": "^6.0.0"
       },
@@ -15665,8 +16794,9 @@
     },
     "packages/block-editor-utils/node_modules/@jest/core/node_modules/chalk": {
       "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -15679,59 +16809,63 @@
       }
     },
     "packages/block-editor-utils/node_modules/@jest/environment": {
-      "version": "29.6.2",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.7.0.tgz",
+      "integrity": "sha512-aQIfHDq33ExsN4jP1NWGXhxgQ/wixs60gDiKO+XVMd8Mn0NWPWgc34ZQDTb2jKaUWQ7MuwoitXAsN2XVXNMpAw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@jest/fake-timers": "^29.6.2",
-        "@jest/types": "^29.6.1",
+        "@jest/fake-timers": "^29.7.0",
+        "@jest/types": "^29.6.3",
         "@types/node": "*",
-        "jest-mock": "^29.6.2"
+        "jest-mock": "^29.7.0"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "packages/block-editor-utils/node_modules/@jest/fake-timers": {
-      "version": "29.6.2",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-29.7.0.tgz",
+      "integrity": "sha512-q4DH1Ha4TTFPdxLsqDXK1d3+ioSL7yL5oCMJZgDYm6i+6CygW5E5xVr/D1HdsGxjt1ZWSfUAs9OxSB/BNelWrQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@jest/types": "^29.6.1",
+        "@jest/types": "^29.6.3",
         "@sinonjs/fake-timers": "^10.0.2",
         "@types/node": "*",
-        "jest-message-util": "^29.6.2",
-        "jest-mock": "^29.6.2",
-        "jest-util": "^29.6.2"
+        "jest-message-util": "^29.7.0",
+        "jest-mock": "^29.7.0",
+        "jest-util": "^29.7.0"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "packages/block-editor-utils/node_modules/@jest/globals": {
-      "version": "29.6.2",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-29.7.0.tgz",
+      "integrity": "sha512-mpiz3dutLbkW2MNFubUGUEVLkTGiqW6yLVTA+JbP6fI6J5iL9Y0Nlg8k95pcF8ctKwCS7WVxteBs29hhfAotzQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@jest/environment": "^29.6.2",
-        "@jest/expect": "^29.6.2",
-        "@jest/types": "^29.6.1",
-        "jest-mock": "^29.6.2"
+        "@jest/environment": "^29.7.0",
+        "@jest/expect": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "jest-mock": "^29.7.0"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "packages/block-editor-utils/node_modules/@jest/reporters": {
-      "version": "29.6.2",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-29.7.0.tgz",
+      "integrity": "sha512-DApq0KJbJOEzAFYjHADNNxAE3KbhxQB1y5Kplb5Waqw6zVbuWatSnMjE5gs8FUgEPmNsnZA3NCWl9NG0ia04Pg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@bcoe/v8-coverage": "^0.2.3",
-        "@jest/console": "^29.6.2",
-        "@jest/test-result": "^29.6.2",
-        "@jest/transform": "^29.6.2",
-        "@jest/types": "^29.6.1",
+        "@jest/console": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
         "@jridgewell/trace-mapping": "^0.3.18",
         "@types/node": "*",
         "chalk": "^4.0.0",
@@ -15740,13 +16874,13 @@
         "glob": "^7.1.3",
         "graceful-fs": "^4.2.9",
         "istanbul-lib-coverage": "^3.0.0",
-        "istanbul-lib-instrument": "^5.1.0",
+        "istanbul-lib-instrument": "^6.0.0",
         "istanbul-lib-report": "^3.0.0",
         "istanbul-lib-source-maps": "^4.0.0",
         "istanbul-reports": "^3.1.3",
-        "jest-message-util": "^29.6.2",
-        "jest-util": "^29.6.2",
-        "jest-worker": "^29.6.2",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-worker": "^29.7.0",
         "slash": "^3.0.0",
         "string-length": "^4.0.1",
         "strip-ansi": "^6.0.0",
@@ -15766,8 +16900,9 @@
     },
     "packages/block-editor-utils/node_modules/@jest/reporters/node_modules/chalk": {
       "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -15780,9 +16915,10 @@
       }
     },
     "packages/block-editor-utils/node_modules/@jest/source-map": {
-      "version": "29.6.0",
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-29.6.3.tgz",
+      "integrity": "sha512-MHjT95QuipcPrpLM+8JMSzFx6eHp5Bm+4XeFDJlwsvVBjmKNiIAvasGK2fxz2WbGRlnvqehFbh07MMa7n3YJnw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.18",
         "callsites": "^3.0.0",
@@ -15793,12 +16929,13 @@
       }
     },
     "packages/block-editor-utils/node_modules/@jest/test-result": {
-      "version": "29.6.2",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-29.7.0.tgz",
+      "integrity": "sha512-Fdx+tv6x1zlkJPcWXmMDAG2HBnaR9XPSd5aDWQVsfrZmLVT3lU1cwyxLgRmXR9yrq4NBoEm9BMsfgFzTQAbJYA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@jest/console": "^29.6.2",
-        "@jest/types": "^29.6.1",
+        "@jest/console": "^29.7.0",
+        "@jest/types": "^29.6.3",
         "@types/istanbul-lib-coverage": "^2.0.0",
         "collect-v8-coverage": "^1.0.0"
       },
@@ -15807,13 +16944,14 @@
       }
     },
     "packages/block-editor-utils/node_modules/@jest/test-sequencer": {
-      "version": "29.6.2",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-29.7.0.tgz",
+      "integrity": "sha512-GQwJ5WZVrKnOJuiYiAF52UNUJXgTZx1NHjFSEB0qEMmSZKAkdMoIzw/Cj6x6NF4AvV23AUqDpFzQkN/eYCYTxw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@jest/test-result": "^29.6.2",
+        "@jest/test-result": "^29.7.0",
         "graceful-fs": "^4.2.9",
-        "jest-haste-map": "^29.6.2",
+        "jest-haste-map": "^29.7.0",
         "slash": "^3.0.0"
       },
       "engines": {
@@ -15821,21 +16959,22 @@
       }
     },
     "packages/block-editor-utils/node_modules/@jest/transform": {
-      "version": "29.6.2",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.7.0.tgz",
+      "integrity": "sha512-ok/BTPFzFKVMwO5eOHRrvnBVHdRy9IrsrW1GpMaQ9MCnilNLXQKmAX8s1YXDFaai9xJpac2ySzV0YeRRECr2Vw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.11.6",
-        "@jest/types": "^29.6.1",
+        "@jest/types": "^29.6.3",
         "@jridgewell/trace-mapping": "^0.3.18",
         "babel-plugin-istanbul": "^6.1.1",
         "chalk": "^4.0.0",
         "convert-source-map": "^2.0.0",
         "fast-json-stable-stringify": "^2.1.0",
         "graceful-fs": "^4.2.9",
-        "jest-haste-map": "^29.6.2",
-        "jest-regex-util": "^29.4.3",
-        "jest-util": "^29.6.2",
+        "jest-haste-map": "^29.7.0",
+        "jest-regex-util": "^29.6.3",
+        "jest-util": "^29.7.0",
         "micromatch": "^4.0.4",
         "pirates": "^4.0.4",
         "slash": "^3.0.0",
@@ -15861,11 +17000,12 @@
       }
     },
     "packages/block-editor-utils/node_modules/@jest/types": {
-      "version": "29.6.1",
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
+      "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@jest/schemas": "^29.6.0",
+        "@jest/schemas": "^29.6.3",
         "@types/istanbul-lib-coverage": "^2.0.0",
         "@types/istanbul-reports": "^3.0.0",
         "@types/node": "*",
@@ -15953,18 +17093,146 @@
     },
     "packages/block-editor-utils/node_modules/@sinonjs/commons": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.0.tgz",
+      "integrity": "sha512-jXBtWAF4vmdNmZgD5FoKsVLv3rPgDnLgPbU84LIJ3otV44vJlDRokVng5v8NFJdCf/da9legHcKaRuZs4L7faA==",
       "dev": true,
-      "license": "BSD-3-Clause",
       "dependencies": {
         "type-detect": "4.0.8"
       }
     },
     "packages/block-editor-utils/node_modules/@sinonjs/fake-timers": {
       "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.3.0.tgz",
+      "integrity": "sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==",
       "dev": true,
-      "license": "BSD-3-Clause",
       "dependencies": {
         "@sinonjs/commons": "^3.0.0"
+      }
+    },
+    "packages/block-editor-utils/node_modules/@testing-library/dom": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-9.3.1.tgz",
+      "integrity": "sha512-0DGPd9AR3+iDTjGoMpxIkAsUihHZ3Ai6CneU6bRRrffXMgzCdlNk43jTrD2/5LT6CBb3MWTP8v510JzYtahD2w==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.1.3",
+        "chalk": "^4.1.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "packages/block-editor-utils/node_modules/@testing-library/dom/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "packages/block-editor-utils/node_modules/@testing-library/dom/node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "packages/block-editor-utils/node_modules/@testing-library/dom/node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "packages/block-editor-utils/node_modules/@testing-library/dom/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true
+    },
+    "packages/block-editor-utils/node_modules/@testing-library/jest-dom": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.1.3.tgz",
+      "integrity": "sha512-YzpjRHoCBWPzpPNtg6gnhasqtE/5O4qz8WCwDEaxtfnPO6gkaLrnuXusrGSPyhIGPezr1HM7ZH0CFaUTY9PJEQ==",
+      "dev": true,
+      "dependencies": {
+        "@adobe/css-tools": "^4.3.0",
+        "@babel/runtime": "^7.9.2",
+        "aria-query": "^5.0.0",
+        "chalk": "^3.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.5.6",
+        "lodash": "^4.17.15",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      },
+      "peerDependencies": {
+        "@jest/globals": ">= 28",
+        "@types/jest": ">= 28",
+        "jest": ">= 28",
+        "vitest": ">= 0.32"
+      },
+      "peerDependenciesMeta": {
+        "@jest/globals": {
+          "optional": true
+        },
+        "@types/jest": {
+          "optional": true
+        },
+        "jest": {
+          "optional": true
+        },
+        "vitest": {
+          "optional": true
+        }
+      }
+    },
+    "packages/block-editor-utils/node_modules/@testing-library/react": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-14.0.0.tgz",
+      "integrity": "sha512-S04gSNJbYE30TlIMLTzv6QCTzt9AqIF5y6s6SzVFILNcNvbV/jU96GeiTPillGQo+Ny64M/5PV7klNYYgv5Dfg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "@testing-library/dom": "^9.0.0",
+        "@types/react-dom": "^18.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
       }
     },
     "packages/block-editor-utils/node_modules/@tootallnate/once": {
@@ -15975,10 +17243,17 @@
         "node": ">= 10"
       }
     },
+    "packages/block-editor-utils/node_modules/@types/aria-query": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.1.tgz",
+      "integrity": "sha512-XTIieEY+gvJ39ChLcB4If5zHtPxt3Syj5rgZR+e1ctpmK8NjPf0zFqsz4JpLJT0xla9GFDKjy8Cpu331nrmE1Q==",
+      "dev": true
+    },
     "packages/block-editor-utils/node_modules/@types/jest": {
-      "version": "29.5.3",
+      "version": "29.5.4",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.4.tgz",
+      "integrity": "sha512-PhglGmhWeD46FYOVLt3X7TiWjzwuVGW9wG/4qocPevXMjCmrIc5b6db9WjeGE4QYVpUAWMDv3v0IiBwObY289A==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "expect": "^29.0.0",
         "pretty-format": "^29.0.0"
@@ -16042,35 +17317,35 @@
       }
     },
     "packages/block-editor-utils/node_modules/@wordpress/a11y": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/a11y/-/a11y-3.40.0.tgz",
-      "integrity": "sha512-DNUihzLPh81fwZVtDkcNxvliBpPH46MSK3tI+IFPjGW0FcolAwWyrXOEZ4ILMvxR27WL1ukDiRhScoZIPy1KRQ==",
+      "version": "3.41.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/a11y/-/a11y-3.41.0.tgz",
+      "integrity": "sha512-T+7rHdX4k72ty3MdtySuL41d4wrIXRKdM1Xhjr89G/OXyetsY0nb4n6jUsFGnf69iq7gFSgVjEVogbOc/ffbTA==",
       "dependencies": {
         "@babel/runtime": "^7.16.0",
-        "@wordpress/dom-ready": "^3.40.0",
-        "@wordpress/i18n": "^4.40.0"
+        "@wordpress/dom-ready": "^3.41.0",
+        "@wordpress/i18n": "^4.41.0"
       },
       "engines": {
         "node": ">=12"
       }
     },
     "packages/block-editor-utils/node_modules/@wordpress/api-fetch": {
-      "version": "6.37.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-6.37.0.tgz",
-      "integrity": "sha512-Cn0ddssCx5kGMEmdqom+kIqdeNl7xDJP4ooUgQhmmR/Hqi0CzazouCO0iNImmwFroFiquig5PrjDS6EWUe2z/w==",
+      "version": "6.38.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-6.38.0.tgz",
+      "integrity": "sha512-EY5+9hxUDFOKCrIBFokUFuF2bPnWjtOlc8yQcB1SmJv5JULdFZF+pgAKXqTPFwWR8wcNjv2hypemV8j82Rq4MA==",
       "dependencies": {
         "@babel/runtime": "^7.16.0",
-        "@wordpress/i18n": "^4.40.0",
-        "@wordpress/url": "^3.41.0"
+        "@wordpress/i18n": "^4.41.0",
+        "@wordpress/url": "^3.42.0"
       },
       "engines": {
         "node": ">=12"
       }
     },
     "packages/block-editor-utils/node_modules/@wordpress/autop": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/autop/-/autop-3.40.0.tgz",
-      "integrity": "sha512-AuuZpPLnonNNlekiE+gDmQEz+juHvCZJml1aGllip4txXCKZDvJUU6WVmnQYp+m1V/Wj4/Szb8w1muUslsjb7Q==",
+      "version": "3.41.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/autop/-/autop-3.41.0.tgz",
+      "integrity": "sha512-oaGwox3PKg6/a4nFul7js4k/wXazgtL0t6v8Epg3IotMUFXBN3rCAqH/zmCl/669LA9gG0TaT0VoqjF3iFuLtQ==",
       "dependencies": {
         "@babel/runtime": "^7.16.0"
       },
@@ -16079,9 +17354,9 @@
       }
     },
     "packages/block-editor-utils/node_modules/@wordpress/blob": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/blob/-/blob-3.40.0.tgz",
-      "integrity": "sha512-eXI9j/XiS0dAjdr04qkYnwKhEH7WevIpEOlCzj9m0FlJmq7HKgNOg3FJX3JhG7xAOJvGBBxtcHshnx29XexBIw==",
+      "version": "3.41.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/blob/-/blob-3.41.0.tgz",
+      "integrity": "sha512-osBcD1IpN/YT96ArGqf7Cdon/Z8gHMC8sWPUAQ1OPLNrxlFLomaCPOoC9UeAgbEh338epoYfqmi7rTwUMCBS3Q==",
       "dependencies": {
         "@babel/runtime": "^7.16.0"
       },
@@ -16090,44 +17365,44 @@
       }
     },
     "packages/block-editor-utils/node_modules/@wordpress/block-editor": {
-      "version": "12.8.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/block-editor/-/block-editor-12.8.0.tgz",
-      "integrity": "sha512-WQSWBAYM6iLN2+rAfZmQm4WMLPCe9woBcPybs0tKgOeXGZZBRgZ6FS01jzVmtWhttWXYZ3uH1PGPaKLJJc/Qyg==",
+      "version": "12.9.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/block-editor/-/block-editor-12.9.0.tgz",
+      "integrity": "sha512-x8fUoP2T6PtuEXm62VGkJSLokDU8EKmh+5sFeVIj2Vbh7av4i0+OWzf/LhP4rCi1bRujZSk8Gn1uzRfJglNMHQ==",
       "dependencies": {
         "@babel/runtime": "^7.16.0",
         "@emotion/react": "^11.7.1",
         "@emotion/styled": "^11.6.0",
         "@react-spring/web": "^9.4.5",
-        "@wordpress/a11y": "^3.40.0",
-        "@wordpress/api-fetch": "^6.37.0",
-        "@wordpress/blob": "^3.40.0",
-        "@wordpress/blocks": "^12.17.0",
-        "@wordpress/commands": "^0.11.0",
-        "@wordpress/components": "^25.6.0",
-        "@wordpress/compose": "^6.17.0",
-        "@wordpress/data": "^9.10.0",
-        "@wordpress/date": "^4.40.0",
-        "@wordpress/deprecated": "^3.40.0",
-        "@wordpress/dom": "^3.40.0",
-        "@wordpress/element": "^5.17.0",
-        "@wordpress/escape-html": "^2.40.0",
-        "@wordpress/hooks": "^3.40.0",
-        "@wordpress/html-entities": "^3.40.0",
-        "@wordpress/i18n": "^4.40.0",
-        "@wordpress/icons": "^9.31.0",
-        "@wordpress/is-shallow-equal": "^4.40.0",
-        "@wordpress/keyboard-shortcuts": "^4.17.0",
-        "@wordpress/keycodes": "^3.40.0",
-        "@wordpress/notices": "^4.8.0",
-        "@wordpress/preferences": "^3.17.0",
-        "@wordpress/private-apis": "^0.22.0",
-        "@wordpress/rich-text": "^6.17.0",
-        "@wordpress/shortcode": "^3.40.0",
-        "@wordpress/style-engine": "^1.23.0",
-        "@wordpress/token-list": "^2.40.0",
-        "@wordpress/url": "^3.41.0",
-        "@wordpress/warning": "^2.40.0",
-        "@wordpress/wordcount": "^3.40.0",
+        "@wordpress/a11y": "^3.41.0",
+        "@wordpress/api-fetch": "^6.38.0",
+        "@wordpress/blob": "^3.41.0",
+        "@wordpress/blocks": "^12.18.0",
+        "@wordpress/commands": "^0.12.0",
+        "@wordpress/components": "^25.7.0",
+        "@wordpress/compose": "^6.18.0",
+        "@wordpress/data": "^9.11.0",
+        "@wordpress/date": "^4.41.0",
+        "@wordpress/deprecated": "^3.41.0",
+        "@wordpress/dom": "^3.41.0",
+        "@wordpress/element": "^5.18.0",
+        "@wordpress/escape-html": "^2.41.0",
+        "@wordpress/hooks": "^3.41.0",
+        "@wordpress/html-entities": "^3.41.0",
+        "@wordpress/i18n": "^4.41.0",
+        "@wordpress/icons": "^9.32.0",
+        "@wordpress/is-shallow-equal": "^4.41.0",
+        "@wordpress/keyboard-shortcuts": "^4.18.0",
+        "@wordpress/keycodes": "^3.41.0",
+        "@wordpress/notices": "^4.9.0",
+        "@wordpress/preferences": "^3.18.0",
+        "@wordpress/private-apis": "^0.23.0",
+        "@wordpress/rich-text": "^6.18.0",
+        "@wordpress/shortcode": "^3.41.0",
+        "@wordpress/style-engine": "^1.24.0",
+        "@wordpress/token-list": "^2.41.0",
+        "@wordpress/url": "^3.42.0",
+        "@wordpress/warning": "^2.41.0",
+        "@wordpress/wordcount": "^3.41.0",
         "change-case": "^4.1.2",
         "classnames": "^2.3.1",
         "colord": "^2.7.0",
@@ -16151,18 +17426,18 @@
       }
     },
     "packages/block-editor-utils/node_modules/@wordpress/block-editor/node_modules/@wordpress/data": {
-      "version": "9.10.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-9.10.0.tgz",
-      "integrity": "sha512-jvg1ei+h9K94ckTaDHoHFtlsrkOMlRCaC/fjt2fWfTkQafrpFEEgFYIZEhT8nTQ3DD6Yuvyz4MmypSLnQ81M7A==",
+      "version": "9.11.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-9.11.0.tgz",
+      "integrity": "sha512-1UaummqcfxO4EU7eKfkxEaRjlZjRvqHRdtdjyBtrpWHxIaLrTzBdM7rBNu06tilZBoAXGRoBc5TyPuvNI3IWNg==",
       "dependencies": {
         "@babel/runtime": "^7.16.0",
-        "@wordpress/compose": "^6.17.0",
-        "@wordpress/deprecated": "^3.40.0",
-        "@wordpress/element": "^5.17.0",
-        "@wordpress/is-shallow-equal": "^4.40.0",
-        "@wordpress/priority-queue": "^2.40.0",
-        "@wordpress/private-apis": "^0.22.0",
-        "@wordpress/redux-routine": "^4.40.0",
+        "@wordpress/compose": "^6.18.0",
+        "@wordpress/deprecated": "^3.41.0",
+        "@wordpress/element": "^5.18.0",
+        "@wordpress/is-shallow-equal": "^4.41.0",
+        "@wordpress/priority-queue": "^2.41.0",
+        "@wordpress/private-apis": "^0.23.0",
+        "@wordpress/redux-routine": "^4.41.0",
         "deepmerge": "^4.3.0",
         "equivalent-key-map": "^0.2.2",
         "is-plain-object": "^5.0.0",
@@ -16179,9 +17454,9 @@
       }
     },
     "packages/block-editor-utils/node_modules/@wordpress/block-serialization-default-parser": {
-      "version": "4.40.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/block-serialization-default-parser/-/block-serialization-default-parser-4.40.0.tgz",
-      "integrity": "sha512-MFQ82tIf/finWY4TPDYP1ZYQfg2MLCC7j60idEwfd4y2jWW+LiksaUOEFBnSryAgZ5nhr2PQd7aciZpg8JM3dA==",
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/block-serialization-default-parser/-/block-serialization-default-parser-4.41.0.tgz",
+      "integrity": "sha512-/bHeVewOO2GSm3y6fSoOlt0ZNweP2jua8G+CTZG3XKrwX1eTXWFQtJTJQPUuerXeWEqMTD58lILxneqyw28hcg==",
       "dependencies": {
         "@babel/runtime": "^7.16.0"
       },
@@ -16190,25 +17465,25 @@
       }
     },
     "packages/block-editor-utils/node_modules/@wordpress/blocks": {
-      "version": "12.17.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/blocks/-/blocks-12.17.0.tgz",
-      "integrity": "sha512-TVUk0WGVe4/Qzm4/i1KCHOBvbB581AJnYuCAi35nhgu9V//vqbKh9JRg2d49ZduFl0SakVmN6/xSTPPEYjmuYQ==",
+      "version": "12.18.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/blocks/-/blocks-12.18.0.tgz",
+      "integrity": "sha512-JS2g4k95GPNdO2hOLBbppz3kTBUdKIoFXJ5w5tn11TGYep4dmEHh8ugGCW9XweOCkz3g4HDT+vansRAz4JF1yQ==",
       "dependencies": {
         "@babel/runtime": "^7.16.0",
-        "@wordpress/autop": "^3.40.0",
-        "@wordpress/blob": "^3.40.0",
-        "@wordpress/block-serialization-default-parser": "^4.40.0",
-        "@wordpress/compose": "^6.17.0",
-        "@wordpress/data": "^9.10.0",
-        "@wordpress/deprecated": "^3.40.0",
-        "@wordpress/dom": "^3.40.0",
-        "@wordpress/element": "^5.17.0",
-        "@wordpress/hooks": "^3.40.0",
-        "@wordpress/html-entities": "^3.40.0",
-        "@wordpress/i18n": "^4.40.0",
-        "@wordpress/is-shallow-equal": "^4.40.0",
-        "@wordpress/private-apis": "^0.22.0",
-        "@wordpress/shortcode": "^3.40.0",
+        "@wordpress/autop": "^3.41.0",
+        "@wordpress/blob": "^3.41.0",
+        "@wordpress/block-serialization-default-parser": "^4.41.0",
+        "@wordpress/compose": "^6.18.0",
+        "@wordpress/data": "^9.11.0",
+        "@wordpress/deprecated": "^3.41.0",
+        "@wordpress/dom": "^3.41.0",
+        "@wordpress/element": "^5.18.0",
+        "@wordpress/hooks": "^3.41.0",
+        "@wordpress/html-entities": "^3.41.0",
+        "@wordpress/i18n": "^4.41.0",
+        "@wordpress/is-shallow-equal": "^4.41.0",
+        "@wordpress/private-apis": "^0.23.0",
+        "@wordpress/shortcode": "^3.41.0",
         "change-case": "^4.1.2",
         "colord": "^2.7.0",
         "deepmerge": "^4.3.0",
@@ -16230,18 +17505,18 @@
       }
     },
     "packages/block-editor-utils/node_modules/@wordpress/blocks/node_modules/@wordpress/data": {
-      "version": "9.10.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-9.10.0.tgz",
-      "integrity": "sha512-jvg1ei+h9K94ckTaDHoHFtlsrkOMlRCaC/fjt2fWfTkQafrpFEEgFYIZEhT8nTQ3DD6Yuvyz4MmypSLnQ81M7A==",
+      "version": "9.11.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-9.11.0.tgz",
+      "integrity": "sha512-1UaummqcfxO4EU7eKfkxEaRjlZjRvqHRdtdjyBtrpWHxIaLrTzBdM7rBNu06tilZBoAXGRoBc5TyPuvNI3IWNg==",
       "dependencies": {
         "@babel/runtime": "^7.16.0",
-        "@wordpress/compose": "^6.17.0",
-        "@wordpress/deprecated": "^3.40.0",
-        "@wordpress/element": "^5.17.0",
-        "@wordpress/is-shallow-equal": "^4.40.0",
-        "@wordpress/priority-queue": "^2.40.0",
-        "@wordpress/private-apis": "^0.22.0",
-        "@wordpress/redux-routine": "^4.40.0",
+        "@wordpress/compose": "^6.18.0",
+        "@wordpress/deprecated": "^3.41.0",
+        "@wordpress/element": "^5.18.0",
+        "@wordpress/is-shallow-equal": "^4.41.0",
+        "@wordpress/priority-queue": "^2.41.0",
+        "@wordpress/private-apis": "^0.23.0",
+        "@wordpress/redux-routine": "^4.41.0",
         "deepmerge": "^4.3.0",
         "equivalent-key-map": "^0.2.2",
         "is-plain-object": "^5.0.0",
@@ -16258,18 +17533,18 @@
       }
     },
     "packages/block-editor-utils/node_modules/@wordpress/commands": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/commands/-/commands-0.11.0.tgz",
-      "integrity": "sha512-M1sfM9yhEAjUZPJcgvFqoRDafxyrIOnTb3mRA+NeFMEKexrmCJ/h/MrzPSugYYRMSzbZVe1FsabWZp+Zz8HsNA==",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/commands/-/commands-0.12.0.tgz",
+      "integrity": "sha512-yeFZ2BCDh9i8+XhcwAjwREXE8WUl9hv4YL5/b2Dh6eUqld/TGH4lUtxIHMxsnlzLqR29ZRaChobU44ji4rZf9g==",
       "dependencies": {
         "@babel/runtime": "^7.16.0",
-        "@wordpress/components": "^25.6.0",
-        "@wordpress/data": "^9.10.0",
-        "@wordpress/element": "^5.17.0",
-        "@wordpress/i18n": "^4.40.0",
-        "@wordpress/icons": "^9.31.0",
-        "@wordpress/keyboard-shortcuts": "^4.17.0",
-        "@wordpress/private-apis": "^0.22.0",
+        "@wordpress/components": "^25.7.0",
+        "@wordpress/data": "^9.11.0",
+        "@wordpress/element": "^5.18.0",
+        "@wordpress/i18n": "^4.41.0",
+        "@wordpress/icons": "^9.32.0",
+        "@wordpress/keyboard-shortcuts": "^4.18.0",
+        "@wordpress/private-apis": "^0.23.0",
         "classnames": "^2.3.1",
         "cmdk": "^0.2.0",
         "rememo": "^4.0.2"
@@ -16283,18 +17558,18 @@
       }
     },
     "packages/block-editor-utils/node_modules/@wordpress/commands/node_modules/@wordpress/data": {
-      "version": "9.10.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-9.10.0.tgz",
-      "integrity": "sha512-jvg1ei+h9K94ckTaDHoHFtlsrkOMlRCaC/fjt2fWfTkQafrpFEEgFYIZEhT8nTQ3DD6Yuvyz4MmypSLnQ81M7A==",
+      "version": "9.11.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-9.11.0.tgz",
+      "integrity": "sha512-1UaummqcfxO4EU7eKfkxEaRjlZjRvqHRdtdjyBtrpWHxIaLrTzBdM7rBNu06tilZBoAXGRoBc5TyPuvNI3IWNg==",
       "dependencies": {
         "@babel/runtime": "^7.16.0",
-        "@wordpress/compose": "^6.17.0",
-        "@wordpress/deprecated": "^3.40.0",
-        "@wordpress/element": "^5.17.0",
-        "@wordpress/is-shallow-equal": "^4.40.0",
-        "@wordpress/priority-queue": "^2.40.0",
-        "@wordpress/private-apis": "^0.22.0",
-        "@wordpress/redux-routine": "^4.40.0",
+        "@wordpress/compose": "^6.18.0",
+        "@wordpress/deprecated": "^3.41.0",
+        "@wordpress/element": "^5.18.0",
+        "@wordpress/is-shallow-equal": "^4.41.0",
+        "@wordpress/priority-queue": "^2.41.0",
+        "@wordpress/private-apis": "^0.23.0",
+        "@wordpress/redux-routine": "^4.41.0",
         "deepmerge": "^4.3.0",
         "equivalent-key-map": "^0.2.2",
         "is-plain-object": "^5.0.0",
@@ -16311,9 +17586,9 @@
       }
     },
     "packages/block-editor-utils/node_modules/@wordpress/components": {
-      "version": "25.6.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-25.6.0.tgz",
-      "integrity": "sha512-VLzGS76MrgS6g5GMjk5q3+glSg1IYSzZAa/c5gZKy16c1a8rFWkc/IMhjw6w8Oyp3vvhB748J0itxsqCmTj5hw==",
+      "version": "25.7.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-25.7.0.tgz",
+      "integrity": "sha512-CFUhdMKuIA+0flsA3ACnJ0h84uKo+PrGkWG3nCSJwifdC6AVB7b7VOriDRhYsJXKoyr3QV+gRfAnFn0Hrc7tQQ==",
       "dependencies": {
         "@ariakit/react": "^0.2.12",
         "@babel/runtime": "^7.16.0",
@@ -16323,26 +17598,26 @@
         "@emotion/serialize": "^1.0.2",
         "@emotion/styled": "^11.6.0",
         "@emotion/utils": "^1.0.0",
-        "@floating-ui/react-dom": "1.0.0",
+        "@floating-ui/react-dom": "^2.0.1",
         "@radix-ui/react-dropdown-menu": "2.0.4",
         "@use-gesture/react": "^10.2.24",
-        "@wordpress/a11y": "^3.40.0",
-        "@wordpress/compose": "^6.17.0",
-        "@wordpress/date": "^4.40.0",
-        "@wordpress/deprecated": "^3.40.0",
-        "@wordpress/dom": "^3.40.0",
-        "@wordpress/element": "^5.17.0",
-        "@wordpress/escape-html": "^2.40.0",
-        "@wordpress/hooks": "^3.40.0",
-        "@wordpress/html-entities": "^3.40.0",
-        "@wordpress/i18n": "^4.40.0",
-        "@wordpress/icons": "^9.31.0",
-        "@wordpress/is-shallow-equal": "^4.40.0",
-        "@wordpress/keycodes": "^3.40.0",
-        "@wordpress/primitives": "^3.38.0",
-        "@wordpress/private-apis": "^0.22.0",
-        "@wordpress/rich-text": "^6.17.0",
-        "@wordpress/warning": "^2.40.0",
+        "@wordpress/a11y": "^3.41.0",
+        "@wordpress/compose": "^6.18.0",
+        "@wordpress/date": "^4.41.0",
+        "@wordpress/deprecated": "^3.41.0",
+        "@wordpress/dom": "^3.41.0",
+        "@wordpress/element": "^5.18.0",
+        "@wordpress/escape-html": "^2.41.0",
+        "@wordpress/hooks": "^3.41.0",
+        "@wordpress/html-entities": "^3.41.0",
+        "@wordpress/i18n": "^4.41.0",
+        "@wordpress/icons": "^9.32.0",
+        "@wordpress/is-shallow-equal": "^4.41.0",
+        "@wordpress/keycodes": "^3.41.0",
+        "@wordpress/primitives": "^3.39.0",
+        "@wordpress/private-apis": "^0.23.0",
+        "@wordpress/rich-text": "^6.18.0",
+        "@wordpress/warning": "^2.41.0",
         "change-case": "^4.1.2",
         "classnames": "^2.3.1",
         "colord": "^2.7.0",
@@ -16374,18 +17649,18 @@
       }
     },
     "packages/block-editor-utils/node_modules/@wordpress/compose": {
-      "version": "6.17.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-6.17.0.tgz",
-      "integrity": "sha512-G2IhRJma2lm+vNKduWofMy4jHliJGN83fTkyCQmtvREKz6uVcxcuNCgwGNSnh9JtuVSPlz9YpBQHmH6WsulMBA==",
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-6.18.0.tgz",
+      "integrity": "sha512-aZyvttCnT8HI4vS8Nb8y5Go+AycrThy0gvEl9jc9ZB9emm1ZifNkA6gTNpBd7zU2uzS4wUpiZYGGvUNeAuShvQ==",
       "dependencies": {
         "@babel/runtime": "^7.16.0",
         "@types/mousetrap": "^1.6.8",
-        "@wordpress/deprecated": "^3.40.0",
-        "@wordpress/dom": "^3.40.0",
-        "@wordpress/element": "^5.17.0",
-        "@wordpress/is-shallow-equal": "^4.40.0",
-        "@wordpress/keycodes": "^3.40.0",
-        "@wordpress/priority-queue": "^2.40.0",
+        "@wordpress/deprecated": "^3.41.0",
+        "@wordpress/dom": "^3.41.0",
+        "@wordpress/element": "^5.18.0",
+        "@wordpress/is-shallow-equal": "^4.41.0",
+        "@wordpress/keycodes": "^3.41.0",
+        "@wordpress/priority-queue": "^2.41.0",
         "change-case": "^4.1.2",
         "clipboard": "^2.0.8",
         "mousetrap": "^1.6.5",
@@ -16440,12 +17715,12 @@
       }
     },
     "packages/block-editor-utils/node_modules/@wordpress/date": {
-      "version": "4.40.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/date/-/date-4.40.0.tgz",
-      "integrity": "sha512-FtfeGY9QRg1qMQSIpQxeRRShNJ37V2UOH/B3z0dHyxD8vKkVz4R0FmuBFw1mpJIPHwxbDI7hR0EO58c31+oyNg==",
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/date/-/date-4.41.0.tgz",
+      "integrity": "sha512-R0cTQKev7xT/srjAgUJOgW7CYnXuRdxSpXG7timYr3jEqgYoJFSAP2miq3+FWWSra1nesdT+r4o5z+3rIKFLLg==",
       "dependencies": {
         "@babel/runtime": "^7.16.0",
-        "@wordpress/deprecated": "^3.40.0",
+        "@wordpress/deprecated": "^3.41.0",
         "moment": "^2.29.4",
         "moment-timezone": "^0.5.40"
       },
@@ -16453,34 +17728,10 @@
         "node": ">=12"
       }
     },
-    "packages/block-editor-utils/node_modules/@wordpress/deprecated": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-3.40.0.tgz",
-      "integrity": "sha512-BWs90kVsAM4INmqFd5TrzAJOSehYSGkxgd8kGCipJXkcD7CWxoFEqS9W97Vva6yZekvrq63gFbmy++lllP3Llw==",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/hooks": "^3.40.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "packages/block-editor-utils/node_modules/@wordpress/dom": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-3.40.0.tgz",
-      "integrity": "sha512-Xv8vymbZk8kFuJKSh2bdnxL1w2sprbdhXksJ/QF/1Il+u1QBV9f9KbmMzW3fsdFl9SM6oGtod7KHJArke67TXw==",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/deprecated": "^3.40.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "packages/block-editor-utils/node_modules/@wordpress/dom-ready": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/dom-ready/-/dom-ready-3.40.0.tgz",
-      "integrity": "sha512-XFrAWHxHO3YhJVrpHMOftf07Yw7duKBt/6K5QHyfDX2Ly4Noqna2/0pP1coJoYApjHvqhz6GAJCIXwT+t2QtBQ==",
+      "version": "3.41.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/dom-ready/-/dom-ready-3.41.0.tgz",
+      "integrity": "sha512-xbTCYC1192nUiBLB384GrzlQMbFnSv31TjI4+Y4JhR46+alcSsF2KPmlR8htxRbAXBx7z8lT78Fv+0ULhSIERA==",
       "dependencies": {
         "@babel/runtime": "^7.16.0"
       },
@@ -16489,14 +17740,14 @@
       }
     },
     "packages/block-editor-utils/node_modules/@wordpress/element": {
-      "version": "5.17.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-5.17.0.tgz",
-      "integrity": "sha512-sVjVWlKnpzTM4kfwfTgT9TtCcqqb3MqII9cLzM3DCVDFIUrudEUlbqX9lUCnnSfWCjoQ/YPaWg4LikKrRVmPQw==",
+      "version": "5.18.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-5.18.0.tgz",
+      "integrity": "sha512-OynuZuTFdmterh/ASmMSSKjdBj5r1hcwQi37AQnp7+GpyIV3Ol5PR4UWWYB0coW0Gkd0giJkQAwC71/ZkEPYqQ==",
       "dependencies": {
         "@babel/runtime": "^7.16.0",
         "@types/react": "^18.0.21",
         "@types/react-dom": "^18.0.6",
-        "@wordpress/escape-html": "^2.40.0",
+        "@wordpress/escape-html": "^2.41.0",
         "change-case": "^4.1.2",
         "is-plain-object": "^5.0.0",
         "react": "^18.2.0",
@@ -16506,89 +17757,38 @@
         "node": ">=12"
       }
     },
-    "packages/block-editor-utils/node_modules/@wordpress/escape-html": {
-      "version": "2.40.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-2.40.0.tgz",
-      "integrity": "sha512-hWbtydaYHud/qbXauCNR1h5pfmXJQwzdKfdQUMqEjms2sqm2nQQXGxi/t8CLc2HjrNenzHqOZaonfQ/nx+1l1A==",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "packages/block-editor-utils/node_modules/@wordpress/hooks": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-3.40.0.tgz",
-      "integrity": "sha512-vbhGayL/KpGSpc0OTdPV4FeR/r9r42qQ9ElBd6RX6PVPUfgJ/on2PukMY5HBVM+3As4XQklRjMoc6EgFRh09rg==",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "packages/block-editor-utils/node_modules/@wordpress/html-entities": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/html-entities/-/html-entities-3.40.0.tgz",
-      "integrity": "sha512-Jd/EMTnakQoIYr02RrI+0w9z1Zi3ZxdtfSztLnUYushAtEXIo7TmBScMuIWQhhy9bT6+g5dQo7RP/UUh0sEwtg==",
+      "version": "3.41.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/html-entities/-/html-entities-3.41.0.tgz",
+      "integrity": "sha512-nb8ioGMi9yBfOzy2tIvIKQA+MaVNbgTflM/uiwhb5D/KTqtIUp+e84BOCOOZDI7xtWKQKhtGAn126Ko7hi73Jg==",
       "dependencies": {
         "@babel/runtime": "^7.16.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "packages/block-editor-utils/node_modules/@wordpress/i18n": {
-      "version": "4.40.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-4.40.0.tgz",
-      "integrity": "sha512-vm0qqYRl0ULmQoD0nHO0nfRQYoVgJf0Hf56fX3rJ9BKsiQkMtpurhUb0QViqjXShlR6rTryq4Ru3fXJqlpdL4w==",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/hooks": "^3.40.0",
-        "gettext-parser": "^1.3.1",
-        "memize": "^2.1.0",
-        "sprintf-js": "^1.1.1",
-        "tannin": "^1.2.0"
-      },
-      "bin": {
-        "pot-to-php": "tools/pot-to-php.js"
       },
       "engines": {
         "node": ">=12"
       }
     },
     "packages/block-editor-utils/node_modules/@wordpress/icons": {
-      "version": "9.31.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-9.31.0.tgz",
-      "integrity": "sha512-o8Yj3+BtsrwytN1tSRyINsAAXACdlgS+ELl6HnB3iE3K+qi2KzJGFVZPXS7vDZRPDxt6foNVk1LDp60hbEKvYQ==",
+      "version": "9.32.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-9.32.0.tgz",
+      "integrity": "sha512-67imRDf5LF6v4vCBmvAEa4ZzcH0jvwIaBr1Y2ou4ElVJ1KZjiu1C93Lp6dcAy/08L8eX+eZZCwTrTYI+tl9v5w==",
       "dependencies": {
         "@babel/runtime": "^7.16.0",
-        "@wordpress/element": "^5.17.0",
-        "@wordpress/primitives": "^3.38.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "packages/block-editor-utils/node_modules/@wordpress/is-shallow-equal": {
-      "version": "4.40.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-4.40.0.tgz",
-      "integrity": "sha512-JAFbiYTT4LUG2hER496UwHq6D7q9b0aPyhimGvqcsiuNUCy0IptiiYge6G/EPpyUwPS43qyKULgCaPYR9Js0pw==",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0"
+        "@wordpress/element": "^5.18.0",
+        "@wordpress/primitives": "^3.39.0"
       },
       "engines": {
         "node": ">=12"
       }
     },
     "packages/block-editor-utils/node_modules/@wordpress/jest-console": {
-      "version": "7.10.0",
+      "version": "7.12.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/jest-console/-/jest-console-7.12.0.tgz",
+      "integrity": "sha512-sSgG65n32wPdKVWT6aaaslpOOn/TcRw9413UY+NqBgyc/HIlsSR9zKeoFwR3RoOyWr055PABOGNLup+RgdPKxw==",
       "dev": true,
-      "license": "GPL-2.0-or-later",
       "dependencies": {
         "@babel/runtime": "^7.16.0",
-        "jest-matcher-utils": "^29.5.0"
+        "jest-matcher-utils": "^29.6.2"
       },
       "engines": {
         "node": ">=14"
@@ -16598,12 +17798,13 @@
       }
     },
     "packages/block-editor-utils/node_modules/@wordpress/jest-preset-default": {
-      "version": "11.10.0",
+      "version": "11.12.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/jest-preset-default/-/jest-preset-default-11.12.0.tgz",
+      "integrity": "sha512-HPpjUZsjxwvDDTw2ZWdgR1QVaVbsENCR/u0GRiC4NAArHABoleoFopwMZXJtbO1ii9vdeLJvgRNg1YXV5Zj79g==",
       "dev": true,
-      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/jest-console": "^7.10.0",
-        "babel-jest": "^29.5.0"
+        "@wordpress/jest-console": "^7.12.0",
+        "babel-jest": "^29.6.2"
       },
       "engines": {
         "node": ">=14"
@@ -16614,14 +17815,14 @@
       }
     },
     "packages/block-editor-utils/node_modules/@wordpress/keyboard-shortcuts": {
-      "version": "4.17.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/keyboard-shortcuts/-/keyboard-shortcuts-4.17.0.tgz",
-      "integrity": "sha512-460xcjMzuBen6y8yOiWdpFpQ3PFjd+sE3L4cWa7uOALXOBAr5u37t3e7mBQFECKwX9k+6kWVlz1ThgobI3pERQ==",
+      "version": "4.18.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/keyboard-shortcuts/-/keyboard-shortcuts-4.18.0.tgz",
+      "integrity": "sha512-3q3Kmzzu6PTsx3abce4t/FHFuyN1jn7oukViNA17lIIFTfIL8Eu6ZfKy+UyPgAoCCXohEjCmaaB801qnsLsooQ==",
       "dependencies": {
         "@babel/runtime": "^7.16.0",
-        "@wordpress/data": "^9.10.0",
-        "@wordpress/element": "^5.17.0",
-        "@wordpress/keycodes": "^3.40.0",
+        "@wordpress/data": "^9.11.0",
+        "@wordpress/element": "^5.18.0",
+        "@wordpress/keycodes": "^3.41.0",
         "rememo": "^4.0.2"
       },
       "engines": {
@@ -16632,18 +17833,18 @@
       }
     },
     "packages/block-editor-utils/node_modules/@wordpress/keyboard-shortcuts/node_modules/@wordpress/data": {
-      "version": "9.10.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-9.10.0.tgz",
-      "integrity": "sha512-jvg1ei+h9K94ckTaDHoHFtlsrkOMlRCaC/fjt2fWfTkQafrpFEEgFYIZEhT8nTQ3DD6Yuvyz4MmypSLnQ81M7A==",
+      "version": "9.11.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-9.11.0.tgz",
+      "integrity": "sha512-1UaummqcfxO4EU7eKfkxEaRjlZjRvqHRdtdjyBtrpWHxIaLrTzBdM7rBNu06tilZBoAXGRoBc5TyPuvNI3IWNg==",
       "dependencies": {
         "@babel/runtime": "^7.16.0",
-        "@wordpress/compose": "^6.17.0",
-        "@wordpress/deprecated": "^3.40.0",
-        "@wordpress/element": "^5.17.0",
-        "@wordpress/is-shallow-equal": "^4.40.0",
-        "@wordpress/priority-queue": "^2.40.0",
-        "@wordpress/private-apis": "^0.22.0",
-        "@wordpress/redux-routine": "^4.40.0",
+        "@wordpress/compose": "^6.18.0",
+        "@wordpress/deprecated": "^3.41.0",
+        "@wordpress/element": "^5.18.0",
+        "@wordpress/is-shallow-equal": "^4.41.0",
+        "@wordpress/priority-queue": "^2.41.0",
+        "@wordpress/private-apis": "^0.23.0",
+        "@wordpress/redux-routine": "^4.41.0",
         "deepmerge": "^4.3.0",
         "equivalent-key-map": "^0.2.2",
         "is-plain-object": "^5.0.0",
@@ -16659,27 +17860,14 @@
         "react": "^18.0.0"
       }
     },
-    "packages/block-editor-utils/node_modules/@wordpress/keycodes": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-3.40.0.tgz",
-      "integrity": "sha512-yoU/iN5QGFdyk72M5x1LZHl9iMpkx1hJxGIxUFA9LkO8bqUMuv4qhvRqwbXs6n+b+R6/aGUWH1nOMA57E2OiZg==",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/i18n": "^4.40.0",
-        "change-case": "^4.1.2"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "packages/block-editor-utils/node_modules/@wordpress/notices": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/notices/-/notices-4.8.0.tgz",
-      "integrity": "sha512-VGPAbt6BC4+E17XbmgZRM3KVVbhQIIu2pBapCOk6pvsvbCy5ewvcl9dy/Wlf6YRrFSmT4nrVPayldea5OVIC6Q==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/notices/-/notices-4.9.0.tgz",
+      "integrity": "sha512-X7LfAJy6jYBq6d7lbW32lrt1DxkdNOg/VpOyiv8klwn30AKSPws/vBSrTPNDpp9phleuIuRr3tDcpS9/p+jRIw==",
       "dependencies": {
         "@babel/runtime": "^7.16.0",
-        "@wordpress/a11y": "^3.40.0",
-        "@wordpress/data": "^9.10.0"
+        "@wordpress/a11y": "^3.41.0",
+        "@wordpress/data": "^9.11.0"
       },
       "engines": {
         "node": ">=12"
@@ -16689,18 +17877,18 @@
       }
     },
     "packages/block-editor-utils/node_modules/@wordpress/notices/node_modules/@wordpress/data": {
-      "version": "9.10.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-9.10.0.tgz",
-      "integrity": "sha512-jvg1ei+h9K94ckTaDHoHFtlsrkOMlRCaC/fjt2fWfTkQafrpFEEgFYIZEhT8nTQ3DD6Yuvyz4MmypSLnQ81M7A==",
+      "version": "9.11.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-9.11.0.tgz",
+      "integrity": "sha512-1UaummqcfxO4EU7eKfkxEaRjlZjRvqHRdtdjyBtrpWHxIaLrTzBdM7rBNu06tilZBoAXGRoBc5TyPuvNI3IWNg==",
       "dependencies": {
         "@babel/runtime": "^7.16.0",
-        "@wordpress/compose": "^6.17.0",
-        "@wordpress/deprecated": "^3.40.0",
-        "@wordpress/element": "^5.17.0",
-        "@wordpress/is-shallow-equal": "^4.40.0",
-        "@wordpress/priority-queue": "^2.40.0",
-        "@wordpress/private-apis": "^0.22.0",
-        "@wordpress/redux-routine": "^4.40.0",
+        "@wordpress/compose": "^6.18.0",
+        "@wordpress/deprecated": "^3.41.0",
+        "@wordpress/element": "^5.18.0",
+        "@wordpress/is-shallow-equal": "^4.41.0",
+        "@wordpress/priority-queue": "^2.41.0",
+        "@wordpress/private-apis": "^0.23.0",
+        "@wordpress/redux-routine": "^4.41.0",
         "deepmerge": "^4.3.0",
         "equivalent-key-map": "^0.2.2",
         "is-plain-object": "^5.0.0",
@@ -16717,17 +17905,17 @@
       }
     },
     "packages/block-editor-utils/node_modules/@wordpress/preferences": {
-      "version": "3.17.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/preferences/-/preferences-3.17.0.tgz",
-      "integrity": "sha512-57G0HrEy0Ym2zkT8/pI3ihXZot2tUnwQOFdO2GlhCaxxKgmVYkyQ44VneMcN2JbtFfjHzGueG09QeFt3rFyywQ==",
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/preferences/-/preferences-3.18.0.tgz",
+      "integrity": "sha512-S7eDEKvUIIJMWpiO+0j/iLDqspyhNdKR2N39HNkkrAA2mdr4LMvs5bOr/+m6xTpiik+8I29hwI/OuJOomqJ7PQ==",
       "dependencies": {
         "@babel/runtime": "^7.16.0",
-        "@wordpress/a11y": "^3.40.0",
-        "@wordpress/components": "^25.6.0",
-        "@wordpress/data": "^9.10.0",
-        "@wordpress/element": "^5.17.0",
-        "@wordpress/i18n": "^4.40.0",
-        "@wordpress/icons": "^9.31.0",
+        "@wordpress/a11y": "^3.41.0",
+        "@wordpress/components": "^25.7.0",
+        "@wordpress/data": "^9.11.0",
+        "@wordpress/element": "^5.18.0",
+        "@wordpress/i18n": "^4.41.0",
+        "@wordpress/icons": "^9.32.0",
         "classnames": "^2.3.1"
       },
       "engines": {
@@ -16739,18 +17927,18 @@
       }
     },
     "packages/block-editor-utils/node_modules/@wordpress/preferences/node_modules/@wordpress/data": {
-      "version": "9.10.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-9.10.0.tgz",
-      "integrity": "sha512-jvg1ei+h9K94ckTaDHoHFtlsrkOMlRCaC/fjt2fWfTkQafrpFEEgFYIZEhT8nTQ3DD6Yuvyz4MmypSLnQ81M7A==",
+      "version": "9.11.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-9.11.0.tgz",
+      "integrity": "sha512-1UaummqcfxO4EU7eKfkxEaRjlZjRvqHRdtdjyBtrpWHxIaLrTzBdM7rBNu06tilZBoAXGRoBc5TyPuvNI3IWNg==",
       "dependencies": {
         "@babel/runtime": "^7.16.0",
-        "@wordpress/compose": "^6.17.0",
-        "@wordpress/deprecated": "^3.40.0",
-        "@wordpress/element": "^5.17.0",
-        "@wordpress/is-shallow-equal": "^4.40.0",
-        "@wordpress/priority-queue": "^2.40.0",
-        "@wordpress/private-apis": "^0.22.0",
-        "@wordpress/redux-routine": "^4.40.0",
+        "@wordpress/compose": "^6.18.0",
+        "@wordpress/deprecated": "^3.41.0",
+        "@wordpress/element": "^5.18.0",
+        "@wordpress/is-shallow-equal": "^4.41.0",
+        "@wordpress/priority-queue": "^2.41.0",
+        "@wordpress/private-apis": "^0.23.0",
+        "@wordpress/redux-routine": "^4.41.0",
         "deepmerge": "^4.3.0",
         "equivalent-key-map": "^0.2.2",
         "is-plain-object": "^5.0.0",
@@ -16767,34 +17955,22 @@
       }
     },
     "packages/block-editor-utils/node_modules/@wordpress/primitives": {
-      "version": "3.38.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-3.38.0.tgz",
-      "integrity": "sha512-quRkAzZknTCqrBI/HvJ2Eas0x1irU6m2GbV/8opyZoE/2BAN+W07JgDhE8Aukd+3q03nfpKPeRJAO1dZ4/Vnuw==",
+      "version": "3.39.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-3.39.0.tgz",
+      "integrity": "sha512-QvtVJFQGCOEwdXIpXqktz31p327lj/5n4iwbIlOaGf0AZCPA8974m+O/wFkQCskGOJ9tVRveqZtH60aqKH/ffA==",
       "dependencies": {
         "@babel/runtime": "^7.16.0",
-        "@wordpress/element": "^5.17.0",
+        "@wordpress/element": "^5.18.0",
         "classnames": "^2.3.1"
       },
       "engines": {
         "node": ">=12"
       }
     },
-    "packages/block-editor-utils/node_modules/@wordpress/priority-queue": {
-      "version": "2.40.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-2.40.0.tgz",
-      "integrity": "sha512-SzbbEjzSoBmluSJk6p3uXT1z/m5+fvFZWnI6l06P6gsrvVebB7SvsrIO0rR1cBoEJP6HB7EkQ/ORhM1Hn3W/hA==",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "requestidlecallback": "^0.3.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "packages/block-editor-utils/node_modules/@wordpress/private-apis": {
-      "version": "0.22.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-0.22.0.tgz",
-      "integrity": "sha512-NB6fOPf6nU4SP4qzC9vk0LlXxWBd1U4vFbWLbM873ChC+gkZJWym8ow6aMmIezozNZAI3glXx9xEtdbyfHeD7A==",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-0.23.0.tgz",
+      "integrity": "sha512-Z/mAnPF+IcN13S0k7F55lA5J0ducNB+IYDGtujErx4fjnYsBIoF9VeQ5pRc+SPDCx5yYDtR7yL8unLbVbztVBQ==",
       "dependencies": {
         "@babel/runtime": "^7.16.0"
       },
@@ -16803,9 +17979,9 @@
       }
     },
     "packages/block-editor-utils/node_modules/@wordpress/redux-routine": {
-      "version": "4.40.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-4.40.0.tgz",
-      "integrity": "sha512-YKGn/46v73TaTr/gcvLYT66YJkYMM1xQS3IP9E/jDW6+e/GXjCJjerI1cWPmTLWesCclUQOg2qRzCoMIOoweXQ==",
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-4.41.0.tgz",
+      "integrity": "sha512-u5MVqtcChtHOqy3Fk5ml0HPBF13uHoz6ca1XvzstHKOiMWi4xNj6Nn2YgnscfvsxGxxjQz2su1Qcs0SGZI0g+w==",
       "dependencies": {
         "@babel/runtime": "^7.16.0",
         "is-plain-object": "^5.0.0",
@@ -16820,19 +17996,19 @@
       }
     },
     "packages/block-editor-utils/node_modules/@wordpress/rich-text": {
-      "version": "6.17.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/rich-text/-/rich-text-6.17.0.tgz",
-      "integrity": "sha512-jFduYBaKVc4AeTHjH/PU+hfOdxgBXBdvjvSICIyBObtcANL3chzikNJjPzJP4Z6O22Q9LwHoTktCtr3oyYE8RQ==",
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/rich-text/-/rich-text-6.18.0.tgz",
+      "integrity": "sha512-BuBb/yWFLq+/joYI3XMYyF7MQDVYGh8V4AB0+v4mHH+7cTecSOOilUAW/JlEXqXS3LhvghabBk157UaH1gh8IA==",
       "dependencies": {
         "@babel/runtime": "^7.16.0",
-        "@wordpress/a11y": "^3.40.0",
-        "@wordpress/compose": "^6.17.0",
-        "@wordpress/data": "^9.10.0",
-        "@wordpress/deprecated": "^3.40.0",
-        "@wordpress/element": "^5.17.0",
-        "@wordpress/escape-html": "^2.40.0",
-        "@wordpress/i18n": "^4.40.0",
-        "@wordpress/keycodes": "^3.40.0",
+        "@wordpress/a11y": "^3.41.0",
+        "@wordpress/compose": "^6.18.0",
+        "@wordpress/data": "^9.11.0",
+        "@wordpress/deprecated": "^3.41.0",
+        "@wordpress/element": "^5.18.0",
+        "@wordpress/escape-html": "^2.41.0",
+        "@wordpress/i18n": "^4.41.0",
+        "@wordpress/keycodes": "^3.41.0",
         "memize": "^2.1.0",
         "rememo": "^4.0.2"
       },
@@ -16844,18 +18020,18 @@
       }
     },
     "packages/block-editor-utils/node_modules/@wordpress/rich-text/node_modules/@wordpress/data": {
-      "version": "9.10.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-9.10.0.tgz",
-      "integrity": "sha512-jvg1ei+h9K94ckTaDHoHFtlsrkOMlRCaC/fjt2fWfTkQafrpFEEgFYIZEhT8nTQ3DD6Yuvyz4MmypSLnQ81M7A==",
+      "version": "9.11.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-9.11.0.tgz",
+      "integrity": "sha512-1UaummqcfxO4EU7eKfkxEaRjlZjRvqHRdtdjyBtrpWHxIaLrTzBdM7rBNu06tilZBoAXGRoBc5TyPuvNI3IWNg==",
       "dependencies": {
         "@babel/runtime": "^7.16.0",
-        "@wordpress/compose": "^6.17.0",
-        "@wordpress/deprecated": "^3.40.0",
-        "@wordpress/element": "^5.17.0",
-        "@wordpress/is-shallow-equal": "^4.40.0",
-        "@wordpress/priority-queue": "^2.40.0",
-        "@wordpress/private-apis": "^0.22.0",
-        "@wordpress/redux-routine": "^4.40.0",
+        "@wordpress/compose": "^6.18.0",
+        "@wordpress/deprecated": "^3.41.0",
+        "@wordpress/element": "^5.18.0",
+        "@wordpress/is-shallow-equal": "^4.41.0",
+        "@wordpress/priority-queue": "^2.41.0",
+        "@wordpress/private-apis": "^0.23.0",
+        "@wordpress/redux-routine": "^4.41.0",
         "deepmerge": "^4.3.0",
         "equivalent-key-map": "^0.2.2",
         "is-plain-object": "^5.0.0",
@@ -16872,9 +18048,9 @@
       }
     },
     "packages/block-editor-utils/node_modules/@wordpress/shortcode": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/shortcode/-/shortcode-3.40.0.tgz",
-      "integrity": "sha512-H3jd1GgsNHtRuXVvItsjtf/OQOGI0vEZ+o964Ie4xqODwqOceYKASj4Bu2x9FKl94xa7tNfsn9ZSs6ADKWHh3g==",
+      "version": "3.41.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/shortcode/-/shortcode-3.41.0.tgz",
+      "integrity": "sha512-pJuFIQbGwn8tMpPf5vtKZqQmXVm2+UnQZXVyyQGXUCBnvyGmGnbKv7lbx0NGUDBZ1AVo8/PAdssd7P/QUn7Cxg==",
       "dependencies": {
         "@babel/runtime": "^7.16.0",
         "memize": "^2.0.1"
@@ -16884,9 +18060,9 @@
       }
     },
     "packages/block-editor-utils/node_modules/@wordpress/style-engine": {
-      "version": "1.23.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/style-engine/-/style-engine-1.23.0.tgz",
-      "integrity": "sha512-Jxr8o9YB0ZKKXw15h6XCQkNV6fFPj73L42MIhHixE7Pq3mxTrwEeKl4LsnRlatBrzT6mnknP1qNWfaStTnY0AQ==",
+      "version": "1.24.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/style-engine/-/style-engine-1.24.0.tgz",
+      "integrity": "sha512-1qXkNwbuLeliQZ0yjdjjy2kJzWtvm56k0xUtFsF/0thMQ04EV0JJHwWDI6EOUCIVVFnJO6xdj2UK/KtnxGYfVw==",
       "dependencies": {
         "@babel/runtime": "^7.16.0",
         "change-case": "^4.1.2"
@@ -16896,9 +18072,9 @@
       }
     },
     "packages/block-editor-utils/node_modules/@wordpress/token-list": {
-      "version": "2.40.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/token-list/-/token-list-2.40.0.tgz",
-      "integrity": "sha512-cVEgf0PRpN9I1csIi24dElhH3zghH2yC2afgjlZwNPWy8jmUNbgLEBwtgt+iA9WpmhanvS1XhwVoP4EY3WESEg==",
+      "version": "2.41.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/token-list/-/token-list-2.41.0.tgz",
+      "integrity": "sha512-GeGPzyoVshaifYiz11KqBwkUDqAbMVVkHn5ccpqLVbn+Yc7Ur3tRJ5ikgqNikSq0EyvnHdy8XdivdLJq2xcduA==",
       "dependencies": {
         "@babel/runtime": "^7.16.0"
       },
@@ -16907,9 +18083,9 @@
       }
     },
     "packages/block-editor-utils/node_modules/@wordpress/url": {
-      "version": "3.41.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/url/-/url-3.41.0.tgz",
-      "integrity": "sha512-1DX/Nd8YdVwj/So3DEBT0YRSv2JusspAc9McRY9IttRn9pOC3m0RUNV11JPsYgwilO30WofhFsxOKvGKtEEQIg==",
+      "version": "3.42.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/url/-/url-3.42.0.tgz",
+      "integrity": "sha512-Q1eZAkgnq/Ji3UDdBPxj2mBiBusGoTkcUH2XnJDGyPIezJjC7fY/9GXE6Jj0bm37CkEH3bP6G4Yrh+YpDwMn6Q==",
       "dependencies": {
         "@babel/runtime": "^7.16.0",
         "remove-accents": "^0.5.0"
@@ -16919,17 +18095,17 @@
       }
     },
     "packages/block-editor-utils/node_modules/@wordpress/warning": {
-      "version": "2.40.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-2.40.0.tgz",
-      "integrity": "sha512-y/XdIq38m8gyotK7t8/n14VDccN9IQ9FihiUlhP3Dk46kZd9w5kBqaStd3jux2ZXSWCim9fZ3KkH03a2rNCsaA==",
+      "version": "2.41.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-2.41.0.tgz",
+      "integrity": "sha512-kSqx1z7MaNjNFg+/b5H9oY5D6hYpsKPvaonpk5CADTXOoWoEdSSkwDnCZWxaXu3Kgz4qB5EmaC4D3bKTFkFldw==",
       "engines": {
         "node": ">=12"
       }
     },
     "packages/block-editor-utils/node_modules/@wordpress/wordcount": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/wordcount/-/wordcount-3.40.0.tgz",
-      "integrity": "sha512-emZQt/WwrIYk5iOO6LjrGBZ7FB6rUms4CaFoj2Zfs5JZAkXxjnT5cO355rA1woJOmYD+4L2X4qgz5X3rePSIRA==",
+      "version": "3.41.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/wordcount/-/wordcount-3.41.0.tgz",
+      "integrity": "sha512-1GjIVx+JIeYl7mmRZf9AA5e/YhmGm043dt1/3Zto1k7/MLIpI5ValPPXlHWBA2GU1lfHdfMkSzSC5CLzBQM2ow==",
       "dependencies": {
         "@babel/runtime": "^7.16.0"
       },
@@ -16979,15 +18155,25 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "packages/block-editor-utils/node_modules/babel-jest": {
-      "version": "29.6.2",
+    "packages/block-editor-utils/node_modules/aria-query": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.1.3.tgz",
+      "integrity": "sha512-R5iJ5lkuHybztUfuOAznmboyjWq8O6sqNqtK7CLOqdydi54VNbORp49mb14KbWgG1QD3JFO9hJdZ+y4KutfdOQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@jest/transform": "^29.6.2",
+        "deep-equal": "^2.0.5"
+      }
+    },
+    "packages/block-editor-utils/node_modules/babel-jest": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.7.0.tgz",
+      "integrity": "sha512-BrvGY3xZSwEcCzKvKsCi2GgHqDqsYkOP4/by5xCgIwGXQxIEh+8ew3gmrE1y7XRR6LHZIj6yLYnUi/mm2KXKBg==",
+      "dev": true,
+      "dependencies": {
+        "@jest/transform": "^29.7.0",
         "@types/babel__core": "^7.1.14",
         "babel-plugin-istanbul": "^6.1.1",
-        "babel-preset-jest": "^29.5.0",
+        "babel-preset-jest": "^29.6.3",
         "chalk": "^4.0.0",
         "graceful-fs": "^4.2.9",
         "slash": "^3.0.0"
@@ -17015,9 +18201,10 @@
       }
     },
     "packages/block-editor-utils/node_modules/babel-plugin-jest-hoist": {
-      "version": "29.5.0",
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-29.6.3.tgz",
+      "integrity": "sha512-ESAc/RJvGTFEzRwOTT4+lNDk/GNHMkKbNzsvT0qKRfDyyYTskxB5rnU2njIDYVxXCBHHEI1c0YwHob3WaYujOg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/template": "^7.3.3",
         "@babel/types": "^7.3.3",
@@ -17029,11 +18216,12 @@
       }
     },
     "packages/block-editor-utils/node_modules/babel-preset-jest": {
-      "version": "29.5.0",
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-29.6.3.tgz",
+      "integrity": "sha512-0B3bhxR6snWXJZtR/RliHTDPRgn1sNHOR0yVtq/IiQFyuOVjFS+wuio/R4gSNkyYmKmJB4wGZv2NZanmKmTnNA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "babel-plugin-jest-hoist": "^29.5.0",
+        "babel-plugin-jest-hoist": "^29.6.3",
         "babel-preset-current-node-syntax": "^1.0.0"
       },
       "engines": {
@@ -17053,13 +18241,27 @@
     },
     "packages/block-editor-utils/node_modules/camelcase": {
       "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/block-editor-utils/node_modules/chalk": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+      "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "packages/block-editor-utils/node_modules/cmdk": {
@@ -17121,8 +18323,9 @@
     },
     "packages/block-editor-utils/node_modules/dedent": {
       "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.5.1.tgz",
+      "integrity": "sha512-+LxW+KLWxu3HW3M2w2ympwtqPrqYRzU8fqi6Fhd18fBALe15blJPI/I4+UHveMVG6lJqB4JNd4UG0S5cnVHwIg==",
       "dev": true,
-      "license": "MIT",
       "peerDependencies": {
         "babel-plugin-macros": "^3.1.0"
       },
@@ -17133,9 +18336,10 @@
       }
     },
     "packages/block-editor-utils/node_modules/diff-sequences": {
-      "version": "29.4.3",
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
+      "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
@@ -17153,8 +18357,9 @@
     },
     "packages/block-editor-utils/node_modules/emittery": {
       "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.13.1.tgz",
+      "integrity": "sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=12"
       },
@@ -17163,16 +18368,16 @@
       }
     },
     "packages/block-editor-utils/node_modules/expect": {
-      "version": "29.6.2",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-29.7.0.tgz",
+      "integrity": "sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@jest/expect-utils": "^29.6.2",
-        "@types/node": "*",
-        "jest-get-type": "^29.4.3",
-        "jest-matcher-utils": "^29.6.2",
-        "jest-message-util": "^29.6.2",
-        "jest-util": "^29.6.2"
+        "@jest/expect-utils": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "jest-matcher-utils": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -17192,9 +18397,9 @@
       }
     },
     "packages/block-editor-utils/node_modules/framer-motion": {
-      "version": "10.16.1",
-      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-10.16.1.tgz",
-      "integrity": "sha512-K6TXr5mZtitC/dxQCBdg7xzdN0d5IAIrlaqCPKtIQVdzVPGC0qBuJKXggHX1vjnP5gPOFwB1KbCCTWcnFc3kWg==",
+      "version": "10.16.4",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-10.16.4.tgz",
+      "integrity": "sha512-p9V9nGomS3m6/CALXqv6nFGMuFOxbWsmaOrdmhyQimMIlLl3LC7h7l86wge/Js/8cRu5ktutS/zlzgR7eBOtFA==",
       "dependencies": {
         "tslib": "^2.4.0"
       },
@@ -17257,15 +18462,32 @@
         "node": ">=0.10.0"
       }
     },
-    "packages/block-editor-utils/node_modules/jest": {
-      "version": "29.6.2",
+    "packages/block-editor-utils/node_modules/istanbul-lib-instrument": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-6.0.0.tgz",
+      "integrity": "sha512-x58orMzEVfzPUKqlbLd1hXCnySCxKdDKa6Rjg97CwuLLRI4g3FHTdnExu1OqffVFay6zeMW+T6/DowFLndWnIw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@jest/core": "^29.6.2",
-        "@jest/types": "^29.6.1",
+        "@babel/core": "^7.12.3",
+        "@babel/parser": "^7.14.7",
+        "@istanbuljs/schema": "^0.1.2",
+        "istanbul-lib-coverage": "^3.2.0",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "packages/block-editor-utils/node_modules/jest": {
+      "version": "29.6.4",
+      "resolved": "https://registry.npmjs.org/jest/-/jest-29.6.4.tgz",
+      "integrity": "sha512-tEFhVQFF/bzoYV1YuGyzLPZ6vlPrdfvDmmAxudA1dLEuiztqg2Rkx20vkKY32xiDROcD2KXlgZ7Cu8RPeEHRKw==",
+      "dev": true,
+      "dependencies": {
+        "@jest/core": "^29.6.4",
+        "@jest/types": "^29.6.3",
         "import-local": "^3.0.2",
-        "jest-cli": "^29.6.2"
+        "jest-cli": "^29.6.4"
       },
       "bin": {
         "jest": "bin/jest.js"
@@ -17283,11 +18505,13 @@
       }
     },
     "packages/block-editor-utils/node_modules/jest-changed-files": {
-      "version": "29.5.0",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-29.7.0.tgz",
+      "integrity": "sha512-fEArFiwf1BpQ+4bXSprcDc3/x4HSzL4al2tozwVpDFpsxALjLYdyiIK4e5Vz66GQJIbXJ82+35PtysofptNX2w==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "execa": "^5.0.0",
+        "jest-util": "^29.7.0",
         "p-limit": "^3.1.0"
       },
       "engines": {
@@ -17295,27 +18519,28 @@
       }
     },
     "packages/block-editor-utils/node_modules/jest-circus": {
-      "version": "29.6.2",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-29.7.0.tgz",
+      "integrity": "sha512-3E1nCMgipcTkCocFwM90XXQab9bS+GMsjdpmPrlelaxwD93Ad8iVEjX/vvHPdLPnFf+L40u+5+iutRdA1N9myw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@jest/environment": "^29.6.2",
-        "@jest/expect": "^29.6.2",
-        "@jest/test-result": "^29.6.2",
-        "@jest/types": "^29.6.1",
+        "@jest/environment": "^29.7.0",
+        "@jest/expect": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/types": "^29.6.3",
         "@types/node": "*",
         "chalk": "^4.0.0",
         "co": "^4.6.0",
         "dedent": "^1.0.0",
         "is-generator-fn": "^2.0.0",
-        "jest-each": "^29.6.2",
-        "jest-matcher-utils": "^29.6.2",
-        "jest-message-util": "^29.6.2",
-        "jest-runtime": "^29.6.2",
-        "jest-snapshot": "^29.6.2",
-        "jest-util": "^29.6.2",
+        "jest-each": "^29.7.0",
+        "jest-matcher-utils": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-runtime": "^29.7.0",
+        "jest-snapshot": "^29.7.0",
+        "jest-util": "^29.7.0",
         "p-limit": "^3.1.0",
-        "pretty-format": "^29.6.2",
+        "pretty-format": "^29.7.0",
         "pure-rand": "^6.0.0",
         "slash": "^3.0.0",
         "stack-utils": "^2.0.3"
@@ -17326,8 +18551,9 @@
     },
     "packages/block-editor-utils/node_modules/jest-circus/node_modules/chalk": {
       "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -17340,21 +18566,21 @@
       }
     },
     "packages/block-editor-utils/node_modules/jest-cli": {
-      "version": "29.6.2",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-29.7.0.tgz",
+      "integrity": "sha512-OVVobw2IubN/GSYsxETi+gOe7Ka59EFMR/twOU3Jb2GnKKeMGJB5SGUUrEz3SFVmJASUdZUzy83sLNNQ2gZslg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@jest/core": "^29.6.2",
-        "@jest/test-result": "^29.6.2",
-        "@jest/types": "^29.6.1",
+        "@jest/core": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/types": "^29.6.3",
         "chalk": "^4.0.0",
+        "create-jest": "^29.7.0",
         "exit": "^0.1.2",
-        "graceful-fs": "^4.2.9",
         "import-local": "^3.0.2",
-        "jest-config": "^29.6.2",
-        "jest-util": "^29.6.2",
-        "jest-validate": "^29.6.2",
-        "prompts": "^2.0.1",
+        "jest-config": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-validate": "^29.7.0",
         "yargs": "^17.3.1"
       },
       "bin": {
@@ -17374,8 +18600,9 @@
     },
     "packages/block-editor-utils/node_modules/jest-cli/node_modules/chalk": {
       "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -17388,30 +18615,31 @@
       }
     },
     "packages/block-editor-utils/node_modules/jest-config": {
-      "version": "29.6.2",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-29.7.0.tgz",
+      "integrity": "sha512-uXbpfeQ7R6TZBqI3/TxCU4q4ttk3u0PJeC+E0zbfSoSjq6bJ7buBPxzQPL0ifrkY4DNu4JUdk0ImlBUYi840eQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.11.6",
-        "@jest/test-sequencer": "^29.6.2",
-        "@jest/types": "^29.6.1",
-        "babel-jest": "^29.6.2",
+        "@jest/test-sequencer": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "babel-jest": "^29.7.0",
         "chalk": "^4.0.0",
         "ci-info": "^3.2.0",
         "deepmerge": "^4.2.2",
         "glob": "^7.1.3",
         "graceful-fs": "^4.2.9",
-        "jest-circus": "^29.6.2",
-        "jest-environment-node": "^29.6.2",
-        "jest-get-type": "^29.4.3",
-        "jest-regex-util": "^29.4.3",
-        "jest-resolve": "^29.6.2",
-        "jest-runner": "^29.6.2",
-        "jest-util": "^29.6.2",
-        "jest-validate": "^29.6.2",
+        "jest-circus": "^29.7.0",
+        "jest-environment-node": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "jest-regex-util": "^29.6.3",
+        "jest-resolve": "^29.7.0",
+        "jest-runner": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-validate": "^29.7.0",
         "micromatch": "^4.0.4",
         "parse-json": "^5.2.0",
-        "pretty-format": "^29.6.2",
+        "pretty-format": "^29.7.0",
         "slash": "^3.0.0",
         "strip-json-comments": "^3.1.1"
       },
@@ -17433,8 +18661,9 @@
     },
     "packages/block-editor-utils/node_modules/jest-config/node_modules/chalk": {
       "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -17447,14 +18676,15 @@
       }
     },
     "packages/block-editor-utils/node_modules/jest-diff": {
-      "version": "29.6.2",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.7.0.tgz",
+      "integrity": "sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "chalk": "^4.0.0",
-        "diff-sequences": "^29.4.3",
-        "jest-get-type": "^29.4.3",
-        "pretty-format": "^29.6.2"
+        "diff-sequences": "^29.6.3",
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -17462,8 +18692,9 @@
     },
     "packages/block-editor-utils/node_modules/jest-diff/node_modules/chalk": {
       "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -17476,9 +18707,10 @@
       }
     },
     "packages/block-editor-utils/node_modules/jest-docblock": {
-      "version": "29.4.3",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-29.7.0.tgz",
+      "integrity": "sha512-q617Auw3A612guyaFgsbFeYpNP5t2aoUNLwBUbc/0kD1R4t9ixDbyFTHd1nok4epoVFpr7PmeWHrhvuV3XaJ4g==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "detect-newline": "^3.0.0"
       },
@@ -17487,15 +18719,16 @@
       }
     },
     "packages/block-editor-utils/node_modules/jest-each": {
-      "version": "29.6.2",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-29.7.0.tgz",
+      "integrity": "sha512-gns+Er14+ZrEoC5fhOfYCY1LOHHr0TI+rQUHZS8Ttw2l7gl+80eHc/gFf2Ktkw0+SIACDTeWvpFcv3B04VembQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@jest/types": "^29.6.1",
+        "@jest/types": "^29.6.3",
         "chalk": "^4.0.0",
-        "jest-get-type": "^29.4.3",
-        "jest-util": "^29.6.2",
-        "pretty-format": "^29.6.2"
+        "jest-get-type": "^29.6.3",
+        "jest-util": "^29.7.0",
+        "pretty-format": "^29.7.0"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -17503,8 +18736,9 @@
     },
     "packages/block-editor-utils/node_modules/jest-each/node_modules/chalk": {
       "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -17517,17 +18751,18 @@
       }
     },
     "packages/block-editor-utils/node_modules/jest-environment-jsdom": {
-      "version": "29.6.2",
+      "version": "29.6.4",
+      "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-29.6.4.tgz",
+      "integrity": "sha512-K6wfgUJ16DoMs02JYFid9lOsqfpoVtyJxpRlnTxUHzvZWBnnh2VNGRB9EC1Cro96TQdq5TtSjb3qUjNaJP9IyA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@jest/environment": "^29.6.2",
-        "@jest/fake-timers": "^29.6.2",
-        "@jest/types": "^29.6.1",
+        "@jest/environment": "^29.6.4",
+        "@jest/fake-timers": "^29.6.4",
+        "@jest/types": "^29.6.3",
         "@types/jsdom": "^20.0.0",
         "@types/node": "*",
-        "jest-mock": "^29.6.2",
-        "jest-util": "^29.6.2",
+        "jest-mock": "^29.6.3",
+        "jest-util": "^29.6.3",
         "jsdom": "^20.0.0"
       },
       "engines": {
@@ -17543,43 +18778,46 @@
       }
     },
     "packages/block-editor-utils/node_modules/jest-environment-node": {
-      "version": "29.6.2",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-29.7.0.tgz",
+      "integrity": "sha512-DOSwCRqXirTOyheM+4d5YZOrWcdu0LNZ87ewUoywbcb2XR4wKgqiG8vNeYwhjFMbEkfju7wx2GYH0P2gevGvFw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@jest/environment": "^29.6.2",
-        "@jest/fake-timers": "^29.6.2",
-        "@jest/types": "^29.6.1",
+        "@jest/environment": "^29.7.0",
+        "@jest/fake-timers": "^29.7.0",
+        "@jest/types": "^29.6.3",
         "@types/node": "*",
-        "jest-mock": "^29.6.2",
-        "jest-util": "^29.6.2"
+        "jest-mock": "^29.7.0",
+        "jest-util": "^29.7.0"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "packages/block-editor-utils/node_modules/jest-get-type": {
-      "version": "29.4.3",
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.6.3.tgz",
+      "integrity": "sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "packages/block-editor-utils/node_modules/jest-haste-map": {
-      "version": "29.6.2",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-29.7.0.tgz",
+      "integrity": "sha512-fP8u2pyfqx0K1rGn1R9pyE0/KTn+G7PxktWidOBTqFPLYX0b9ksaMFkhK5vrS3DVun09pckLdlx90QthlW7AmA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@jest/types": "^29.6.1",
+        "@jest/types": "^29.6.3",
         "@types/graceful-fs": "^4.1.3",
         "@types/node": "*",
         "anymatch": "^3.0.3",
         "fb-watchman": "^2.0.0",
         "graceful-fs": "^4.2.9",
-        "jest-regex-util": "^29.4.3",
-        "jest-util": "^29.6.2",
-        "jest-worker": "^29.6.2",
+        "jest-regex-util": "^29.6.3",
+        "jest-util": "^29.7.0",
+        "jest-worker": "^29.7.0",
         "micromatch": "^4.0.4",
         "walker": "^1.0.8"
       },
@@ -17591,26 +18829,28 @@
       }
     },
     "packages/block-editor-utils/node_modules/jest-leak-detector": {
-      "version": "29.6.2",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-29.7.0.tgz",
+      "integrity": "sha512-kYA8IJcSYtST2BY9I+SMC32nDpBT3J2NvWJx8+JCuCdl/CR1I4EKUJROiP8XtCcxqgTTBGJNdbB1A8XRKbTetw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "jest-get-type": "^29.4.3",
-        "pretty-format": "^29.6.2"
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "packages/block-editor-utils/node_modules/jest-matcher-utils": {
-      "version": "29.6.2",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.7.0.tgz",
+      "integrity": "sha512-sBkD+Xi9DtcChsI3L3u0+N0opgPYnCRPtGcQYrgXmR+hmt/fYfWAL0xRXYU8eWOdfuLgBe0YCW3AFtnRLagq/g==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "chalk": "^4.0.0",
-        "jest-diff": "^29.6.2",
-        "jest-get-type": "^29.4.3",
-        "pretty-format": "^29.6.2"
+        "jest-diff": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -17632,17 +18872,18 @@
       }
     },
     "packages/block-editor-utils/node_modules/jest-message-util": {
-      "version": "29.6.2",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.7.0.tgz",
+      "integrity": "sha512-GBEV4GRADeP+qtB2+6u61stea8mGcOT4mCtrYISZwfu9/ISHFJ/5zOMXYbpBE9RsS5+Gb63DW4FgmnKJ79Kf6w==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.12.13",
-        "@jest/types": "^29.6.1",
+        "@jest/types": "^29.6.3",
         "@types/stack-utils": "^2.0.0",
         "chalk": "^4.0.0",
         "graceful-fs": "^4.2.9",
         "micromatch": "^4.0.4",
-        "pretty-format": "^29.6.2",
+        "pretty-format": "^29.7.0",
         "slash": "^3.0.0",
         "stack-utils": "^2.0.3"
       },
@@ -17666,37 +18907,40 @@
       }
     },
     "packages/block-editor-utils/node_modules/jest-mock": {
-      "version": "29.6.2",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.7.0.tgz",
+      "integrity": "sha512-ITOMZn+UkYS4ZFh83xYAOzWStloNzJFO2s8DWrE4lhtGD+AorgnbkiKERe4wQVBydIGPx059g6riW5Btp6Llnw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@jest/types": "^29.6.1",
+        "@jest/types": "^29.6.3",
         "@types/node": "*",
-        "jest-util": "^29.6.2"
+        "jest-util": "^29.7.0"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "packages/block-editor-utils/node_modules/jest-regex-util": {
-      "version": "29.4.3",
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-29.6.3.tgz",
+      "integrity": "sha512-KJJBsRCyyLNWCNBOvZyRDnAIfUiRJ8v+hOBQYGn8gDyF3UegwiP4gwRR3/SDa42g1YbVycTidUF3rKjyLFDWbg==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "packages/block-editor-utils/node_modules/jest-resolve": {
-      "version": "29.6.2",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-29.7.0.tgz",
+      "integrity": "sha512-IOVhZSrg+UvVAshDSDtHyFCCBUl/Q3AAJv8iZ6ZjnZ74xzvwuzLXid9IIIPgTnY62SJjfuupMKZsZQRsCvxEgA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "chalk": "^4.0.0",
         "graceful-fs": "^4.2.9",
-        "jest-haste-map": "^29.6.2",
+        "jest-haste-map": "^29.7.0",
         "jest-pnp-resolver": "^1.2.2",
-        "jest-util": "^29.6.2",
-        "jest-validate": "^29.6.2",
+        "jest-util": "^29.7.0",
+        "jest-validate": "^29.7.0",
         "resolve": "^1.20.0",
         "resolve.exports": "^2.0.0",
         "slash": "^3.0.0"
@@ -17706,12 +18950,13 @@
       }
     },
     "packages/block-editor-utils/node_modules/jest-resolve-dependencies": {
-      "version": "29.6.2",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-29.7.0.tgz",
+      "integrity": "sha512-un0zD/6qxJ+S0et7WxeI3H5XSe9lTBBR7bOHCHXkKR6luG5mwDDlIzVQ0V5cZCuoTgEdcdwzTghYkTWfubi+nA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "jest-regex-util": "^29.4.3",
-        "jest-snapshot": "^29.6.2"
+        "jest-regex-util": "^29.6.3",
+        "jest-snapshot": "^29.7.0"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -17719,8 +18964,9 @@
     },
     "packages/block-editor-utils/node_modules/jest-resolve/node_modules/chalk": {
       "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -17733,29 +18979,30 @@
       }
     },
     "packages/block-editor-utils/node_modules/jest-runner": {
-      "version": "29.6.2",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-29.7.0.tgz",
+      "integrity": "sha512-fsc4N6cPCAahybGBfTRcq5wFR6fpLznMg47sY5aDpsoejOcVYFb07AHuSnR0liMcPTgBsA3ZJL6kFOjPdoNipQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@jest/console": "^29.6.2",
-        "@jest/environment": "^29.6.2",
-        "@jest/test-result": "^29.6.2",
-        "@jest/transform": "^29.6.2",
-        "@jest/types": "^29.6.1",
+        "@jest/console": "^29.7.0",
+        "@jest/environment": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
         "@types/node": "*",
         "chalk": "^4.0.0",
         "emittery": "^0.13.1",
         "graceful-fs": "^4.2.9",
-        "jest-docblock": "^29.4.3",
-        "jest-environment-node": "^29.6.2",
-        "jest-haste-map": "^29.6.2",
-        "jest-leak-detector": "^29.6.2",
-        "jest-message-util": "^29.6.2",
-        "jest-resolve": "^29.6.2",
-        "jest-runtime": "^29.6.2",
-        "jest-util": "^29.6.2",
-        "jest-watcher": "^29.6.2",
-        "jest-worker": "^29.6.2",
+        "jest-docblock": "^29.7.0",
+        "jest-environment-node": "^29.7.0",
+        "jest-haste-map": "^29.7.0",
+        "jest-leak-detector": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-resolve": "^29.7.0",
+        "jest-runtime": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-watcher": "^29.7.0",
+        "jest-worker": "^29.7.0",
         "p-limit": "^3.1.0",
         "source-map-support": "0.5.13"
       },
@@ -17765,8 +19012,9 @@
     },
     "packages/block-editor-utils/node_modules/jest-runner/node_modules/chalk": {
       "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -17779,30 +19027,31 @@
       }
     },
     "packages/block-editor-utils/node_modules/jest-runtime": {
-      "version": "29.6.2",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-29.7.0.tgz",
+      "integrity": "sha512-gUnLjgwdGqW7B4LvOIkbKs9WGbn+QLqRQQ9juC6HndeDiezIwhDP+mhMwHWCEcfQ5RUXa6OPnFF8BJh5xegwwQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@jest/environment": "^29.6.2",
-        "@jest/fake-timers": "^29.6.2",
-        "@jest/globals": "^29.6.2",
-        "@jest/source-map": "^29.6.0",
-        "@jest/test-result": "^29.6.2",
-        "@jest/transform": "^29.6.2",
-        "@jest/types": "^29.6.1",
+        "@jest/environment": "^29.7.0",
+        "@jest/fake-timers": "^29.7.0",
+        "@jest/globals": "^29.7.0",
+        "@jest/source-map": "^29.6.3",
+        "@jest/test-result": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
         "@types/node": "*",
         "chalk": "^4.0.0",
         "cjs-module-lexer": "^1.0.0",
         "collect-v8-coverage": "^1.0.0",
         "glob": "^7.1.3",
         "graceful-fs": "^4.2.9",
-        "jest-haste-map": "^29.6.2",
-        "jest-message-util": "^29.6.2",
-        "jest-mock": "^29.6.2",
-        "jest-regex-util": "^29.4.3",
-        "jest-resolve": "^29.6.2",
-        "jest-snapshot": "^29.6.2",
-        "jest-util": "^29.6.2",
+        "jest-haste-map": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-mock": "^29.7.0",
+        "jest-regex-util": "^29.6.3",
+        "jest-resolve": "^29.7.0",
+        "jest-snapshot": "^29.7.0",
+        "jest-util": "^29.7.0",
         "slash": "^3.0.0",
         "strip-bom": "^4.0.0"
       },
@@ -17812,8 +19061,9 @@
     },
     "packages/block-editor-utils/node_modules/jest-runtime/node_modules/chalk": {
       "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -17826,29 +19076,30 @@
       }
     },
     "packages/block-editor-utils/node_modules/jest-snapshot": {
-      "version": "29.6.2",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-29.7.0.tgz",
+      "integrity": "sha512-Rm0BMWtxBcioHr1/OX5YCP8Uov4riHvKPknOGs804Zg9JGZgmIBkbtlxJC/7Z4msKYVbIJtfU+tKb8xlYNfdkw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.11.6",
         "@babel/generator": "^7.7.2",
         "@babel/plugin-syntax-jsx": "^7.7.2",
         "@babel/plugin-syntax-typescript": "^7.7.2",
         "@babel/types": "^7.3.3",
-        "@jest/expect-utils": "^29.6.2",
-        "@jest/transform": "^29.6.2",
-        "@jest/types": "^29.6.1",
+        "@jest/expect-utils": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
         "babel-preset-current-node-syntax": "^1.0.0",
         "chalk": "^4.0.0",
-        "expect": "^29.6.2",
+        "expect": "^29.7.0",
         "graceful-fs": "^4.2.9",
-        "jest-diff": "^29.6.2",
-        "jest-get-type": "^29.4.3",
-        "jest-matcher-utils": "^29.6.2",
-        "jest-message-util": "^29.6.2",
-        "jest-util": "^29.6.2",
+        "jest-diff": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "jest-matcher-utils": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0",
         "natural-compare": "^1.4.0",
-        "pretty-format": "^29.6.2",
+        "pretty-format": "^29.7.0",
         "semver": "^7.5.3"
       },
       "engines": {
@@ -17857,8 +19108,9 @@
     },
     "packages/block-editor-utils/node_modules/jest-snapshot/node_modules/chalk": {
       "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -17871,11 +19123,12 @@
       }
     },
     "packages/block-editor-utils/node_modules/jest-util": {
-      "version": "29.6.2",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
+      "integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@jest/types": "^29.6.1",
+        "@jest/types": "^29.6.3",
         "@types/node": "*",
         "chalk": "^4.0.0",
         "ci-info": "^3.2.0",
@@ -17902,16 +19155,17 @@
       }
     },
     "packages/block-editor-utils/node_modules/jest-validate": {
-      "version": "29.6.2",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-29.7.0.tgz",
+      "integrity": "sha512-ZB7wHqaRGVw/9hST/OuFUReG7M8vKeq0/J2egIGLdvjHCmYqGARhzXmtgi+gVeZ5uXFF219aOc3Ls2yLg27tkw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@jest/types": "^29.6.1",
+        "@jest/types": "^29.6.3",
         "camelcase": "^6.2.0",
         "chalk": "^4.0.0",
-        "jest-get-type": "^29.4.3",
+        "jest-get-type": "^29.6.3",
         "leven": "^3.1.0",
-        "pretty-format": "^29.6.2"
+        "pretty-format": "^29.7.0"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -17919,8 +19173,9 @@
     },
     "packages/block-editor-utils/node_modules/jest-validate/node_modules/chalk": {
       "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -17933,17 +19188,18 @@
       }
     },
     "packages/block-editor-utils/node_modules/jest-watcher": {
-      "version": "29.6.2",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-29.7.0.tgz",
+      "integrity": "sha512-49Fg7WXkU3Vl2h6LbLtMQ/HyB6rXSIX7SqvBLQmssRBGN9I0PNvPmAmCWSOY6SOvrjhI/F7/bGAv9RtnsPA03g==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@jest/test-result": "^29.6.2",
-        "@jest/types": "^29.6.1",
+        "@jest/test-result": "^29.7.0",
+        "@jest/types": "^29.6.3",
         "@types/node": "*",
         "ansi-escapes": "^4.2.1",
         "chalk": "^4.0.0",
         "emittery": "^0.13.1",
-        "jest-util": "^29.6.2",
+        "jest-util": "^29.7.0",
         "string-length": "^4.0.1"
       },
       "engines": {
@@ -17952,8 +19208,9 @@
     },
     "packages/block-editor-utils/node_modules/jest-watcher/node_modules/chalk": {
       "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -17966,12 +19223,13 @@
       }
     },
     "packages/block-editor-utils/node_modules/jest-worker": {
-      "version": "29.6.2",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.7.0.tgz",
+      "integrity": "sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@types/node": "*",
-        "jest-util": "^29.6.2",
+        "jest-util": "^29.7.0",
         "merge-stream": "^2.0.0",
         "supports-color": "^8.0.0"
       },
@@ -17981,8 +19239,9 @@
     },
     "packages/block-editor-utils/node_modules/jest-worker/node_modules/supports-color": {
       "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -18037,6 +19296,15 @@
         }
       }
     },
+    "packages/block-editor-utils/node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "packages/block-editor-utils/node_modules/memize": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/memize/-/memize-2.1.0.tgz",
@@ -18058,8 +19326,9 @@
     },
     "packages/block-editor-utils/node_modules/p-limit": {
       "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "yocto-queue": "^0.1.0"
       },
@@ -18087,11 +19356,12 @@
       "integrity": "sha512-JLyh7xT1kizaEvcaXOQwOc2/Yhw6KZOvPf1S8401UyLk86CU79LN3vl7ztXGm/pZ+YjoyAJ4rxmHwbkBXJX+yw=="
     },
     "packages/block-editor-utils/node_modules/pretty-format": {
-      "version": "29.6.2",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@jest/schemas": "^29.6.0",
+        "@jest/schemas": "^29.6.3",
         "ansi-styles": "^5.0.0",
         "react-is": "^18.0.0"
       },
@@ -18148,8 +19418,9 @@
     },
     "packages/block-editor-utils/node_modules/resolve.exports": {
       "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-2.0.2.tgz",
+      "integrity": "sha512-X2UW6Nw3n/aMgDVy+0rSqgHlv39WZAlZrXCdnbyEiKm17DSqHX4MmQMaST3FbeWR5FTuRcUwYAziZajji0Y7mg==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=10"
       }
@@ -18206,19 +19477,30 @@
         "loose-envify": "^1.1.0"
       }
     },
+    "packages/block-editor-utils/node_modules/semver": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "packages/block-editor-utils/node_modules/source-map-support": {
       "version": "0.5.13",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
+      "integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
       }
-    },
-    "packages/block-editor-utils/node_modules/sprintf-js": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
-      "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug=="
     },
     "packages/block-editor-utils/node_modules/supports-color": {
       "version": "7.2.0",
@@ -18286,8 +19568,9 @@
     },
     "packages/block-editor-utils/node_modules/v8-to-istanbul": {
       "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.1.0.tgz",
+      "integrity": "sha512-6z3GW9x8G1gd+JIIgQQQxXuiJtCXeAjp6RaPEPLv62mH3iPHPxV6W3robxtCzNErRo6ZwTmzWhsbNvjyEBKzKA==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.12",
         "@types/istanbul-lib-coverage": "^2.0.1",
@@ -18299,8 +19582,9 @@
     },
     "packages/block-editor-utils/node_modules/v8-to-istanbul/node_modules/convert-source-map": {
       "version": "1.9.0",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
+      "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
+      "dev": true
     },
     "packages/block-editor-utils/node_modules/valtio": {
       "version": "1.7.0",
@@ -18564,13 +19848,13 @@
     },
     "packages/experimental-app-router": {
       "name": "@faustwp/experimental-app-router",
-      "version": "0.0.2",
+      "version": "0.0.3",
       "license": "MIT",
       "devDependencies": {
         "@apollo/client": "^3.8.0",
         "@apollo/experimental-nextjs-app-support": "^0.4.1",
         "@faustwp/cli": "^1.1.1",
-        "@faustwp/core": "^1.1.1",
+        "@faustwp/core": "^1.1.2",
         "@testing-library/jest-dom": "^5.17.0",
         "@types/node": "^20.4.6",
         "concurrently": "^8.2.0",
@@ -18592,7 +19876,7 @@
         "@apollo/client": ">=3.8.0",
         "@apollo/experimental-nextjs-app-support": ">=0.3.2",
         "@faustwp/cli": ">=1.1.1",
-        "@faustwp/core": ">=1.1.1",
+        "@faustwp/core": ">=1.1.2",
         "next": ">=12.1.6",
         "react": ">=17.0.2",
         "react-dom": ">=17.0.2"
@@ -18904,21 +20188,6 @@
         "node": ">= 10"
       }
     },
-    "packages/experimental-app-router/node_modules/@next/swc-darwin-arm64": {
-      "version": "13.4.13",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.4.13.tgz",
-      "integrity": "sha512-ZptVhHjzUuivnXMNCJ6lER33HN7lC+rZ01z+PM10Ows21NHFYMvGhi5iXkGtBDk6VmtzsbqnAjnx4Oz5um0FjA==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
     "packages/experimental-app-router/node_modules/@next/swc-darwin-x64": {
       "version": "13.4.13",
       "cpu": [
@@ -19038,111 +20307,6 @@
         "x64"
       ],
       "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "packages/experimental-app-router/node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "13.4.13",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-13.4.13.tgz",
-      "integrity": "sha512-xEHUqC8eqR5DHe8SOmMnDU1K3ggrJ28uIKltrQAwqFSSSmzjnN/XMocZkcVhuncuxYrpbri0iMQstRyRVdQVWg==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "packages/experimental-app-router/node_modules/@next/swc-linux-arm64-musl": {
-      "version": "13.4.13",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-13.4.13.tgz",
-      "integrity": "sha512-sNf3MnLAm8rquSSAoeD9nVcdaDeRYOeey4stOWOyWIgbBDtP+C93amSgH/LPTDoUV7gNiU6f+ghepTjTjRgIUQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "packages/experimental-app-router/node_modules/@next/swc-linux-x64-gnu": {
-      "version": "13.4.13",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-13.4.13.tgz",
-      "integrity": "sha512-WhcRaJJSHyx9OWmKjjz+OWHumiPZWRqmM/09Bt7Up4UqUJFFhGExeztR4trtv3rflvULatu9IH/nTV8fUUgaMA==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "packages/experimental-app-router/node_modules/@next/swc-linux-x64-musl": {
-      "version": "13.4.13",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-13.4.13.tgz",
-      "integrity": "sha512-+Y4LLhOWWZQIDKVwr2R17lq2KSN0F1c30QVgGIWfnjjHpH8nrIWHEndhqYU+iFuW8It78CiJjQKTw4f51HD7jA==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "packages/experimental-app-router/node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "13.4.13",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-13.4.13.tgz",
-      "integrity": "sha512-rWurdOR20uxjfqd1X9vDAgv0Jb26KjyL8akF9CBeFqX8rVaBAnW/Wf6A2gYEwyYY4Bai3T7p1kro6DFrsvBAAw==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "packages/experimental-app-router/node_modules/@next/swc-win32-ia32-msvc": {
-      "version": "13.4.13",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-13.4.13.tgz",
-      "integrity": "sha512-E8bSPwRuY5ibJ3CzLQmJEt8qaWrPYuUTwnrwygPUEWoLzD5YRx9SD37oXRdU81TgGwDzCxpl7z5Nqlfk50xAog==",
-      "cpu": [
-        "ia32"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "packages/experimental-app-router/node_modules/@next/swc-win32-x64-msvc": {
-      "version": "13.4.13",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-13.4.13.tgz",
-      "integrity": "sha512-4KlyC6jWRubPnppgfYsNTPeWfGCxtWLh5vaOAW/kdzAk9widqho8Qb5S4K2vHmal1tsURi7Onk2MMCV1phvyqA==",
-      "cpu": [
-        "x64"
-      ],
       "optional": true,
       "os": [
         "win32"
@@ -20828,7 +21992,7 @@
     },
     "packages/faustwp-core": {
       "name": "@faustwp/core",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "license": "MIT",
       "dependencies": {
         "@wordpress/hooks": "^3.14.0",
@@ -21095,7 +22259,7 @@
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
         "json5": "^2.2.2",
-        "semver": "^6.3.0"
+        "semver": "~7.5.2"
       }
     },
     "@babel/generator": {
@@ -21127,7 +22291,7 @@
         "@babel/helper-validator-option": "^7.22.5",
         "browserslist": "^4.21.3",
         "lru-cache": "^5.1.1",
-        "semver": "^6.3.0"
+        "semver": "~7.5.2"
       },
       "dependencies": {
         "lru-cache": {
@@ -21402,7 +22566,7 @@
         "outdent": "^0.5.0",
         "prettier": "^2.7.1",
         "resolve-from": "^5.0.0",
-        "semver": "^7.5.3"
+        "semver": "~7.5.2"
       }
     },
     "@changesets/assemble-release-plan": {
@@ -21414,7 +22578,7 @@
         "@changesets/get-dependents-graph": "^1.3.6",
         "@changesets/types": "^5.2.1",
         "@manypkg/get-packages": "^1.1.3",
-        "semver": "^7.5.3"
+        "semver": "~7.5.2"
       }
     },
     "@changesets/changelog-git": {
@@ -21833,10 +22997,10 @@
         "@apollo/client": "^3.8.0",
         "@apollo/experimental-nextjs-app-support": "^0.4.1",
         "@faustwp/cli": "1.1.1",
-        "@faustwp/core": "1.1.1",
-        "@faustwp/experimental-app-router": "^0.0.2",
+        "@faustwp/core": "1.1.2",
+        "@faustwp/experimental-app-router": "^0.0.3",
         "graphql": "^16.7.1",
-        "next": "^13.4.13",
+        "next": "^13.4.20-canary.18",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
       },
@@ -21867,10 +23031,14 @@
           }
         },
         "@next/env": {
-          "version": "13.4.13"
+          "version": "13.4.20-canary.18",
+          "resolved": "https://registry.npmjs.org/@next/env/-/env-13.4.20-canary.18.tgz",
+          "integrity": "sha512-v0LXMmRRLPUCyUdO3sVMwCTCY/1tp+kye+78drjkQm0MC+ujKyVemVS0HYH0kkz1oUibuD2gthlVgiokPL08pA=="
         },
         "@next/swc-darwin-x64": {
-          "version": "13.4.13",
+          "version": "13.4.20-canary.18",
+          "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-13.4.20-canary.18.tgz",
+          "integrity": "sha512-sKPC/CwZntxQKYmdpV0mqzbxE8whGKd7onPR7PDFCOYCzaZhfEoAAWHwokBsv/MQ+CEtTy7x8sMvzlN8DgvNaA==",
           "optional": true
         },
         "@swc/helpers": {
@@ -21901,18 +23069,20 @@
           "version": "16.7.1"
         },
         "next": {
-          "version": "13.4.13",
+          "version": "13.4.20-canary.18",
+          "resolved": "https://registry.npmjs.org/next/-/next-13.4.20-canary.18.tgz",
+          "integrity": "sha512-ebHSLdj2EusCFIuF0W385dvcFrof53d/kb2DNsLKtOVjiboXgMZ7ZKSLG0KE4lM08nTg0GTpNyRu5OAJB0oUWw==",
           "requires": {
-            "@next/env": "13.4.13",
-            "@next/swc-darwin-arm64": "13.4.13",
-            "@next/swc-darwin-x64": "13.4.13",
-            "@next/swc-linux-arm64-gnu": "13.4.13",
-            "@next/swc-linux-arm64-musl": "13.4.13",
-            "@next/swc-linux-x64-gnu": "13.4.13",
-            "@next/swc-linux-x64-musl": "13.4.13",
-            "@next/swc-win32-arm64-msvc": "13.4.13",
-            "@next/swc-win32-ia32-msvc": "13.4.13",
-            "@next/swc-win32-x64-msvc": "13.4.13",
+            "@next/env": "13.4.20-canary.18",
+            "@next/swc-darwin-arm64": "13.4.20-canary.18",
+            "@next/swc-darwin-x64": "13.4.20-canary.18",
+            "@next/swc-linux-arm64-gnu": "13.4.20-canary.18",
+            "@next/swc-linux-arm64-musl": "13.4.20-canary.18",
+            "@next/swc-linux-x64-gnu": "13.4.20-canary.18",
+            "@next/swc-linux-x64-musl": "13.4.20-canary.18",
+            "@next/swc-win32-arm64-msvc": "13.4.20-canary.18",
+            "@next/swc-win32-ia32-msvc": "13.4.20-canary.18",
+            "@next/swc-win32-x64-msvc": "13.4.20-canary.18",
             "@swc/helpers": "0.5.1",
             "busboy": "1.6.0",
             "caniuse-lite": "^1.0.30001406",
@@ -21961,22 +23131,24 @@
       "version": "file:packages/block-editor-utils",
       "requires": {
         "@react-spring/web": "9.7.3",
-        "@types/jest": "^29.5.3",
+        "@testing-library/jest-dom": "^6.1.3",
+        "@testing-library/react": "^14.0.0",
+        "@types/jest": "^29.5.4",
         "@types/node": "^18.0.6",
         "@types/react": "^18.0.0",
-        "@types/wordpress__block-editor": "11.5.2",
-        "@types/wordpress__blocks": "12.5.2",
-        "@wordpress/block-editor": "^12.8.0",
-        "@wordpress/blocks": "^12.17.0",
-        "@wordpress/components": "^25.6.0",
-        "@wordpress/element": "5.17.0",
-        "@wordpress/hooks": "^3.40.0",
-        "@wordpress/i18n": "^4.40.0",
-        "@wordpress/jest-preset-default": "^11.9.0",
-        "jest": "29.6.2",
-        "jest-environment-jsdom": "29.6.2",
-        "react": ">=18.0.0",
-        "react-dom": ">=18.0.0",
+        "@types/wordpress__block-editor": "11.5.3",
+        "@types/wordpress__blocks": "12.5.3",
+        "@wordpress/block-editor": "^12.9.0",
+        "@wordpress/blocks": "^12.18.0",
+        "@wordpress/components": "^25.7.0",
+        "@wordpress/element": "5.18.0",
+        "@wordpress/hooks": "^3.41.0",
+        "@wordpress/i18n": "^4.41.0",
+        "@wordpress/jest-preset-default": "^11.12.0",
+        "jest": "29.6.4",
+        "jest-environment-jsdom": "29.6.4",
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0",
         "rimraf": "^4.4.0",
         "ts-jest": "29.1.1"
       },
@@ -21996,28 +23168,49 @@
           "integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==",
           "optional": true
         },
-        "@floating-ui/react-dom": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-1.0.0.tgz",
-          "integrity": "sha512-uiOalFKPG937UCLm42RxjESTWUVpbbatvlphQAU6bsv+ence6IoVG8JOUZcy8eW81NkU+Idiwvx10WFLmR4MIg==",
+        "@floating-ui/core": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.4.1.tgz",
+          "integrity": "sha512-jk3WqquEJRlcyu7997NtR5PibI+y5bi+LS3hPmguVClypenMsCY3CBa3LAQnozRCtCrYWSEtAdiskpamuJRFOQ==",
           "requires": {
-            "@floating-ui/dom": "^1.0.0"
+            "@floating-ui/utils": "^0.1.1"
+          }
+        },
+        "@floating-ui/dom": {
+          "version": "1.5.2",
+          "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.5.2.tgz",
+          "integrity": "sha512-6ArmenS6qJEWmwzczWyhvrXRdI/rI78poBcW0h/456+onlabit+2G+QxHx5xTOX60NBJQXjsCLFbW2CmsXpUog==",
+          "requires": {
+            "@floating-ui/core": "^1.4.1",
+            "@floating-ui/utils": "^0.1.1"
+          }
+        },
+        "@floating-ui/react-dom": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.0.2.tgz",
+          "integrity": "sha512-5qhlDvjaLmAst/rKb3VdlCinwTF4EYMiVxuuc/HVUjs46W0zgtbMmAZ1UTsDrRTxRmUEzl92mOtWbeeXL26lSQ==",
+          "requires": {
+            "@floating-ui/dom": "^1.5.1"
           }
         },
         "@jest/console": {
-          "version": "29.6.2",
+          "version": "29.7.0",
+          "resolved": "https://registry.npmjs.org/@jest/console/-/console-29.7.0.tgz",
+          "integrity": "sha512-5Ni4CU7XHQi32IJ398EEP4RrB8eV09sXP2ROqD4bksHrnTree52PsxvX8tpL8LvTZ3pFzXyPbNQReSN41CAhOg==",
           "dev": true,
           "requires": {
-            "@jest/types": "^29.6.1",
+            "@jest/types": "^29.6.3",
             "@types/node": "*",
             "chalk": "^4.0.0",
-            "jest-message-util": "^29.6.2",
-            "jest-util": "^29.6.2",
+            "jest-message-util": "^29.7.0",
+            "jest-util": "^29.7.0",
             "slash": "^3.0.0"
           },
           "dependencies": {
             "chalk": {
               "version": "4.1.2",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+              "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
               "dev": true,
               "requires": {
                 "ansi-styles": "^4.1.0",
@@ -22027,41 +23220,45 @@
           }
         },
         "@jest/core": {
-          "version": "29.6.2",
+          "version": "29.7.0",
+          "resolved": "https://registry.npmjs.org/@jest/core/-/core-29.7.0.tgz",
+          "integrity": "sha512-n7aeXWKMnGtDA48y8TLWJPJmLmmZ642Ceo78cYWEpiD7FzDgmNDV/GCVRorPABdXLJZ/9wzzgZAlHjXjxDHGsg==",
           "dev": true,
           "requires": {
-            "@jest/console": "^29.6.2",
-            "@jest/reporters": "^29.6.2",
-            "@jest/test-result": "^29.6.2",
-            "@jest/transform": "^29.6.2",
-            "@jest/types": "^29.6.1",
+            "@jest/console": "^29.7.0",
+            "@jest/reporters": "^29.7.0",
+            "@jest/test-result": "^29.7.0",
+            "@jest/transform": "^29.7.0",
+            "@jest/types": "^29.6.3",
             "@types/node": "*",
             "ansi-escapes": "^4.2.1",
             "chalk": "^4.0.0",
             "ci-info": "^3.2.0",
             "exit": "^0.1.2",
             "graceful-fs": "^4.2.9",
-            "jest-changed-files": "^29.5.0",
-            "jest-config": "^29.6.2",
-            "jest-haste-map": "^29.6.2",
-            "jest-message-util": "^29.6.2",
-            "jest-regex-util": "^29.4.3",
-            "jest-resolve": "^29.6.2",
-            "jest-resolve-dependencies": "^29.6.2",
-            "jest-runner": "^29.6.2",
-            "jest-runtime": "^29.6.2",
-            "jest-snapshot": "^29.6.2",
-            "jest-util": "^29.6.2",
-            "jest-validate": "^29.6.2",
-            "jest-watcher": "^29.6.2",
+            "jest-changed-files": "^29.7.0",
+            "jest-config": "^29.7.0",
+            "jest-haste-map": "^29.7.0",
+            "jest-message-util": "^29.7.0",
+            "jest-regex-util": "^29.6.3",
+            "jest-resolve": "^29.7.0",
+            "jest-resolve-dependencies": "^29.7.0",
+            "jest-runner": "^29.7.0",
+            "jest-runtime": "^29.7.0",
+            "jest-snapshot": "^29.7.0",
+            "jest-util": "^29.7.0",
+            "jest-validate": "^29.7.0",
+            "jest-watcher": "^29.7.0",
             "micromatch": "^4.0.4",
-            "pretty-format": "^29.6.2",
+            "pretty-format": "^29.7.0",
             "slash": "^3.0.0",
             "strip-ansi": "^6.0.0"
           },
           "dependencies": {
             "chalk": {
               "version": "4.1.2",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+              "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
               "dev": true,
               "requires": {
                 "ansi-styles": "^4.1.0",
@@ -22071,46 +23268,54 @@
           }
         },
         "@jest/environment": {
-          "version": "29.6.2",
+          "version": "29.7.0",
+          "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.7.0.tgz",
+          "integrity": "sha512-aQIfHDq33ExsN4jP1NWGXhxgQ/wixs60gDiKO+XVMd8Mn0NWPWgc34ZQDTb2jKaUWQ7MuwoitXAsN2XVXNMpAw==",
           "dev": true,
           "requires": {
-            "@jest/fake-timers": "^29.6.2",
-            "@jest/types": "^29.6.1",
+            "@jest/fake-timers": "^29.7.0",
+            "@jest/types": "^29.6.3",
             "@types/node": "*",
-            "jest-mock": "^29.6.2"
+            "jest-mock": "^29.7.0"
           }
         },
         "@jest/fake-timers": {
-          "version": "29.6.2",
+          "version": "29.7.0",
+          "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-29.7.0.tgz",
+          "integrity": "sha512-q4DH1Ha4TTFPdxLsqDXK1d3+ioSL7yL5oCMJZgDYm6i+6CygW5E5xVr/D1HdsGxjt1ZWSfUAs9OxSB/BNelWrQ==",
           "dev": true,
           "requires": {
-            "@jest/types": "^29.6.1",
+            "@jest/types": "^29.6.3",
             "@sinonjs/fake-timers": "^10.0.2",
             "@types/node": "*",
-            "jest-message-util": "^29.6.2",
-            "jest-mock": "^29.6.2",
-            "jest-util": "^29.6.2"
+            "jest-message-util": "^29.7.0",
+            "jest-mock": "^29.7.0",
+            "jest-util": "^29.7.0"
           }
         },
         "@jest/globals": {
-          "version": "29.6.2",
+          "version": "29.7.0",
+          "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-29.7.0.tgz",
+          "integrity": "sha512-mpiz3dutLbkW2MNFubUGUEVLkTGiqW6yLVTA+JbP6fI6J5iL9Y0Nlg8k95pcF8ctKwCS7WVxteBs29hhfAotzQ==",
           "dev": true,
           "requires": {
-            "@jest/environment": "^29.6.2",
-            "@jest/expect": "^29.6.2",
-            "@jest/types": "^29.6.1",
-            "jest-mock": "^29.6.2"
+            "@jest/environment": "^29.7.0",
+            "@jest/expect": "^29.7.0",
+            "@jest/types": "^29.6.3",
+            "jest-mock": "^29.7.0"
           }
         },
         "@jest/reporters": {
-          "version": "29.6.2",
+          "version": "29.7.0",
+          "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-29.7.0.tgz",
+          "integrity": "sha512-DApq0KJbJOEzAFYjHADNNxAE3KbhxQB1y5Kplb5Waqw6zVbuWatSnMjE5gs8FUgEPmNsnZA3NCWl9NG0ia04Pg==",
           "dev": true,
           "requires": {
             "@bcoe/v8-coverage": "^0.2.3",
-            "@jest/console": "^29.6.2",
-            "@jest/test-result": "^29.6.2",
-            "@jest/transform": "^29.6.2",
-            "@jest/types": "^29.6.1",
+            "@jest/console": "^29.7.0",
+            "@jest/test-result": "^29.7.0",
+            "@jest/transform": "^29.7.0",
+            "@jest/types": "^29.6.3",
             "@jridgewell/trace-mapping": "^0.3.18",
             "@types/node": "*",
             "chalk": "^4.0.0",
@@ -22119,13 +23324,13 @@
             "glob": "^7.1.3",
             "graceful-fs": "^4.2.9",
             "istanbul-lib-coverage": "^3.0.0",
-            "istanbul-lib-instrument": "^5.1.0",
+            "istanbul-lib-instrument": "^6.0.0",
             "istanbul-lib-report": "^3.0.0",
             "istanbul-lib-source-maps": "^4.0.0",
             "istanbul-reports": "^3.1.3",
-            "jest-message-util": "^29.6.2",
-            "jest-util": "^29.6.2",
-            "jest-worker": "^29.6.2",
+            "jest-message-util": "^29.7.0",
+            "jest-util": "^29.7.0",
+            "jest-worker": "^29.7.0",
             "slash": "^3.0.0",
             "string-length": "^4.0.1",
             "strip-ansi": "^6.0.0",
@@ -22134,6 +23339,8 @@
           "dependencies": {
             "chalk": {
               "version": "4.1.2",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+              "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
               "dev": true,
               "requires": {
                 "ansi-styles": "^4.1.0",
@@ -22143,7 +23350,9 @@
           }
         },
         "@jest/source-map": {
-          "version": "29.6.0",
+          "version": "29.6.3",
+          "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-29.6.3.tgz",
+          "integrity": "sha512-MHjT95QuipcPrpLM+8JMSzFx6eHp5Bm+4XeFDJlwsvVBjmKNiIAvasGK2fxz2WbGRlnvqehFbh07MMa7n3YJnw==",
           "dev": true,
           "requires": {
             "@jridgewell/trace-mapping": "^0.3.18",
@@ -22152,40 +23361,46 @@
           }
         },
         "@jest/test-result": {
-          "version": "29.6.2",
+          "version": "29.7.0",
+          "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-29.7.0.tgz",
+          "integrity": "sha512-Fdx+tv6x1zlkJPcWXmMDAG2HBnaR9XPSd5aDWQVsfrZmLVT3lU1cwyxLgRmXR9yrq4NBoEm9BMsfgFzTQAbJYA==",
           "dev": true,
           "requires": {
-            "@jest/console": "^29.6.2",
-            "@jest/types": "^29.6.1",
+            "@jest/console": "^29.7.0",
+            "@jest/types": "^29.6.3",
             "@types/istanbul-lib-coverage": "^2.0.0",
             "collect-v8-coverage": "^1.0.0"
           }
         },
         "@jest/test-sequencer": {
-          "version": "29.6.2",
+          "version": "29.7.0",
+          "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-29.7.0.tgz",
+          "integrity": "sha512-GQwJ5WZVrKnOJuiYiAF52UNUJXgTZx1NHjFSEB0qEMmSZKAkdMoIzw/Cj6x6NF4AvV23AUqDpFzQkN/eYCYTxw==",
           "dev": true,
           "requires": {
-            "@jest/test-result": "^29.6.2",
+            "@jest/test-result": "^29.7.0",
             "graceful-fs": "^4.2.9",
-            "jest-haste-map": "^29.6.2",
+            "jest-haste-map": "^29.7.0",
             "slash": "^3.0.0"
           }
         },
         "@jest/transform": {
-          "version": "29.6.2",
+          "version": "29.7.0",
+          "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.7.0.tgz",
+          "integrity": "sha512-ok/BTPFzFKVMwO5eOHRrvnBVHdRy9IrsrW1GpMaQ9MCnilNLXQKmAX8s1YXDFaai9xJpac2ySzV0YeRRECr2Vw==",
           "dev": true,
           "requires": {
             "@babel/core": "^7.11.6",
-            "@jest/types": "^29.6.1",
+            "@jest/types": "^29.6.3",
             "@jridgewell/trace-mapping": "^0.3.18",
             "babel-plugin-istanbul": "^6.1.1",
             "chalk": "^4.0.0",
             "convert-source-map": "^2.0.0",
             "fast-json-stable-stringify": "^2.1.0",
             "graceful-fs": "^4.2.9",
-            "jest-haste-map": "^29.6.2",
-            "jest-regex-util": "^29.4.3",
-            "jest-util": "^29.6.2",
+            "jest-haste-map": "^29.7.0",
+            "jest-regex-util": "^29.6.3",
+            "jest-util": "^29.7.0",
             "micromatch": "^4.0.4",
             "pirates": "^4.0.4",
             "slash": "^3.0.0",
@@ -22203,10 +23418,12 @@
           }
         },
         "@jest/types": {
-          "version": "29.6.1",
+          "version": "29.6.3",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
+          "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
           "dev": true,
           "requires": {
-            "@jest/schemas": "^29.6.0",
+            "@jest/schemas": "^29.6.3",
             "@types/istanbul-lib-coverage": "^2.0.0",
             "@types/istanbul-reports": "^3.0.0",
             "@types/node": "*",
@@ -22269,6 +23486,8 @@
         },
         "@sinonjs/commons": {
           "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.0.tgz",
+          "integrity": "sha512-jXBtWAF4vmdNmZgD5FoKsVLv3rPgDnLgPbU84LIJ3otV44vJlDRokVng5v8NFJdCf/da9legHcKaRuZs4L7faA==",
           "dev": true,
           "requires": {
             "type-detect": "4.0.8"
@@ -22276,17 +23495,107 @@
         },
         "@sinonjs/fake-timers": {
           "version": "10.3.0",
+          "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.3.0.tgz",
+          "integrity": "sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==",
           "dev": true,
           "requires": {
             "@sinonjs/commons": "^3.0.0"
+          }
+        },
+        "@testing-library/dom": {
+          "version": "9.3.1",
+          "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-9.3.1.tgz",
+          "integrity": "sha512-0DGPd9AR3+iDTjGoMpxIkAsUihHZ3Ai6CneU6bRRrffXMgzCdlNk43jTrD2/5LT6CBb3MWTP8v510JzYtahD2w==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.10.4",
+            "@babel/runtime": "^7.12.5",
+            "@types/aria-query": "^5.0.1",
+            "aria-query": "5.1.3",
+            "chalk": "^4.1.0",
+            "dom-accessibility-api": "^0.5.9",
+            "lz-string": "^1.5.0",
+            "pretty-format": "^27.0.2"
+          },
+          "dependencies": {
+            "chalk": {
+              "version": "4.1.2",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+              "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+              "dev": true,
+              "requires": {
+                "ansi-styles": "^4.1.0",
+                "supports-color": "^7.1.0"
+              }
+            },
+            "pretty-format": {
+              "version": "27.5.1",
+              "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+              "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+              "dev": true,
+              "requires": {
+                "ansi-regex": "^5.0.1",
+                "ansi-styles": "^5.0.0",
+                "react-is": "^17.0.1"
+              },
+              "dependencies": {
+                "ansi-styles": {
+                  "version": "5.2.0",
+                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+                  "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+                  "dev": true
+                }
+              }
+            },
+            "react-is": {
+              "version": "17.0.2",
+              "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+              "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+              "dev": true
+            }
+          }
+        },
+        "@testing-library/jest-dom": {
+          "version": "6.1.3",
+          "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.1.3.tgz",
+          "integrity": "sha512-YzpjRHoCBWPzpPNtg6gnhasqtE/5O4qz8WCwDEaxtfnPO6gkaLrnuXusrGSPyhIGPezr1HM7ZH0CFaUTY9PJEQ==",
+          "dev": true,
+          "requires": {
+            "@adobe/css-tools": "^4.3.0",
+            "@babel/runtime": "^7.9.2",
+            "aria-query": "^5.0.0",
+            "chalk": "^3.0.0",
+            "css.escape": "^1.5.1",
+            "dom-accessibility-api": "^0.5.6",
+            "lodash": "^4.17.15",
+            "redent": "^3.0.0"
+          }
+        },
+        "@testing-library/react": {
+          "version": "14.0.0",
+          "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-14.0.0.tgz",
+          "integrity": "sha512-S04gSNJbYE30TlIMLTzv6QCTzt9AqIF5y6s6SzVFILNcNvbV/jU96GeiTPillGQo+Ny64M/5PV7klNYYgv5Dfg==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.12.5",
+            "@testing-library/dom": "^9.0.0",
+            "@types/react-dom": "^18.0.0"
           }
         },
         "@tootallnate/once": {
           "version": "2.0.0",
           "dev": true
         },
+        "@types/aria-query": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.1.tgz",
+          "integrity": "sha512-XTIieEY+gvJ39ChLcB4If5zHtPxt3Syj5rgZR+e1ctpmK8NjPf0zFqsz4JpLJT0xla9GFDKjy8Cpu331nrmE1Q==",
+          "dev": true
+        },
         "@types/jest": {
-          "version": "29.5.3",
+          "version": "29.5.4",
+          "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.4.tgz",
+          "integrity": "sha512-PhglGmhWeD46FYOVLt3X7TiWjzwuVGW9wG/4qocPevXMjCmrIc5b6db9WjeGE4QYVpUAWMDv3v0IiBwObY289A==",
           "dev": true,
           "requires": {
             "expect": "^29.0.0",
@@ -22312,8 +23621,7 @@
           }
         },
         "@types/wordpress__block-editor": {
-          "version": "11.5.2",
-          "resolved": "https://registry.npmjs.org/@types/wordpress__block-editor/-/wordpress__block-editor-11.5.2.tgz",
+          "version": "https://registry.npmjs.org/@types/wordpress__block-editor/-/wordpress__block-editor-11.5.2.tgz",
           "integrity": "sha512-1y1o4t5S5FjJ0g9n4KTj/4NvbFb7I1rTJTO4bEiMgKeArR37hqUGj9K4pA8ed5Vx19tBnbxiKEGwAWWOIOKdZA==",
           "dev": true,
           "requires": {
@@ -22347,80 +23655,80 @@
           }
         },
         "@wordpress/a11y": {
-          "version": "3.40.0",
-          "resolved": "https://registry.npmjs.org/@wordpress/a11y/-/a11y-3.40.0.tgz",
-          "integrity": "sha512-DNUihzLPh81fwZVtDkcNxvliBpPH46MSK3tI+IFPjGW0FcolAwWyrXOEZ4ILMvxR27WL1ukDiRhScoZIPy1KRQ==",
+          "version": "3.41.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/a11y/-/a11y-3.41.0.tgz",
+          "integrity": "sha512-T+7rHdX4k72ty3MdtySuL41d4wrIXRKdM1Xhjr89G/OXyetsY0nb4n6jUsFGnf69iq7gFSgVjEVogbOc/ffbTA==",
           "requires": {
             "@babel/runtime": "^7.16.0",
-            "@wordpress/dom-ready": "^3.40.0",
-            "@wordpress/i18n": "^4.40.0"
+            "@wordpress/dom-ready": "^3.41.0",
+            "@wordpress/i18n": "^4.41.0"
           }
         },
         "@wordpress/api-fetch": {
-          "version": "6.37.0",
-          "resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-6.37.0.tgz",
-          "integrity": "sha512-Cn0ddssCx5kGMEmdqom+kIqdeNl7xDJP4ooUgQhmmR/Hqi0CzazouCO0iNImmwFroFiquig5PrjDS6EWUe2z/w==",
+          "version": "6.38.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-6.38.0.tgz",
+          "integrity": "sha512-EY5+9hxUDFOKCrIBFokUFuF2bPnWjtOlc8yQcB1SmJv5JULdFZF+pgAKXqTPFwWR8wcNjv2hypemV8j82Rq4MA==",
           "requires": {
             "@babel/runtime": "^7.16.0",
-            "@wordpress/i18n": "^4.40.0",
-            "@wordpress/url": "^3.41.0"
+            "@wordpress/i18n": "^4.41.0",
+            "@wordpress/url": "^3.42.0"
           }
         },
         "@wordpress/autop": {
-          "version": "3.40.0",
-          "resolved": "https://registry.npmjs.org/@wordpress/autop/-/autop-3.40.0.tgz",
-          "integrity": "sha512-AuuZpPLnonNNlekiE+gDmQEz+juHvCZJml1aGllip4txXCKZDvJUU6WVmnQYp+m1V/Wj4/Szb8w1muUslsjb7Q==",
+          "version": "3.41.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/autop/-/autop-3.41.0.tgz",
+          "integrity": "sha512-oaGwox3PKg6/a4nFul7js4k/wXazgtL0t6v8Epg3IotMUFXBN3rCAqH/zmCl/669LA9gG0TaT0VoqjF3iFuLtQ==",
           "requires": {
             "@babel/runtime": "^7.16.0"
           }
         },
         "@wordpress/blob": {
-          "version": "3.40.0",
-          "resolved": "https://registry.npmjs.org/@wordpress/blob/-/blob-3.40.0.tgz",
-          "integrity": "sha512-eXI9j/XiS0dAjdr04qkYnwKhEH7WevIpEOlCzj9m0FlJmq7HKgNOg3FJX3JhG7xAOJvGBBxtcHshnx29XexBIw==",
+          "version": "3.41.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/blob/-/blob-3.41.0.tgz",
+          "integrity": "sha512-osBcD1IpN/YT96ArGqf7Cdon/Z8gHMC8sWPUAQ1OPLNrxlFLomaCPOoC9UeAgbEh338epoYfqmi7rTwUMCBS3Q==",
           "requires": {
             "@babel/runtime": "^7.16.0"
           }
         },
         "@wordpress/block-editor": {
-          "version": "12.8.0",
-          "resolved": "https://registry.npmjs.org/@wordpress/block-editor/-/block-editor-12.8.0.tgz",
-          "integrity": "sha512-WQSWBAYM6iLN2+rAfZmQm4WMLPCe9woBcPybs0tKgOeXGZZBRgZ6FS01jzVmtWhttWXYZ3uH1PGPaKLJJc/Qyg==",
+          "version": "12.9.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/block-editor/-/block-editor-12.9.0.tgz",
+          "integrity": "sha512-x8fUoP2T6PtuEXm62VGkJSLokDU8EKmh+5sFeVIj2Vbh7av4i0+OWzf/LhP4rCi1bRujZSk8Gn1uzRfJglNMHQ==",
           "requires": {
             "@babel/runtime": "^7.16.0",
             "@emotion/react": "^11.7.1",
             "@emotion/styled": "^11.6.0",
             "@react-spring/web": "^9.4.5",
-            "@wordpress/a11y": "^3.40.0",
-            "@wordpress/api-fetch": "^6.37.0",
-            "@wordpress/blob": "^3.40.0",
-            "@wordpress/blocks": "^12.17.0",
-            "@wordpress/commands": "^0.11.0",
-            "@wordpress/components": "^25.6.0",
-            "@wordpress/compose": "^6.17.0",
-            "@wordpress/data": "^9.10.0",
-            "@wordpress/date": "^4.40.0",
-            "@wordpress/deprecated": "^3.40.0",
-            "@wordpress/dom": "^3.40.0",
-            "@wordpress/element": "^5.17.0",
-            "@wordpress/escape-html": "^2.40.0",
-            "@wordpress/hooks": "^3.40.0",
-            "@wordpress/html-entities": "^3.40.0",
-            "@wordpress/i18n": "^4.40.0",
-            "@wordpress/icons": "^9.31.0",
-            "@wordpress/is-shallow-equal": "^4.40.0",
-            "@wordpress/keyboard-shortcuts": "^4.17.0",
-            "@wordpress/keycodes": "^3.40.0",
-            "@wordpress/notices": "^4.8.0",
-            "@wordpress/preferences": "^3.17.0",
-            "@wordpress/private-apis": "^0.22.0",
-            "@wordpress/rich-text": "^6.17.0",
-            "@wordpress/shortcode": "^3.40.0",
-            "@wordpress/style-engine": "^1.23.0",
-            "@wordpress/token-list": "^2.40.0",
-            "@wordpress/url": "^3.41.0",
-            "@wordpress/warning": "^2.40.0",
-            "@wordpress/wordcount": "^3.40.0",
+            "@wordpress/a11y": "^3.41.0",
+            "@wordpress/api-fetch": "^6.38.0",
+            "@wordpress/blob": "^3.41.0",
+            "@wordpress/blocks": "^12.18.0",
+            "@wordpress/commands": "^0.12.0",
+            "@wordpress/components": "^25.7.0",
+            "@wordpress/compose": "^6.18.0",
+            "@wordpress/data": "^9.11.0",
+            "@wordpress/date": "^4.41.0",
+            "@wordpress/deprecated": "^3.41.0",
+            "@wordpress/dom": "^3.41.0",
+            "@wordpress/element": "^5.18.0",
+            "@wordpress/escape-html": "^2.41.0",
+            "@wordpress/hooks": "^3.41.0",
+            "@wordpress/html-entities": "^3.41.0",
+            "@wordpress/i18n": "^4.41.0",
+            "@wordpress/icons": "^9.32.0",
+            "@wordpress/is-shallow-equal": "^4.41.0",
+            "@wordpress/keyboard-shortcuts": "^4.18.0",
+            "@wordpress/keycodes": "^3.41.0",
+            "@wordpress/notices": "^4.9.0",
+            "@wordpress/preferences": "^3.18.0",
+            "@wordpress/private-apis": "^0.23.0",
+            "@wordpress/rich-text": "^6.18.0",
+            "@wordpress/shortcode": "^3.41.0",
+            "@wordpress/style-engine": "^1.24.0",
+            "@wordpress/token-list": "^2.41.0",
+            "@wordpress/url": "^3.42.0",
+            "@wordpress/warning": "^2.41.0",
+            "@wordpress/wordcount": "^3.41.0",
             "change-case": "^4.1.2",
             "classnames": "^2.3.1",
             "colord": "^2.7.0",
@@ -22437,18 +23745,18 @@
           },
           "dependencies": {
             "@wordpress/data": {
-              "version": "9.10.0",
-              "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-9.10.0.tgz",
-              "integrity": "sha512-jvg1ei+h9K94ckTaDHoHFtlsrkOMlRCaC/fjt2fWfTkQafrpFEEgFYIZEhT8nTQ3DD6Yuvyz4MmypSLnQ81M7A==",
+              "version": "9.11.0",
+              "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-9.11.0.tgz",
+              "integrity": "sha512-1UaummqcfxO4EU7eKfkxEaRjlZjRvqHRdtdjyBtrpWHxIaLrTzBdM7rBNu06tilZBoAXGRoBc5TyPuvNI3IWNg==",
               "requires": {
                 "@babel/runtime": "^7.16.0",
-                "@wordpress/compose": "^6.17.0",
-                "@wordpress/deprecated": "^3.40.0",
-                "@wordpress/element": "^5.17.0",
-                "@wordpress/is-shallow-equal": "^4.40.0",
-                "@wordpress/priority-queue": "^2.40.0",
-                "@wordpress/private-apis": "^0.22.0",
-                "@wordpress/redux-routine": "^4.40.0",
+                "@wordpress/compose": "^6.18.0",
+                "@wordpress/deprecated": "^3.41.0",
+                "@wordpress/element": "^5.18.0",
+                "@wordpress/is-shallow-equal": "^4.41.0",
+                "@wordpress/priority-queue": "^2.41.0",
+                "@wordpress/private-apis": "^0.23.0",
+                "@wordpress/redux-routine": "^4.41.0",
                 "deepmerge": "^4.3.0",
                 "equivalent-key-map": "^0.2.2",
                 "is-plain-object": "^5.0.0",
@@ -22461,33 +23769,33 @@
           }
         },
         "@wordpress/block-serialization-default-parser": {
-          "version": "4.40.0",
-          "resolved": "https://registry.npmjs.org/@wordpress/block-serialization-default-parser/-/block-serialization-default-parser-4.40.0.tgz",
-          "integrity": "sha512-MFQ82tIf/finWY4TPDYP1ZYQfg2MLCC7j60idEwfd4y2jWW+LiksaUOEFBnSryAgZ5nhr2PQd7aciZpg8JM3dA==",
+          "version": "4.41.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/block-serialization-default-parser/-/block-serialization-default-parser-4.41.0.tgz",
+          "integrity": "sha512-/bHeVewOO2GSm3y6fSoOlt0ZNweP2jua8G+CTZG3XKrwX1eTXWFQtJTJQPUuerXeWEqMTD58lILxneqyw28hcg==",
           "requires": {
             "@babel/runtime": "^7.16.0"
           }
         },
         "@wordpress/blocks": {
-          "version": "12.17.0",
-          "resolved": "https://registry.npmjs.org/@wordpress/blocks/-/blocks-12.17.0.tgz",
-          "integrity": "sha512-TVUk0WGVe4/Qzm4/i1KCHOBvbB581AJnYuCAi35nhgu9V//vqbKh9JRg2d49ZduFl0SakVmN6/xSTPPEYjmuYQ==",
+          "version": "12.18.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/blocks/-/blocks-12.18.0.tgz",
+          "integrity": "sha512-JS2g4k95GPNdO2hOLBbppz3kTBUdKIoFXJ5w5tn11TGYep4dmEHh8ugGCW9XweOCkz3g4HDT+vansRAz4JF1yQ==",
           "requires": {
             "@babel/runtime": "^7.16.0",
-            "@wordpress/autop": "^3.40.0",
-            "@wordpress/blob": "^3.40.0",
-            "@wordpress/block-serialization-default-parser": "^4.40.0",
-            "@wordpress/compose": "^6.17.0",
-            "@wordpress/data": "^9.10.0",
-            "@wordpress/deprecated": "^3.40.0",
-            "@wordpress/dom": "^3.40.0",
-            "@wordpress/element": "^5.17.0",
-            "@wordpress/hooks": "^3.40.0",
-            "@wordpress/html-entities": "^3.40.0",
-            "@wordpress/i18n": "^4.40.0",
-            "@wordpress/is-shallow-equal": "^4.40.0",
-            "@wordpress/private-apis": "^0.22.0",
-            "@wordpress/shortcode": "^3.40.0",
+            "@wordpress/autop": "^3.41.0",
+            "@wordpress/blob": "^3.41.0",
+            "@wordpress/block-serialization-default-parser": "^4.41.0",
+            "@wordpress/compose": "^6.18.0",
+            "@wordpress/data": "^9.11.0",
+            "@wordpress/deprecated": "^3.41.0",
+            "@wordpress/dom": "^3.41.0",
+            "@wordpress/element": "^5.18.0",
+            "@wordpress/hooks": "^3.41.0",
+            "@wordpress/html-entities": "^3.41.0",
+            "@wordpress/i18n": "^4.41.0",
+            "@wordpress/is-shallow-equal": "^4.41.0",
+            "@wordpress/private-apis": "^0.23.0",
+            "@wordpress/shortcode": "^3.41.0",
             "change-case": "^4.1.2",
             "colord": "^2.7.0",
             "deepmerge": "^4.3.0",
@@ -22503,18 +23811,18 @@
           },
           "dependencies": {
             "@wordpress/data": {
-              "version": "9.10.0",
-              "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-9.10.0.tgz",
-              "integrity": "sha512-jvg1ei+h9K94ckTaDHoHFtlsrkOMlRCaC/fjt2fWfTkQafrpFEEgFYIZEhT8nTQ3DD6Yuvyz4MmypSLnQ81M7A==",
+              "version": "9.11.0",
+              "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-9.11.0.tgz",
+              "integrity": "sha512-1UaummqcfxO4EU7eKfkxEaRjlZjRvqHRdtdjyBtrpWHxIaLrTzBdM7rBNu06tilZBoAXGRoBc5TyPuvNI3IWNg==",
               "requires": {
                 "@babel/runtime": "^7.16.0",
-                "@wordpress/compose": "^6.17.0",
-                "@wordpress/deprecated": "^3.40.0",
-                "@wordpress/element": "^5.17.0",
-                "@wordpress/is-shallow-equal": "^4.40.0",
-                "@wordpress/priority-queue": "^2.40.0",
-                "@wordpress/private-apis": "^0.22.0",
-                "@wordpress/redux-routine": "^4.40.0",
+                "@wordpress/compose": "^6.18.0",
+                "@wordpress/deprecated": "^3.41.0",
+                "@wordpress/element": "^5.18.0",
+                "@wordpress/is-shallow-equal": "^4.41.0",
+                "@wordpress/priority-queue": "^2.41.0",
+                "@wordpress/private-apis": "^0.23.0",
+                "@wordpress/redux-routine": "^4.41.0",
                 "deepmerge": "^4.3.0",
                 "equivalent-key-map": "^0.2.2",
                 "is-plain-object": "^5.0.0",
@@ -22527,36 +23835,36 @@
           }
         },
         "@wordpress/commands": {
-          "version": "0.11.0",
-          "resolved": "https://registry.npmjs.org/@wordpress/commands/-/commands-0.11.0.tgz",
-          "integrity": "sha512-M1sfM9yhEAjUZPJcgvFqoRDafxyrIOnTb3mRA+NeFMEKexrmCJ/h/MrzPSugYYRMSzbZVe1FsabWZp+Zz8HsNA==",
+          "version": "0.12.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/commands/-/commands-0.12.0.tgz",
+          "integrity": "sha512-yeFZ2BCDh9i8+XhcwAjwREXE8WUl9hv4YL5/b2Dh6eUqld/TGH4lUtxIHMxsnlzLqR29ZRaChobU44ji4rZf9g==",
           "requires": {
             "@babel/runtime": "^7.16.0",
-            "@wordpress/components": "^25.6.0",
-            "@wordpress/data": "^9.10.0",
-            "@wordpress/element": "^5.17.0",
-            "@wordpress/i18n": "^4.40.0",
-            "@wordpress/icons": "^9.31.0",
-            "@wordpress/keyboard-shortcuts": "^4.17.0",
-            "@wordpress/private-apis": "^0.22.0",
+            "@wordpress/components": "^25.7.0",
+            "@wordpress/data": "^9.11.0",
+            "@wordpress/element": "^5.18.0",
+            "@wordpress/i18n": "^4.41.0",
+            "@wordpress/icons": "^9.32.0",
+            "@wordpress/keyboard-shortcuts": "^4.18.0",
+            "@wordpress/private-apis": "^0.23.0",
             "classnames": "^2.3.1",
             "cmdk": "^0.2.0",
             "rememo": "^4.0.2"
           },
           "dependencies": {
             "@wordpress/data": {
-              "version": "9.10.0",
-              "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-9.10.0.tgz",
-              "integrity": "sha512-jvg1ei+h9K94ckTaDHoHFtlsrkOMlRCaC/fjt2fWfTkQafrpFEEgFYIZEhT8nTQ3DD6Yuvyz4MmypSLnQ81M7A==",
+              "version": "9.11.0",
+              "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-9.11.0.tgz",
+              "integrity": "sha512-1UaummqcfxO4EU7eKfkxEaRjlZjRvqHRdtdjyBtrpWHxIaLrTzBdM7rBNu06tilZBoAXGRoBc5TyPuvNI3IWNg==",
               "requires": {
                 "@babel/runtime": "^7.16.0",
-                "@wordpress/compose": "^6.17.0",
-                "@wordpress/deprecated": "^3.40.0",
-                "@wordpress/element": "^5.17.0",
-                "@wordpress/is-shallow-equal": "^4.40.0",
-                "@wordpress/priority-queue": "^2.40.0",
-                "@wordpress/private-apis": "^0.22.0",
-                "@wordpress/redux-routine": "^4.40.0",
+                "@wordpress/compose": "^6.18.0",
+                "@wordpress/deprecated": "^3.41.0",
+                "@wordpress/element": "^5.18.0",
+                "@wordpress/is-shallow-equal": "^4.41.0",
+                "@wordpress/priority-queue": "^2.41.0",
+                "@wordpress/private-apis": "^0.23.0",
+                "@wordpress/redux-routine": "^4.41.0",
                 "deepmerge": "^4.3.0",
                 "equivalent-key-map": "^0.2.2",
                 "is-plain-object": "^5.0.0",
@@ -22569,9 +23877,9 @@
           }
         },
         "@wordpress/components": {
-          "version": "25.6.0",
-          "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-25.6.0.tgz",
-          "integrity": "sha512-VLzGS76MrgS6g5GMjk5q3+glSg1IYSzZAa/c5gZKy16c1a8rFWkc/IMhjw6w8Oyp3vvhB748J0itxsqCmTj5hw==",
+          "version": "25.7.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-25.7.0.tgz",
+          "integrity": "sha512-CFUhdMKuIA+0flsA3ACnJ0h84uKo+PrGkWG3nCSJwifdC6AVB7b7VOriDRhYsJXKoyr3QV+gRfAnFn0Hrc7tQQ==",
           "requires": {
             "@ariakit/react": "^0.2.12",
             "@babel/runtime": "^7.16.0",
@@ -22581,26 +23889,26 @@
             "@emotion/serialize": "^1.0.2",
             "@emotion/styled": "^11.6.0",
             "@emotion/utils": "^1.0.0",
-            "@floating-ui/react-dom": "1.0.0",
+            "@floating-ui/react-dom": "^2.0.1",
             "@radix-ui/react-dropdown-menu": "2.0.4",
             "@use-gesture/react": "^10.2.24",
-            "@wordpress/a11y": "^3.40.0",
-            "@wordpress/compose": "^6.17.0",
-            "@wordpress/date": "^4.40.0",
-            "@wordpress/deprecated": "^3.40.0",
-            "@wordpress/dom": "^3.40.0",
-            "@wordpress/element": "^5.17.0",
-            "@wordpress/escape-html": "^2.40.0",
-            "@wordpress/hooks": "^3.40.0",
-            "@wordpress/html-entities": "^3.40.0",
-            "@wordpress/i18n": "^4.40.0",
-            "@wordpress/icons": "^9.31.0",
-            "@wordpress/is-shallow-equal": "^4.40.0",
-            "@wordpress/keycodes": "^3.40.0",
-            "@wordpress/primitives": "^3.38.0",
-            "@wordpress/private-apis": "^0.22.0",
-            "@wordpress/rich-text": "^6.17.0",
-            "@wordpress/warning": "^2.40.0",
+            "@wordpress/a11y": "^3.41.0",
+            "@wordpress/compose": "^6.18.0",
+            "@wordpress/date": "^4.41.0",
+            "@wordpress/deprecated": "^3.41.0",
+            "@wordpress/dom": "^3.41.0",
+            "@wordpress/element": "^5.18.0",
+            "@wordpress/escape-html": "^2.41.0",
+            "@wordpress/hooks": "^3.41.0",
+            "@wordpress/html-entities": "^3.41.0",
+            "@wordpress/i18n": "^4.41.0",
+            "@wordpress/icons": "^9.32.0",
+            "@wordpress/is-shallow-equal": "^4.41.0",
+            "@wordpress/keycodes": "^3.41.0",
+            "@wordpress/primitives": "^3.39.0",
+            "@wordpress/private-apis": "^0.23.0",
+            "@wordpress/rich-text": "^6.18.0",
+            "@wordpress/warning": "^2.41.0",
             "change-case": "^4.1.2",
             "classnames": "^2.3.1",
             "colord": "^2.7.0",
@@ -22625,18 +23933,18 @@
           }
         },
         "@wordpress/compose": {
-          "version": "6.17.0",
-          "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-6.17.0.tgz",
-          "integrity": "sha512-G2IhRJma2lm+vNKduWofMy4jHliJGN83fTkyCQmtvREKz6uVcxcuNCgwGNSnh9JtuVSPlz9YpBQHmH6WsulMBA==",
+          "version": "6.18.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-6.18.0.tgz",
+          "integrity": "sha512-aZyvttCnT8HI4vS8Nb8y5Go+AycrThy0gvEl9jc9ZB9emm1ZifNkA6gTNpBd7zU2uzS4wUpiZYGGvUNeAuShvQ==",
           "requires": {
             "@babel/runtime": "^7.16.0",
             "@types/mousetrap": "^1.6.8",
-            "@wordpress/deprecated": "^3.40.0",
-            "@wordpress/dom": "^3.40.0",
-            "@wordpress/element": "^5.17.0",
-            "@wordpress/is-shallow-equal": "^4.40.0",
-            "@wordpress/keycodes": "^3.40.0",
-            "@wordpress/priority-queue": "^2.40.0",
+            "@wordpress/deprecated": "^3.41.0",
+            "@wordpress/dom": "^3.41.0",
+            "@wordpress/element": "^5.18.0",
+            "@wordpress/is-shallow-equal": "^4.41.0",
+            "@wordpress/keycodes": "^3.41.0",
+            "@wordpress/priority-queue": "^2.41.0",
             "change-case": "^4.1.2",
             "clipboard": "^2.0.8",
             "mousetrap": "^1.6.5",
@@ -22678,153 +23986,102 @@
           }
         },
         "@wordpress/date": {
-          "version": "4.40.0",
-          "resolved": "https://registry.npmjs.org/@wordpress/date/-/date-4.40.0.tgz",
-          "integrity": "sha512-FtfeGY9QRg1qMQSIpQxeRRShNJ37V2UOH/B3z0dHyxD8vKkVz4R0FmuBFw1mpJIPHwxbDI7hR0EO58c31+oyNg==",
+          "version": "4.41.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/date/-/date-4.41.0.tgz",
+          "integrity": "sha512-R0cTQKev7xT/srjAgUJOgW7CYnXuRdxSpXG7timYr3jEqgYoJFSAP2miq3+FWWSra1nesdT+r4o5z+3rIKFLLg==",
           "requires": {
             "@babel/runtime": "^7.16.0",
-            "@wordpress/deprecated": "^3.40.0",
+            "@wordpress/deprecated": "^3.41.0",
             "moment": "^2.29.4",
             "moment-timezone": "^0.5.40"
           }
         },
-        "@wordpress/deprecated": {
-          "version": "3.40.0",
-          "resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-3.40.0.tgz",
-          "integrity": "sha512-BWs90kVsAM4INmqFd5TrzAJOSehYSGkxgd8kGCipJXkcD7CWxoFEqS9W97Vva6yZekvrq63gFbmy++lllP3Llw==",
-          "requires": {
-            "@babel/runtime": "^7.16.0",
-            "@wordpress/hooks": "^3.40.0"
-          }
-        },
-        "@wordpress/dom": {
-          "version": "3.40.0",
-          "resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-3.40.0.tgz",
-          "integrity": "sha512-Xv8vymbZk8kFuJKSh2bdnxL1w2sprbdhXksJ/QF/1Il+u1QBV9f9KbmMzW3fsdFl9SM6oGtod7KHJArke67TXw==",
-          "requires": {
-            "@babel/runtime": "^7.16.0",
-            "@wordpress/deprecated": "^3.40.0"
-          }
-        },
         "@wordpress/dom-ready": {
-          "version": "3.40.0",
-          "resolved": "https://registry.npmjs.org/@wordpress/dom-ready/-/dom-ready-3.40.0.tgz",
-          "integrity": "sha512-XFrAWHxHO3YhJVrpHMOftf07Yw7duKBt/6K5QHyfDX2Ly4Noqna2/0pP1coJoYApjHvqhz6GAJCIXwT+t2QtBQ==",
+          "version": "3.41.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/dom-ready/-/dom-ready-3.41.0.tgz",
+          "integrity": "sha512-xbTCYC1192nUiBLB384GrzlQMbFnSv31TjI4+Y4JhR46+alcSsF2KPmlR8htxRbAXBx7z8lT78Fv+0ULhSIERA==",
           "requires": {
             "@babel/runtime": "^7.16.0"
           }
         },
         "@wordpress/element": {
-          "version": "5.17.0",
-          "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-5.17.0.tgz",
-          "integrity": "sha512-sVjVWlKnpzTM4kfwfTgT9TtCcqqb3MqII9cLzM3DCVDFIUrudEUlbqX9lUCnnSfWCjoQ/YPaWg4LikKrRVmPQw==",
+          "version": "5.18.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-5.18.0.tgz",
+          "integrity": "sha512-OynuZuTFdmterh/ASmMSSKjdBj5r1hcwQi37AQnp7+GpyIV3Ol5PR4UWWYB0coW0Gkd0giJkQAwC71/ZkEPYqQ==",
           "requires": {
             "@babel/runtime": "^7.16.0",
             "@types/react": "^18.0.21",
             "@types/react-dom": "^18.0.6",
-            "@wordpress/escape-html": "^2.40.0",
+            "@wordpress/escape-html": "^2.41.0",
             "change-case": "^4.1.2",
             "is-plain-object": "^5.0.0",
             "react": "^18.2.0",
             "react-dom": "^18.2.0"
           }
         },
-        "@wordpress/escape-html": {
-          "version": "2.40.0",
-          "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-2.40.0.tgz",
-          "integrity": "sha512-hWbtydaYHud/qbXauCNR1h5pfmXJQwzdKfdQUMqEjms2sqm2nQQXGxi/t8CLc2HjrNenzHqOZaonfQ/nx+1l1A==",
-          "requires": {
-            "@babel/runtime": "^7.16.0"
-          }
-        },
-        "@wordpress/hooks": {
-          "version": "3.40.0",
-          "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-3.40.0.tgz",
-          "integrity": "sha512-vbhGayL/KpGSpc0OTdPV4FeR/r9r42qQ9ElBd6RX6PVPUfgJ/on2PukMY5HBVM+3As4XQklRjMoc6EgFRh09rg==",
-          "requires": {
-            "@babel/runtime": "^7.16.0"
-          }
-        },
         "@wordpress/html-entities": {
-          "version": "3.40.0",
-          "resolved": "https://registry.npmjs.org/@wordpress/html-entities/-/html-entities-3.40.0.tgz",
-          "integrity": "sha512-Jd/EMTnakQoIYr02RrI+0w9z1Zi3ZxdtfSztLnUYushAtEXIo7TmBScMuIWQhhy9bT6+g5dQo7RP/UUh0sEwtg==",
+          "version": "3.41.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/html-entities/-/html-entities-3.41.0.tgz",
+          "integrity": "sha512-nb8ioGMi9yBfOzy2tIvIKQA+MaVNbgTflM/uiwhb5D/KTqtIUp+e84BOCOOZDI7xtWKQKhtGAn126Ko7hi73Jg==",
           "requires": {
             "@babel/runtime": "^7.16.0"
-          }
-        },
-        "@wordpress/i18n": {
-          "version": "4.40.0",
-          "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-4.40.0.tgz",
-          "integrity": "sha512-vm0qqYRl0ULmQoD0nHO0nfRQYoVgJf0Hf56fX3rJ9BKsiQkMtpurhUb0QViqjXShlR6rTryq4Ru3fXJqlpdL4w==",
-          "requires": {
-            "@babel/runtime": "^7.16.0",
-            "@wordpress/hooks": "^3.40.0",
-            "gettext-parser": "^1.3.1",
-            "memize": "^2.1.0",
-            "sprintf-js": "^1.1.1",
-            "tannin": "^1.2.0"
           }
         },
         "@wordpress/icons": {
-          "version": "9.31.0",
-          "resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-9.31.0.tgz",
-          "integrity": "sha512-o8Yj3+BtsrwytN1tSRyINsAAXACdlgS+ELl6HnB3iE3K+qi2KzJGFVZPXS7vDZRPDxt6foNVk1LDp60hbEKvYQ==",
+          "version": "9.32.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-9.32.0.tgz",
+          "integrity": "sha512-67imRDf5LF6v4vCBmvAEa4ZzcH0jvwIaBr1Y2ou4ElVJ1KZjiu1C93Lp6dcAy/08L8eX+eZZCwTrTYI+tl9v5w==",
           "requires": {
             "@babel/runtime": "^7.16.0",
-            "@wordpress/element": "^5.17.0",
-            "@wordpress/primitives": "^3.38.0"
-          }
-        },
-        "@wordpress/is-shallow-equal": {
-          "version": "4.40.0",
-          "resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-4.40.0.tgz",
-          "integrity": "sha512-JAFbiYTT4LUG2hER496UwHq6D7q9b0aPyhimGvqcsiuNUCy0IptiiYge6G/EPpyUwPS43qyKULgCaPYR9Js0pw==",
-          "requires": {
-            "@babel/runtime": "^7.16.0"
+            "@wordpress/element": "^5.18.0",
+            "@wordpress/primitives": "^3.39.0"
           }
         },
         "@wordpress/jest-console": {
-          "version": "7.10.0",
+          "version": "7.12.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/jest-console/-/jest-console-7.12.0.tgz",
+          "integrity": "sha512-sSgG65n32wPdKVWT6aaaslpOOn/TcRw9413UY+NqBgyc/HIlsSR9zKeoFwR3RoOyWr055PABOGNLup+RgdPKxw==",
           "dev": true,
           "requires": {
             "@babel/runtime": "^7.16.0",
-            "jest-matcher-utils": "^29.5.0"
+            "jest-matcher-utils": "^29.6.2"
           }
         },
         "@wordpress/jest-preset-default": {
-          "version": "11.10.0",
+          "version": "11.12.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/jest-preset-default/-/jest-preset-default-11.12.0.tgz",
+          "integrity": "sha512-HPpjUZsjxwvDDTw2ZWdgR1QVaVbsENCR/u0GRiC4NAArHABoleoFopwMZXJtbO1ii9vdeLJvgRNg1YXV5Zj79g==",
           "dev": true,
           "requires": {
-            "@wordpress/jest-console": "^7.10.0",
-            "babel-jest": "^29.5.0"
+            "@wordpress/jest-console": "^7.12.0",
+            "babel-jest": "^29.6.2"
           }
         },
         "@wordpress/keyboard-shortcuts": {
-          "version": "4.17.0",
-          "resolved": "https://registry.npmjs.org/@wordpress/keyboard-shortcuts/-/keyboard-shortcuts-4.17.0.tgz",
-          "integrity": "sha512-460xcjMzuBen6y8yOiWdpFpQ3PFjd+sE3L4cWa7uOALXOBAr5u37t3e7mBQFECKwX9k+6kWVlz1ThgobI3pERQ==",
+          "version": "4.18.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/keyboard-shortcuts/-/keyboard-shortcuts-4.18.0.tgz",
+          "integrity": "sha512-3q3Kmzzu6PTsx3abce4t/FHFuyN1jn7oukViNA17lIIFTfIL8Eu6ZfKy+UyPgAoCCXohEjCmaaB801qnsLsooQ==",
           "requires": {
             "@babel/runtime": "^7.16.0",
-            "@wordpress/data": "^9.10.0",
-            "@wordpress/element": "^5.17.0",
-            "@wordpress/keycodes": "^3.40.0",
+            "@wordpress/data": "^9.11.0",
+            "@wordpress/element": "^5.18.0",
+            "@wordpress/keycodes": "^3.41.0",
             "rememo": "^4.0.2"
           },
           "dependencies": {
             "@wordpress/data": {
-              "version": "9.10.0",
-              "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-9.10.0.tgz",
-              "integrity": "sha512-jvg1ei+h9K94ckTaDHoHFtlsrkOMlRCaC/fjt2fWfTkQafrpFEEgFYIZEhT8nTQ3DD6Yuvyz4MmypSLnQ81M7A==",
+              "version": "9.11.0",
+              "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-9.11.0.tgz",
+              "integrity": "sha512-1UaummqcfxO4EU7eKfkxEaRjlZjRvqHRdtdjyBtrpWHxIaLrTzBdM7rBNu06tilZBoAXGRoBc5TyPuvNI3IWNg==",
               "requires": {
                 "@babel/runtime": "^7.16.0",
-                "@wordpress/compose": "^6.17.0",
-                "@wordpress/deprecated": "^3.40.0",
-                "@wordpress/element": "^5.17.0",
-                "@wordpress/is-shallow-equal": "^4.40.0",
-                "@wordpress/priority-queue": "^2.40.0",
-                "@wordpress/private-apis": "^0.22.0",
-                "@wordpress/redux-routine": "^4.40.0",
+                "@wordpress/compose": "^6.18.0",
+                "@wordpress/deprecated": "^3.41.0",
+                "@wordpress/element": "^5.18.0",
+                "@wordpress/is-shallow-equal": "^4.41.0",
+                "@wordpress/priority-queue": "^2.41.0",
+                "@wordpress/private-apis": "^0.23.0",
+                "@wordpress/redux-routine": "^4.41.0",
                 "deepmerge": "^4.3.0",
                 "equivalent-key-map": "^0.2.2",
                 "is-plain-object": "^5.0.0",
@@ -22836,39 +24093,29 @@
             }
           }
         },
-        "@wordpress/keycodes": {
-          "version": "3.40.0",
-          "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-3.40.0.tgz",
-          "integrity": "sha512-yoU/iN5QGFdyk72M5x1LZHl9iMpkx1hJxGIxUFA9LkO8bqUMuv4qhvRqwbXs6n+b+R6/aGUWH1nOMA57E2OiZg==",
-          "requires": {
-            "@babel/runtime": "^7.16.0",
-            "@wordpress/i18n": "^4.40.0",
-            "change-case": "^4.1.2"
-          }
-        },
         "@wordpress/notices": {
-          "version": "4.8.0",
-          "resolved": "https://registry.npmjs.org/@wordpress/notices/-/notices-4.8.0.tgz",
-          "integrity": "sha512-VGPAbt6BC4+E17XbmgZRM3KVVbhQIIu2pBapCOk6pvsvbCy5ewvcl9dy/Wlf6YRrFSmT4nrVPayldea5OVIC6Q==",
+          "version": "4.9.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/notices/-/notices-4.9.0.tgz",
+          "integrity": "sha512-X7LfAJy6jYBq6d7lbW32lrt1DxkdNOg/VpOyiv8klwn30AKSPws/vBSrTPNDpp9phleuIuRr3tDcpS9/p+jRIw==",
           "requires": {
             "@babel/runtime": "^7.16.0",
-            "@wordpress/a11y": "^3.40.0",
-            "@wordpress/data": "^9.10.0"
+            "@wordpress/a11y": "^3.41.0",
+            "@wordpress/data": "^9.11.0"
           },
           "dependencies": {
             "@wordpress/data": {
-              "version": "9.10.0",
-              "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-9.10.0.tgz",
-              "integrity": "sha512-jvg1ei+h9K94ckTaDHoHFtlsrkOMlRCaC/fjt2fWfTkQafrpFEEgFYIZEhT8nTQ3DD6Yuvyz4MmypSLnQ81M7A==",
+              "version": "9.11.0",
+              "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-9.11.0.tgz",
+              "integrity": "sha512-1UaummqcfxO4EU7eKfkxEaRjlZjRvqHRdtdjyBtrpWHxIaLrTzBdM7rBNu06tilZBoAXGRoBc5TyPuvNI3IWNg==",
               "requires": {
                 "@babel/runtime": "^7.16.0",
-                "@wordpress/compose": "^6.17.0",
-                "@wordpress/deprecated": "^3.40.0",
-                "@wordpress/element": "^5.17.0",
-                "@wordpress/is-shallow-equal": "^4.40.0",
-                "@wordpress/priority-queue": "^2.40.0",
-                "@wordpress/private-apis": "^0.22.0",
-                "@wordpress/redux-routine": "^4.40.0",
+                "@wordpress/compose": "^6.18.0",
+                "@wordpress/deprecated": "^3.41.0",
+                "@wordpress/element": "^5.18.0",
+                "@wordpress/is-shallow-equal": "^4.41.0",
+                "@wordpress/priority-queue": "^2.41.0",
+                "@wordpress/private-apis": "^0.23.0",
+                "@wordpress/redux-routine": "^4.41.0",
                 "deepmerge": "^4.3.0",
                 "equivalent-key-map": "^0.2.2",
                 "is-plain-object": "^5.0.0",
@@ -22881,33 +24128,33 @@
           }
         },
         "@wordpress/preferences": {
-          "version": "3.17.0",
-          "resolved": "https://registry.npmjs.org/@wordpress/preferences/-/preferences-3.17.0.tgz",
-          "integrity": "sha512-57G0HrEy0Ym2zkT8/pI3ihXZot2tUnwQOFdO2GlhCaxxKgmVYkyQ44VneMcN2JbtFfjHzGueG09QeFt3rFyywQ==",
+          "version": "3.18.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/preferences/-/preferences-3.18.0.tgz",
+          "integrity": "sha512-S7eDEKvUIIJMWpiO+0j/iLDqspyhNdKR2N39HNkkrAA2mdr4LMvs5bOr/+m6xTpiik+8I29hwI/OuJOomqJ7PQ==",
           "requires": {
             "@babel/runtime": "^7.16.0",
-            "@wordpress/a11y": "^3.40.0",
-            "@wordpress/components": "^25.6.0",
-            "@wordpress/data": "^9.10.0",
-            "@wordpress/element": "^5.17.0",
-            "@wordpress/i18n": "^4.40.0",
-            "@wordpress/icons": "^9.31.0",
+            "@wordpress/a11y": "^3.41.0",
+            "@wordpress/components": "^25.7.0",
+            "@wordpress/data": "^9.11.0",
+            "@wordpress/element": "^5.18.0",
+            "@wordpress/i18n": "^4.41.0",
+            "@wordpress/icons": "^9.32.0",
             "classnames": "^2.3.1"
           },
           "dependencies": {
             "@wordpress/data": {
-              "version": "9.10.0",
-              "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-9.10.0.tgz",
-              "integrity": "sha512-jvg1ei+h9K94ckTaDHoHFtlsrkOMlRCaC/fjt2fWfTkQafrpFEEgFYIZEhT8nTQ3DD6Yuvyz4MmypSLnQ81M7A==",
+              "version": "9.11.0",
+              "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-9.11.0.tgz",
+              "integrity": "sha512-1UaummqcfxO4EU7eKfkxEaRjlZjRvqHRdtdjyBtrpWHxIaLrTzBdM7rBNu06tilZBoAXGRoBc5TyPuvNI3IWNg==",
               "requires": {
                 "@babel/runtime": "^7.16.0",
-                "@wordpress/compose": "^6.17.0",
-                "@wordpress/deprecated": "^3.40.0",
-                "@wordpress/element": "^5.17.0",
-                "@wordpress/is-shallow-equal": "^4.40.0",
-                "@wordpress/priority-queue": "^2.40.0",
-                "@wordpress/private-apis": "^0.22.0",
-                "@wordpress/redux-routine": "^4.40.0",
+                "@wordpress/compose": "^6.18.0",
+                "@wordpress/deprecated": "^3.41.0",
+                "@wordpress/element": "^5.18.0",
+                "@wordpress/is-shallow-equal": "^4.41.0",
+                "@wordpress/priority-queue": "^2.41.0",
+                "@wordpress/private-apis": "^0.23.0",
+                "@wordpress/redux-routine": "^4.41.0",
                 "deepmerge": "^4.3.0",
                 "equivalent-key-map": "^0.2.2",
                 "is-plain-object": "^5.0.0",
@@ -22920,36 +24167,27 @@
           }
         },
         "@wordpress/primitives": {
-          "version": "3.38.0",
-          "resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-3.38.0.tgz",
-          "integrity": "sha512-quRkAzZknTCqrBI/HvJ2Eas0x1irU6m2GbV/8opyZoE/2BAN+W07JgDhE8Aukd+3q03nfpKPeRJAO1dZ4/Vnuw==",
+          "version": "3.39.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-3.39.0.tgz",
+          "integrity": "sha512-QvtVJFQGCOEwdXIpXqktz31p327lj/5n4iwbIlOaGf0AZCPA8974m+O/wFkQCskGOJ9tVRveqZtH60aqKH/ffA==",
           "requires": {
             "@babel/runtime": "^7.16.0",
-            "@wordpress/element": "^5.17.0",
+            "@wordpress/element": "^5.18.0",
             "classnames": "^2.3.1"
           }
         },
-        "@wordpress/priority-queue": {
-          "version": "2.40.0",
-          "resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-2.40.0.tgz",
-          "integrity": "sha512-SzbbEjzSoBmluSJk6p3uXT1z/m5+fvFZWnI6l06P6gsrvVebB7SvsrIO0rR1cBoEJP6HB7EkQ/ORhM1Hn3W/hA==",
-          "requires": {
-            "@babel/runtime": "^7.16.0",
-            "requestidlecallback": "^0.3.0"
-          }
-        },
         "@wordpress/private-apis": {
-          "version": "0.22.0",
-          "resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-0.22.0.tgz",
-          "integrity": "sha512-NB6fOPf6nU4SP4qzC9vk0LlXxWBd1U4vFbWLbM873ChC+gkZJWym8ow6aMmIezozNZAI3glXx9xEtdbyfHeD7A==",
+          "version": "0.23.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-0.23.0.tgz",
+          "integrity": "sha512-Z/mAnPF+IcN13S0k7F55lA5J0ducNB+IYDGtujErx4fjnYsBIoF9VeQ5pRc+SPDCx5yYDtR7yL8unLbVbztVBQ==",
           "requires": {
             "@babel/runtime": "^7.16.0"
           }
         },
         "@wordpress/redux-routine": {
-          "version": "4.40.0",
-          "resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-4.40.0.tgz",
-          "integrity": "sha512-YKGn/46v73TaTr/gcvLYT66YJkYMM1xQS3IP9E/jDW6+e/GXjCJjerI1cWPmTLWesCclUQOg2qRzCoMIOoweXQ==",
+          "version": "4.41.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-4.41.0.tgz",
+          "integrity": "sha512-u5MVqtcChtHOqy3Fk5ml0HPBF13uHoz6ca1XvzstHKOiMWi4xNj6Nn2YgnscfvsxGxxjQz2su1Qcs0SGZI0g+w==",
           "requires": {
             "@babel/runtime": "^7.16.0",
             "is-plain-object": "^5.0.0",
@@ -22958,36 +24196,36 @@
           }
         },
         "@wordpress/rich-text": {
-          "version": "6.17.0",
-          "resolved": "https://registry.npmjs.org/@wordpress/rich-text/-/rich-text-6.17.0.tgz",
-          "integrity": "sha512-jFduYBaKVc4AeTHjH/PU+hfOdxgBXBdvjvSICIyBObtcANL3chzikNJjPzJP4Z6O22Q9LwHoTktCtr3oyYE8RQ==",
+          "version": "6.18.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/rich-text/-/rich-text-6.18.0.tgz",
+          "integrity": "sha512-BuBb/yWFLq+/joYI3XMYyF7MQDVYGh8V4AB0+v4mHH+7cTecSOOilUAW/JlEXqXS3LhvghabBk157UaH1gh8IA==",
           "requires": {
             "@babel/runtime": "^7.16.0",
-            "@wordpress/a11y": "^3.40.0",
-            "@wordpress/compose": "^6.17.0",
-            "@wordpress/data": "^9.10.0",
-            "@wordpress/deprecated": "^3.40.0",
-            "@wordpress/element": "^5.17.0",
-            "@wordpress/escape-html": "^2.40.0",
-            "@wordpress/i18n": "^4.40.0",
-            "@wordpress/keycodes": "^3.40.0",
+            "@wordpress/a11y": "^3.41.0",
+            "@wordpress/compose": "^6.18.0",
+            "@wordpress/data": "^9.11.0",
+            "@wordpress/deprecated": "^3.41.0",
+            "@wordpress/element": "^5.18.0",
+            "@wordpress/escape-html": "^2.41.0",
+            "@wordpress/i18n": "^4.41.0",
+            "@wordpress/keycodes": "^3.41.0",
             "memize": "^2.1.0",
             "rememo": "^4.0.2"
           },
           "dependencies": {
             "@wordpress/data": {
-              "version": "9.10.0",
-              "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-9.10.0.tgz",
-              "integrity": "sha512-jvg1ei+h9K94ckTaDHoHFtlsrkOMlRCaC/fjt2fWfTkQafrpFEEgFYIZEhT8nTQ3DD6Yuvyz4MmypSLnQ81M7A==",
+              "version": "9.11.0",
+              "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-9.11.0.tgz",
+              "integrity": "sha512-1UaummqcfxO4EU7eKfkxEaRjlZjRvqHRdtdjyBtrpWHxIaLrTzBdM7rBNu06tilZBoAXGRoBc5TyPuvNI3IWNg==",
               "requires": {
                 "@babel/runtime": "^7.16.0",
-                "@wordpress/compose": "^6.17.0",
-                "@wordpress/deprecated": "^3.40.0",
-                "@wordpress/element": "^5.17.0",
-                "@wordpress/is-shallow-equal": "^4.40.0",
-                "@wordpress/priority-queue": "^2.40.0",
-                "@wordpress/private-apis": "^0.22.0",
-                "@wordpress/redux-routine": "^4.40.0",
+                "@wordpress/compose": "^6.18.0",
+                "@wordpress/deprecated": "^3.41.0",
+                "@wordpress/element": "^5.18.0",
+                "@wordpress/is-shallow-equal": "^4.41.0",
+                "@wordpress/priority-queue": "^2.41.0",
+                "@wordpress/private-apis": "^0.23.0",
+                "@wordpress/redux-routine": "^4.41.0",
                 "deepmerge": "^4.3.0",
                 "equivalent-key-map": "^0.2.2",
                 "is-plain-object": "^5.0.0",
@@ -23000,49 +24238,49 @@
           }
         },
         "@wordpress/shortcode": {
-          "version": "3.40.0",
-          "resolved": "https://registry.npmjs.org/@wordpress/shortcode/-/shortcode-3.40.0.tgz",
-          "integrity": "sha512-H3jd1GgsNHtRuXVvItsjtf/OQOGI0vEZ+o964Ie4xqODwqOceYKASj4Bu2x9FKl94xa7tNfsn9ZSs6ADKWHh3g==",
+          "version": "3.41.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/shortcode/-/shortcode-3.41.0.tgz",
+          "integrity": "sha512-pJuFIQbGwn8tMpPf5vtKZqQmXVm2+UnQZXVyyQGXUCBnvyGmGnbKv7lbx0NGUDBZ1AVo8/PAdssd7P/QUn7Cxg==",
           "requires": {
             "@babel/runtime": "^7.16.0",
             "memize": "^2.0.1"
           }
         },
         "@wordpress/style-engine": {
-          "version": "1.23.0",
-          "resolved": "https://registry.npmjs.org/@wordpress/style-engine/-/style-engine-1.23.0.tgz",
-          "integrity": "sha512-Jxr8o9YB0ZKKXw15h6XCQkNV6fFPj73L42MIhHixE7Pq3mxTrwEeKl4LsnRlatBrzT6mnknP1qNWfaStTnY0AQ==",
+          "version": "1.24.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/style-engine/-/style-engine-1.24.0.tgz",
+          "integrity": "sha512-1qXkNwbuLeliQZ0yjdjjy2kJzWtvm56k0xUtFsF/0thMQ04EV0JJHwWDI6EOUCIVVFnJO6xdj2UK/KtnxGYfVw==",
           "requires": {
             "@babel/runtime": "^7.16.0",
             "change-case": "^4.1.2"
           }
         },
         "@wordpress/token-list": {
-          "version": "2.40.0",
-          "resolved": "https://registry.npmjs.org/@wordpress/token-list/-/token-list-2.40.0.tgz",
-          "integrity": "sha512-cVEgf0PRpN9I1csIi24dElhH3zghH2yC2afgjlZwNPWy8jmUNbgLEBwtgt+iA9WpmhanvS1XhwVoP4EY3WESEg==",
+          "version": "2.41.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/token-list/-/token-list-2.41.0.tgz",
+          "integrity": "sha512-GeGPzyoVshaifYiz11KqBwkUDqAbMVVkHn5ccpqLVbn+Yc7Ur3tRJ5ikgqNikSq0EyvnHdy8XdivdLJq2xcduA==",
           "requires": {
             "@babel/runtime": "^7.16.0"
           }
         },
         "@wordpress/url": {
-          "version": "3.41.0",
-          "resolved": "https://registry.npmjs.org/@wordpress/url/-/url-3.41.0.tgz",
-          "integrity": "sha512-1DX/Nd8YdVwj/So3DEBT0YRSv2JusspAc9McRY9IttRn9pOC3m0RUNV11JPsYgwilO30WofhFsxOKvGKtEEQIg==",
+          "version": "3.42.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/url/-/url-3.42.0.tgz",
+          "integrity": "sha512-Q1eZAkgnq/Ji3UDdBPxj2mBiBusGoTkcUH2XnJDGyPIezJjC7fY/9GXE6Jj0bm37CkEH3bP6G4Yrh+YpDwMn6Q==",
           "requires": {
             "@babel/runtime": "^7.16.0",
             "remove-accents": "^0.5.0"
           }
         },
         "@wordpress/warning": {
-          "version": "2.40.0",
-          "resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-2.40.0.tgz",
-          "integrity": "sha512-y/XdIq38m8gyotK7t8/n14VDccN9IQ9FihiUlhP3Dk46kZd9w5kBqaStd3jux2ZXSWCim9fZ3KkH03a2rNCsaA=="
+          "version": "2.41.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-2.41.0.tgz",
+          "integrity": "sha512-kSqx1z7MaNjNFg+/b5H9oY5D6hYpsKPvaonpk5CADTXOoWoEdSSkwDnCZWxaXu3Kgz4qB5EmaC4D3bKTFkFldw=="
         },
         "@wordpress/wordcount": {
-          "version": "3.40.0",
-          "resolved": "https://registry.npmjs.org/@wordpress/wordcount/-/wordcount-3.40.0.tgz",
-          "integrity": "sha512-emZQt/WwrIYk5iOO6LjrGBZ7FB6rUms4CaFoj2Zfs5JZAkXxjnT5cO355rA1woJOmYD+4L2X4qgz5X3rePSIRA==",
+          "version": "3.41.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/wordcount/-/wordcount-3.41.0.tgz",
+          "integrity": "sha512-1GjIVx+JIeYl7mmRZf9AA5e/YhmGm043dt1/3Zto1k7/MLIpI5ValPPXlHWBA2GU1lfHdfMkSzSC5CLzBQM2ow==",
           "requires": {
             "@babel/runtime": "^7.16.0"
           }
@@ -23070,14 +24308,25 @@
             "color-convert": "^2.0.1"
           }
         },
-        "babel-jest": {
-          "version": "29.6.2",
+        "aria-query": {
+          "version": "5.1.3",
+          "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.1.3.tgz",
+          "integrity": "sha512-R5iJ5lkuHybztUfuOAznmboyjWq8O6sqNqtK7CLOqdydi54VNbORp49mb14KbWgG1QD3JFO9hJdZ+y4KutfdOQ==",
           "dev": true,
           "requires": {
-            "@jest/transform": "^29.6.2",
+            "deep-equal": "^2.0.5"
+          }
+        },
+        "babel-jest": {
+          "version": "29.7.0",
+          "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.7.0.tgz",
+          "integrity": "sha512-BrvGY3xZSwEcCzKvKsCi2GgHqDqsYkOP4/by5xCgIwGXQxIEh+8ew3gmrE1y7XRR6LHZIj6yLYnUi/mm2KXKBg==",
+          "dev": true,
+          "requires": {
+            "@jest/transform": "^29.7.0",
             "@types/babel__core": "^7.1.14",
             "babel-plugin-istanbul": "^6.1.1",
-            "babel-preset-jest": "^29.5.0",
+            "babel-preset-jest": "^29.6.3",
             "chalk": "^4.0.0",
             "graceful-fs": "^4.2.9",
             "slash": "^3.0.0"
@@ -23094,7 +24343,9 @@
           }
         },
         "babel-plugin-jest-hoist": {
-          "version": "29.5.0",
+          "version": "29.6.3",
+          "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-29.6.3.tgz",
+          "integrity": "sha512-ESAc/RJvGTFEzRwOTT4+lNDk/GNHMkKbNzsvT0qKRfDyyYTskxB5rnU2njIDYVxXCBHHEI1c0YwHob3WaYujOg==",
           "dev": true,
           "requires": {
             "@babel/template": "^7.3.3",
@@ -23104,10 +24355,12 @@
           }
         },
         "babel-preset-jest": {
-          "version": "29.5.0",
+          "version": "29.6.3",
+          "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-29.6.3.tgz",
+          "integrity": "sha512-0B3bhxR6snWXJZtR/RliHTDPRgn1sNHOR0yVtq/IiQFyuOVjFS+wuio/R4gSNkyYmKmJB4wGZv2NZanmKmTnNA==",
           "dev": true,
           "requires": {
-            "babel-plugin-jest-hoist": "^29.5.0",
+            "babel-plugin-jest-hoist": "^29.6.3",
             "babel-preset-current-node-syntax": "^1.0.0"
           }
         },
@@ -23120,7 +24373,19 @@
         },
         "camelcase": {
           "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+          "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
           "dev": true
+        },
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
         },
         "cmdk": {
           "version": "0.2.0",
@@ -23165,11 +24430,15 @@
         },
         "dedent": {
           "version": "1.5.1",
+          "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.5.1.tgz",
+          "integrity": "sha512-+LxW+KLWxu3HW3M2w2ympwtqPrqYRzU8fqi6Fhd18fBALe15blJPI/I4+UHveMVG6lJqB4JNd4UG0S5cnVHwIg==",
           "dev": true,
           "requires": {}
         },
         "diff-sequences": {
-          "version": "29.4.3",
+          "version": "29.6.3",
+          "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
+          "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
           "dev": true
         },
         "domexception": {
@@ -23181,18 +24450,21 @@
         },
         "emittery": {
           "version": "0.13.1",
+          "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.13.1.tgz",
+          "integrity": "sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==",
           "dev": true
         },
         "expect": {
-          "version": "29.6.2",
+          "version": "29.7.0",
+          "resolved": "https://registry.npmjs.org/expect/-/expect-29.7.0.tgz",
+          "integrity": "sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==",
           "dev": true,
           "requires": {
-            "@jest/expect-utils": "^29.6.2",
-            "@types/node": "*",
-            "jest-get-type": "^29.4.3",
-            "jest-matcher-utils": "^29.6.2",
-            "jest-message-util": "^29.6.2",
-            "jest-util": "^29.6.2"
+            "@jest/expect-utils": "^29.7.0",
+            "jest-get-type": "^29.6.3",
+            "jest-matcher-utils": "^29.7.0",
+            "jest-message-util": "^29.7.0",
+            "jest-util": "^29.7.0"
           }
         },
         "form-data": {
@@ -23205,9 +24477,9 @@
           }
         },
         "framer-motion": {
-          "version": "10.16.1",
-          "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-10.16.1.tgz",
-          "integrity": "sha512-K6TXr5mZtitC/dxQCBdg7xzdN0d5IAIrlaqCPKtIQVdzVPGC0qBuJKXggHX1vjnP5gPOFwB1KbCCTWcnFc3kWg==",
+          "version": "10.16.4",
+          "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-10.16.4.tgz",
+          "integrity": "sha512-p9V9nGomS3m6/CALXqv6nFGMuFOxbWsmaOrdmhyQimMIlLl3LC7h7l86wge/Js/8cRu5ktutS/zlzgR7eBOtFA==",
           "requires": {
             "@emotion/is-prop-valid": "^0.8.2",
             "tslib": "^2.4.0"
@@ -23240,45 +24512,65 @@
             "safer-buffer": ">= 2.1.2 < 3.0.0"
           }
         },
-        "jest": {
-          "version": "29.6.2",
+        "istanbul-lib-instrument": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-6.0.0.tgz",
+          "integrity": "sha512-x58orMzEVfzPUKqlbLd1hXCnySCxKdDKa6Rjg97CwuLLRI4g3FHTdnExu1OqffVFay6zeMW+T6/DowFLndWnIw==",
           "dev": true,
           "requires": {
-            "@jest/core": "^29.6.2",
-            "@jest/types": "^29.6.1",
+            "@babel/core": "^7.12.3",
+            "@babel/parser": "^7.14.7",
+            "@istanbuljs/schema": "^0.1.2",
+            "istanbul-lib-coverage": "^3.2.0",
+            "semver": "^7.5.4"
+          }
+        },
+        "jest": {
+          "version": "29.6.4",
+          "resolved": "https://registry.npmjs.org/jest/-/jest-29.6.4.tgz",
+          "integrity": "sha512-tEFhVQFF/bzoYV1YuGyzLPZ6vlPrdfvDmmAxudA1dLEuiztqg2Rkx20vkKY32xiDROcD2KXlgZ7Cu8RPeEHRKw==",
+          "dev": true,
+          "requires": {
+            "@jest/core": "^29.6.4",
+            "@jest/types": "^29.6.3",
             "import-local": "^3.0.2",
-            "jest-cli": "^29.6.2"
+            "jest-cli": "^29.6.4"
           }
         },
         "jest-changed-files": {
-          "version": "29.5.0",
+          "version": "29.7.0",
+          "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-29.7.0.tgz",
+          "integrity": "sha512-fEArFiwf1BpQ+4bXSprcDc3/x4HSzL4al2tozwVpDFpsxALjLYdyiIK4e5Vz66GQJIbXJ82+35PtysofptNX2w==",
           "dev": true,
           "requires": {
             "execa": "^5.0.0",
+            "jest-util": "^29.7.0",
             "p-limit": "^3.1.0"
           }
         },
         "jest-circus": {
-          "version": "29.6.2",
+          "version": "29.7.0",
+          "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-29.7.0.tgz",
+          "integrity": "sha512-3E1nCMgipcTkCocFwM90XXQab9bS+GMsjdpmPrlelaxwD93Ad8iVEjX/vvHPdLPnFf+L40u+5+iutRdA1N9myw==",
           "dev": true,
           "requires": {
-            "@jest/environment": "^29.6.2",
-            "@jest/expect": "^29.6.2",
-            "@jest/test-result": "^29.6.2",
-            "@jest/types": "^29.6.1",
+            "@jest/environment": "^29.7.0",
+            "@jest/expect": "^29.7.0",
+            "@jest/test-result": "^29.7.0",
+            "@jest/types": "^29.6.3",
             "@types/node": "*",
             "chalk": "^4.0.0",
             "co": "^4.6.0",
             "dedent": "^1.0.0",
             "is-generator-fn": "^2.0.0",
-            "jest-each": "^29.6.2",
-            "jest-matcher-utils": "^29.6.2",
-            "jest-message-util": "^29.6.2",
-            "jest-runtime": "^29.6.2",
-            "jest-snapshot": "^29.6.2",
-            "jest-util": "^29.6.2",
+            "jest-each": "^29.7.0",
+            "jest-matcher-utils": "^29.7.0",
+            "jest-message-util": "^29.7.0",
+            "jest-runtime": "^29.7.0",
+            "jest-snapshot": "^29.7.0",
+            "jest-util": "^29.7.0",
             "p-limit": "^3.1.0",
-            "pretty-format": "^29.6.2",
+            "pretty-format": "^29.7.0",
             "pure-rand": "^6.0.0",
             "slash": "^3.0.0",
             "stack-utils": "^2.0.3"
@@ -23286,6 +24578,8 @@
           "dependencies": {
             "chalk": {
               "version": "4.1.2",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+              "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
               "dev": true,
               "requires": {
                 "ansi-styles": "^4.1.0",
@@ -23295,25 +24589,28 @@
           }
         },
         "jest-cli": {
-          "version": "29.6.2",
+          "version": "29.7.0",
+          "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-29.7.0.tgz",
+          "integrity": "sha512-OVVobw2IubN/GSYsxETi+gOe7Ka59EFMR/twOU3Jb2GnKKeMGJB5SGUUrEz3SFVmJASUdZUzy83sLNNQ2gZslg==",
           "dev": true,
           "requires": {
-            "@jest/core": "^29.6.2",
-            "@jest/test-result": "^29.6.2",
-            "@jest/types": "^29.6.1",
+            "@jest/core": "^29.7.0",
+            "@jest/test-result": "^29.7.0",
+            "@jest/types": "^29.6.3",
             "chalk": "^4.0.0",
+            "create-jest": "^29.7.0",
             "exit": "^0.1.2",
-            "graceful-fs": "^4.2.9",
             "import-local": "^3.0.2",
-            "jest-config": "^29.6.2",
-            "jest-util": "^29.6.2",
-            "jest-validate": "^29.6.2",
-            "prompts": "^2.0.1",
+            "jest-config": "^29.7.0",
+            "jest-util": "^29.7.0",
+            "jest-validate": "^29.7.0",
             "yargs": "^17.3.1"
           },
           "dependencies": {
             "chalk": {
               "version": "4.1.2",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+              "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
               "dev": true,
               "requires": {
                 "ansi-styles": "^4.1.0",
@@ -23323,35 +24620,39 @@
           }
         },
         "jest-config": {
-          "version": "29.6.2",
+          "version": "29.7.0",
+          "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-29.7.0.tgz",
+          "integrity": "sha512-uXbpfeQ7R6TZBqI3/TxCU4q4ttk3u0PJeC+E0zbfSoSjq6bJ7buBPxzQPL0ifrkY4DNu4JUdk0ImlBUYi840eQ==",
           "dev": true,
           "requires": {
             "@babel/core": "^7.11.6",
-            "@jest/test-sequencer": "^29.6.2",
-            "@jest/types": "^29.6.1",
-            "babel-jest": "^29.6.2",
+            "@jest/test-sequencer": "^29.7.0",
+            "@jest/types": "^29.6.3",
+            "babel-jest": "^29.7.0",
             "chalk": "^4.0.0",
             "ci-info": "^3.2.0",
             "deepmerge": "^4.2.2",
             "glob": "^7.1.3",
             "graceful-fs": "^4.2.9",
-            "jest-circus": "^29.6.2",
-            "jest-environment-node": "^29.6.2",
-            "jest-get-type": "^29.4.3",
-            "jest-regex-util": "^29.4.3",
-            "jest-resolve": "^29.6.2",
-            "jest-runner": "^29.6.2",
-            "jest-util": "^29.6.2",
-            "jest-validate": "^29.6.2",
+            "jest-circus": "^29.7.0",
+            "jest-environment-node": "^29.7.0",
+            "jest-get-type": "^29.6.3",
+            "jest-regex-util": "^29.6.3",
+            "jest-resolve": "^29.7.0",
+            "jest-runner": "^29.7.0",
+            "jest-util": "^29.7.0",
+            "jest-validate": "^29.7.0",
             "micromatch": "^4.0.4",
             "parse-json": "^5.2.0",
-            "pretty-format": "^29.6.2",
+            "pretty-format": "^29.7.0",
             "slash": "^3.0.0",
             "strip-json-comments": "^3.1.1"
           },
           "dependencies": {
             "chalk": {
               "version": "4.1.2",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+              "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
               "dev": true,
               "requires": {
                 "ansi-styles": "^4.1.0",
@@ -23361,17 +24662,21 @@
           }
         },
         "jest-diff": {
-          "version": "29.6.2",
+          "version": "29.7.0",
+          "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.7.0.tgz",
+          "integrity": "sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==",
           "dev": true,
           "requires": {
             "chalk": "^4.0.0",
-            "diff-sequences": "^29.4.3",
-            "jest-get-type": "^29.4.3",
-            "pretty-format": "^29.6.2"
+            "diff-sequences": "^29.6.3",
+            "jest-get-type": "^29.6.3",
+            "pretty-format": "^29.7.0"
           },
           "dependencies": {
             "chalk": {
               "version": "4.1.2",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+              "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
               "dev": true,
               "requires": {
                 "ansi-styles": "^4.1.0",
@@ -23381,25 +24686,31 @@
           }
         },
         "jest-docblock": {
-          "version": "29.4.3",
+          "version": "29.7.0",
+          "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-29.7.0.tgz",
+          "integrity": "sha512-q617Auw3A612guyaFgsbFeYpNP5t2aoUNLwBUbc/0kD1R4t9ixDbyFTHd1nok4epoVFpr7PmeWHrhvuV3XaJ4g==",
           "dev": true,
           "requires": {
             "detect-newline": "^3.0.0"
           }
         },
         "jest-each": {
-          "version": "29.6.2",
+          "version": "29.7.0",
+          "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-29.7.0.tgz",
+          "integrity": "sha512-gns+Er14+ZrEoC5fhOfYCY1LOHHr0TI+rQUHZS8Ttw2l7gl+80eHc/gFf2Ktkw0+SIACDTeWvpFcv3B04VembQ==",
           "dev": true,
           "requires": {
-            "@jest/types": "^29.6.1",
+            "@jest/types": "^29.6.3",
             "chalk": "^4.0.0",
-            "jest-get-type": "^29.4.3",
-            "jest-util": "^29.6.2",
-            "pretty-format": "^29.6.2"
+            "jest-get-type": "^29.6.3",
+            "jest-util": "^29.7.0",
+            "pretty-format": "^29.7.0"
           },
           "dependencies": {
             "chalk": {
               "version": "4.1.2",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+              "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
               "dev": true,
               "requires": {
                 "ansi-styles": "^4.1.0",
@@ -23409,69 +24720,81 @@
           }
         },
         "jest-environment-jsdom": {
-          "version": "29.6.2",
+          "version": "29.6.4",
+          "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-29.6.4.tgz",
+          "integrity": "sha512-K6wfgUJ16DoMs02JYFid9lOsqfpoVtyJxpRlnTxUHzvZWBnnh2VNGRB9EC1Cro96TQdq5TtSjb3qUjNaJP9IyA==",
           "dev": true,
           "requires": {
-            "@jest/environment": "^29.6.2",
-            "@jest/fake-timers": "^29.6.2",
-            "@jest/types": "^29.6.1",
+            "@jest/environment": "^29.6.4",
+            "@jest/fake-timers": "^29.6.4",
+            "@jest/types": "^29.6.3",
             "@types/jsdom": "^20.0.0",
             "@types/node": "*",
-            "jest-mock": "^29.6.2",
-            "jest-util": "^29.6.2",
+            "jest-mock": "^29.6.3",
+            "jest-util": "^29.6.3",
             "jsdom": "^20.0.0"
           }
         },
         "jest-environment-node": {
-          "version": "29.6.2",
+          "version": "29.7.0",
+          "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-29.7.0.tgz",
+          "integrity": "sha512-DOSwCRqXirTOyheM+4d5YZOrWcdu0LNZ87ewUoywbcb2XR4wKgqiG8vNeYwhjFMbEkfju7wx2GYH0P2gevGvFw==",
           "dev": true,
           "requires": {
-            "@jest/environment": "^29.6.2",
-            "@jest/fake-timers": "^29.6.2",
-            "@jest/types": "^29.6.1",
+            "@jest/environment": "^29.7.0",
+            "@jest/fake-timers": "^29.7.0",
+            "@jest/types": "^29.6.3",
             "@types/node": "*",
-            "jest-mock": "^29.6.2",
-            "jest-util": "^29.6.2"
+            "jest-mock": "^29.7.0",
+            "jest-util": "^29.7.0"
           }
         },
         "jest-get-type": {
-          "version": "29.4.3",
+          "version": "29.6.3",
+          "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.6.3.tgz",
+          "integrity": "sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==",
           "dev": true
         },
         "jest-haste-map": {
-          "version": "29.6.2",
+          "version": "29.7.0",
+          "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-29.7.0.tgz",
+          "integrity": "sha512-fP8u2pyfqx0K1rGn1R9pyE0/KTn+G7PxktWidOBTqFPLYX0b9ksaMFkhK5vrS3DVun09pckLdlx90QthlW7AmA==",
           "dev": true,
           "requires": {
-            "@jest/types": "^29.6.1",
+            "@jest/types": "^29.6.3",
             "@types/graceful-fs": "^4.1.3",
             "@types/node": "*",
             "anymatch": "^3.0.3",
             "fb-watchman": "^2.0.0",
             "fsevents": "^2.3.2",
             "graceful-fs": "^4.2.9",
-            "jest-regex-util": "^29.4.3",
-            "jest-util": "^29.6.2",
-            "jest-worker": "^29.6.2",
+            "jest-regex-util": "^29.6.3",
+            "jest-util": "^29.7.0",
+            "jest-worker": "^29.7.0",
             "micromatch": "^4.0.4",
             "walker": "^1.0.8"
           }
         },
         "jest-leak-detector": {
-          "version": "29.6.2",
+          "version": "29.7.0",
+          "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-29.7.0.tgz",
+          "integrity": "sha512-kYA8IJcSYtST2BY9I+SMC32nDpBT3J2NvWJx8+JCuCdl/CR1I4EKUJROiP8XtCcxqgTTBGJNdbB1A8XRKbTetw==",
           "dev": true,
           "requires": {
-            "jest-get-type": "^29.4.3",
-            "pretty-format": "^29.6.2"
+            "jest-get-type": "^29.6.3",
+            "pretty-format": "^29.7.0"
           }
         },
         "jest-matcher-utils": {
-          "version": "29.6.2",
+          "version": "29.7.0",
+          "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.7.0.tgz",
+          "integrity": "sha512-sBkD+Xi9DtcChsI3L3u0+N0opgPYnCRPtGcQYrgXmR+hmt/fYfWAL0xRXYU8eWOdfuLgBe0YCW3AFtnRLagq/g==",
           "dev": true,
           "requires": {
             "chalk": "^4.0.0",
-            "jest-diff": "^29.6.2",
-            "jest-get-type": "^29.4.3",
-            "pretty-format": "^29.6.2"
+            "jest-diff": "^29.7.0",
+            "jest-get-type": "^29.6.3",
+            "pretty-format": "^29.7.0"
           },
           "dependencies": {
             "chalk": {
@@ -23485,16 +24808,18 @@
           }
         },
         "jest-message-util": {
-          "version": "29.6.2",
+          "version": "29.7.0",
+          "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.7.0.tgz",
+          "integrity": "sha512-GBEV4GRADeP+qtB2+6u61stea8mGcOT4mCtrYISZwfu9/ISHFJ/5zOMXYbpBE9RsS5+Gb63DW4FgmnKJ79Kf6w==",
           "dev": true,
           "requires": {
             "@babel/code-frame": "^7.12.13",
-            "@jest/types": "^29.6.1",
+            "@jest/types": "^29.6.3",
             "@types/stack-utils": "^2.0.0",
             "chalk": "^4.0.0",
             "graceful-fs": "^4.2.9",
             "micromatch": "^4.0.4",
-            "pretty-format": "^29.6.2",
+            "pretty-format": "^29.7.0",
             "slash": "^3.0.0",
             "stack-utils": "^2.0.3"
           },
@@ -23510,28 +24835,34 @@
           }
         },
         "jest-mock": {
-          "version": "29.6.2",
+          "version": "29.7.0",
+          "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.7.0.tgz",
+          "integrity": "sha512-ITOMZn+UkYS4ZFh83xYAOzWStloNzJFO2s8DWrE4lhtGD+AorgnbkiKERe4wQVBydIGPx059g6riW5Btp6Llnw==",
           "dev": true,
           "requires": {
-            "@jest/types": "^29.6.1",
+            "@jest/types": "^29.6.3",
             "@types/node": "*",
-            "jest-util": "^29.6.2"
+            "jest-util": "^29.7.0"
           }
         },
         "jest-regex-util": {
-          "version": "29.4.3",
+          "version": "29.6.3",
+          "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-29.6.3.tgz",
+          "integrity": "sha512-KJJBsRCyyLNWCNBOvZyRDnAIfUiRJ8v+hOBQYGn8gDyF3UegwiP4gwRR3/SDa42g1YbVycTidUF3rKjyLFDWbg==",
           "dev": true
         },
         "jest-resolve": {
-          "version": "29.6.2",
+          "version": "29.7.0",
+          "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-29.7.0.tgz",
+          "integrity": "sha512-IOVhZSrg+UvVAshDSDtHyFCCBUl/Q3AAJv8iZ6ZjnZ74xzvwuzLXid9IIIPgTnY62SJjfuupMKZsZQRsCvxEgA==",
           "dev": true,
           "requires": {
             "chalk": "^4.0.0",
             "graceful-fs": "^4.2.9",
-            "jest-haste-map": "^29.6.2",
+            "jest-haste-map": "^29.7.0",
             "jest-pnp-resolver": "^1.2.2",
-            "jest-util": "^29.6.2",
-            "jest-validate": "^29.6.2",
+            "jest-util": "^29.7.0",
+            "jest-validate": "^29.7.0",
             "resolve": "^1.20.0",
             "resolve.exports": "^2.0.0",
             "slash": "^3.0.0"
@@ -23539,6 +24870,8 @@
           "dependencies": {
             "chalk": {
               "version": "4.1.2",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+              "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
               "dev": true,
               "requires": {
                 "ansi-styles": "^4.1.0",
@@ -23548,42 +24881,48 @@
           }
         },
         "jest-resolve-dependencies": {
-          "version": "29.6.2",
+          "version": "29.7.0",
+          "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-29.7.0.tgz",
+          "integrity": "sha512-un0zD/6qxJ+S0et7WxeI3H5XSe9lTBBR7bOHCHXkKR6luG5mwDDlIzVQ0V5cZCuoTgEdcdwzTghYkTWfubi+nA==",
           "dev": true,
           "requires": {
-            "jest-regex-util": "^29.4.3",
-            "jest-snapshot": "^29.6.2"
+            "jest-regex-util": "^29.6.3",
+            "jest-snapshot": "^29.7.0"
           }
         },
         "jest-runner": {
-          "version": "29.6.2",
+          "version": "29.7.0",
+          "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-29.7.0.tgz",
+          "integrity": "sha512-fsc4N6cPCAahybGBfTRcq5wFR6fpLznMg47sY5aDpsoejOcVYFb07AHuSnR0liMcPTgBsA3ZJL6kFOjPdoNipQ==",
           "dev": true,
           "requires": {
-            "@jest/console": "^29.6.2",
-            "@jest/environment": "^29.6.2",
-            "@jest/test-result": "^29.6.2",
-            "@jest/transform": "^29.6.2",
-            "@jest/types": "^29.6.1",
+            "@jest/console": "^29.7.0",
+            "@jest/environment": "^29.7.0",
+            "@jest/test-result": "^29.7.0",
+            "@jest/transform": "^29.7.0",
+            "@jest/types": "^29.6.3",
             "@types/node": "*",
             "chalk": "^4.0.0",
             "emittery": "^0.13.1",
             "graceful-fs": "^4.2.9",
-            "jest-docblock": "^29.4.3",
-            "jest-environment-node": "^29.6.2",
-            "jest-haste-map": "^29.6.2",
-            "jest-leak-detector": "^29.6.2",
-            "jest-message-util": "^29.6.2",
-            "jest-resolve": "^29.6.2",
-            "jest-runtime": "^29.6.2",
-            "jest-util": "^29.6.2",
-            "jest-watcher": "^29.6.2",
-            "jest-worker": "^29.6.2",
+            "jest-docblock": "^29.7.0",
+            "jest-environment-node": "^29.7.0",
+            "jest-haste-map": "^29.7.0",
+            "jest-leak-detector": "^29.7.0",
+            "jest-message-util": "^29.7.0",
+            "jest-resolve": "^29.7.0",
+            "jest-runtime": "^29.7.0",
+            "jest-util": "^29.7.0",
+            "jest-watcher": "^29.7.0",
+            "jest-worker": "^29.7.0",
             "p-limit": "^3.1.0",
             "source-map-support": "0.5.13"
           },
           "dependencies": {
             "chalk": {
               "version": "4.1.2",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+              "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
               "dev": true,
               "requires": {
                 "ansi-styles": "^4.1.0",
@@ -23593,35 +24932,39 @@
           }
         },
         "jest-runtime": {
-          "version": "29.6.2",
+          "version": "29.7.0",
+          "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-29.7.0.tgz",
+          "integrity": "sha512-gUnLjgwdGqW7B4LvOIkbKs9WGbn+QLqRQQ9juC6HndeDiezIwhDP+mhMwHWCEcfQ5RUXa6OPnFF8BJh5xegwwQ==",
           "dev": true,
           "requires": {
-            "@jest/environment": "^29.6.2",
-            "@jest/fake-timers": "^29.6.2",
-            "@jest/globals": "^29.6.2",
-            "@jest/source-map": "^29.6.0",
-            "@jest/test-result": "^29.6.2",
-            "@jest/transform": "^29.6.2",
-            "@jest/types": "^29.6.1",
+            "@jest/environment": "^29.7.0",
+            "@jest/fake-timers": "^29.7.0",
+            "@jest/globals": "^29.7.0",
+            "@jest/source-map": "^29.6.3",
+            "@jest/test-result": "^29.7.0",
+            "@jest/transform": "^29.7.0",
+            "@jest/types": "^29.6.3",
             "@types/node": "*",
             "chalk": "^4.0.0",
             "cjs-module-lexer": "^1.0.0",
             "collect-v8-coverage": "^1.0.0",
             "glob": "^7.1.3",
             "graceful-fs": "^4.2.9",
-            "jest-haste-map": "^29.6.2",
-            "jest-message-util": "^29.6.2",
-            "jest-mock": "^29.6.2",
-            "jest-regex-util": "^29.4.3",
-            "jest-resolve": "^29.6.2",
-            "jest-snapshot": "^29.6.2",
-            "jest-util": "^29.6.2",
+            "jest-haste-map": "^29.7.0",
+            "jest-message-util": "^29.7.0",
+            "jest-mock": "^29.7.0",
+            "jest-regex-util": "^29.6.3",
+            "jest-resolve": "^29.7.0",
+            "jest-snapshot": "^29.7.0",
+            "jest-util": "^29.7.0",
             "slash": "^3.0.0",
             "strip-bom": "^4.0.0"
           },
           "dependencies": {
             "chalk": {
               "version": "4.1.2",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+              "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
               "dev": true,
               "requires": {
                 "ansi-styles": "^4.1.0",
@@ -23631,7 +24974,9 @@
           }
         },
         "jest-snapshot": {
-          "version": "29.6.2",
+          "version": "29.7.0",
+          "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-29.7.0.tgz",
+          "integrity": "sha512-Rm0BMWtxBcioHr1/OX5YCP8Uov4riHvKPknOGs804Zg9JGZgmIBkbtlxJC/7Z4msKYVbIJtfU+tKb8xlYNfdkw==",
           "dev": true,
           "requires": {
             "@babel/core": "^7.11.6",
@@ -23639,25 +24984,27 @@
             "@babel/plugin-syntax-jsx": "^7.7.2",
             "@babel/plugin-syntax-typescript": "^7.7.2",
             "@babel/types": "^7.3.3",
-            "@jest/expect-utils": "^29.6.2",
-            "@jest/transform": "^29.6.2",
-            "@jest/types": "^29.6.1",
+            "@jest/expect-utils": "^29.7.0",
+            "@jest/transform": "^29.7.0",
+            "@jest/types": "^29.6.3",
             "babel-preset-current-node-syntax": "^1.0.0",
             "chalk": "^4.0.0",
-            "expect": "^29.6.2",
+            "expect": "^29.7.0",
             "graceful-fs": "^4.2.9",
-            "jest-diff": "^29.6.2",
-            "jest-get-type": "^29.4.3",
-            "jest-matcher-utils": "^29.6.2",
-            "jest-message-util": "^29.6.2",
-            "jest-util": "^29.6.2",
+            "jest-diff": "^29.7.0",
+            "jest-get-type": "^29.6.3",
+            "jest-matcher-utils": "^29.7.0",
+            "jest-message-util": "^29.7.0",
+            "jest-util": "^29.7.0",
             "natural-compare": "^1.4.0",
-            "pretty-format": "^29.6.2",
+            "pretty-format": "^29.7.0",
             "semver": "^7.5.3"
           },
           "dependencies": {
             "chalk": {
               "version": "4.1.2",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+              "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
               "dev": true,
               "requires": {
                 "ansi-styles": "^4.1.0",
@@ -23667,10 +25014,12 @@
           }
         },
         "jest-util": {
-          "version": "29.6.2",
+          "version": "29.7.0",
+          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
+          "integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
           "dev": true,
           "requires": {
-            "@jest/types": "^29.6.1",
+            "@jest/types": "^29.6.3",
             "@types/node": "*",
             "chalk": "^4.0.0",
             "ci-info": "^3.2.0",
@@ -23689,19 +25038,23 @@
           }
         },
         "jest-validate": {
-          "version": "29.6.2",
+          "version": "29.7.0",
+          "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-29.7.0.tgz",
+          "integrity": "sha512-ZB7wHqaRGVw/9hST/OuFUReG7M8vKeq0/J2egIGLdvjHCmYqGARhzXmtgi+gVeZ5uXFF219aOc3Ls2yLg27tkw==",
           "dev": true,
           "requires": {
-            "@jest/types": "^29.6.1",
+            "@jest/types": "^29.6.3",
             "camelcase": "^6.2.0",
             "chalk": "^4.0.0",
-            "jest-get-type": "^29.4.3",
+            "jest-get-type": "^29.6.3",
             "leven": "^3.1.0",
-            "pretty-format": "^29.6.2"
+            "pretty-format": "^29.7.0"
           },
           "dependencies": {
             "chalk": {
               "version": "4.1.2",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+              "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
               "dev": true,
               "requires": {
                 "ansi-styles": "^4.1.0",
@@ -23711,21 +25064,25 @@
           }
         },
         "jest-watcher": {
-          "version": "29.6.2",
+          "version": "29.7.0",
+          "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-29.7.0.tgz",
+          "integrity": "sha512-49Fg7WXkU3Vl2h6LbLtMQ/HyB6rXSIX7SqvBLQmssRBGN9I0PNvPmAmCWSOY6SOvrjhI/F7/bGAv9RtnsPA03g==",
           "dev": true,
           "requires": {
-            "@jest/test-result": "^29.6.2",
-            "@jest/types": "^29.6.1",
+            "@jest/test-result": "^29.7.0",
+            "@jest/types": "^29.6.3",
             "@types/node": "*",
             "ansi-escapes": "^4.2.1",
             "chalk": "^4.0.0",
             "emittery": "^0.13.1",
-            "jest-util": "^29.6.2",
+            "jest-util": "^29.7.0",
             "string-length": "^4.0.1"
           },
           "dependencies": {
             "chalk": {
               "version": "4.1.2",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+              "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
               "dev": true,
               "requires": {
                 "ansi-styles": "^4.1.0",
@@ -23735,17 +25092,21 @@
           }
         },
         "jest-worker": {
-          "version": "29.6.2",
+          "version": "29.7.0",
+          "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.7.0.tgz",
+          "integrity": "sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==",
           "dev": true,
           "requires": {
             "@types/node": "*",
-            "jest-util": "^29.6.2",
+            "jest-util": "^29.7.0",
             "merge-stream": "^2.0.0",
             "supports-color": "^8.0.0"
           },
           "dependencies": {
             "supports-color": {
               "version": "8.1.1",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+              "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
               "dev": true,
               "requires": {
                 "has-flag": "^4.0.0"
@@ -23785,6 +25146,12 @@
             "xml-name-validator": "^4.0.0"
           }
         },
+        "lz-string": {
+          "version": "1.5.0",
+          "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+          "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+          "dev": true
+        },
         "memize": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/memize/-/memize-2.1.0.tgz",
@@ -23799,6 +25166,8 @@
         },
         "p-limit": {
           "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+          "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
           "dev": true,
           "requires": {
             "yocto-queue": "^0.1.0"
@@ -23817,10 +25186,12 @@
           "integrity": "sha512-JLyh7xT1kizaEvcaXOQwOc2/Yhw6KZOvPf1S8401UyLk86CU79LN3vl7ztXGm/pZ+YjoyAJ4rxmHwbkBXJX+yw=="
         },
         "pretty-format": {
-          "version": "29.6.2",
+          "version": "29.7.0",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+          "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
           "dev": true,
           "requires": {
-            "@jest/schemas": "^29.6.0",
+            "@jest/schemas": "^29.6.3",
             "ansi-styles": "^5.0.0",
             "react-is": "^18.0.0"
           },
@@ -23860,6 +25231,8 @@
         },
         "resolve.exports": {
           "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-2.0.2.tgz",
+          "integrity": "sha512-X2UW6Nw3n/aMgDVy+0rSqgHlv39WZAlZrXCdnbyEiKm17DSqHX4MmQMaST3FbeWR5FTuRcUwYAziZajji0Y7mg==",
           "dev": true
         },
         "rimraf": {
@@ -23894,18 +25267,24 @@
             "loose-envify": "^1.1.0"
           }
         },
+        "semver": {
+          "version": "7.5.4",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+          "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
         "source-map-support": {
           "version": "0.5.13",
+          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
+          "integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
           "dev": true,
           "requires": {
             "buffer-from": "^1.0.0",
             "source-map": "^0.6.0"
           }
-        },
-        "sprintf-js": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
-          "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug=="
         },
         "supports-color": {
           "version": "7.2.0",
@@ -23937,6 +25316,8 @@
         },
         "v8-to-istanbul": {
           "version": "9.1.0",
+          "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.1.0.tgz",
+          "integrity": "sha512-6z3GW9x8G1gd+JIIgQQQxXuiJtCXeAjp6RaPEPLv62mH3iPHPxV6W3robxtCzNErRo6ZwTmzWhsbNvjyEBKzKA==",
           "dev": true,
           "requires": {
             "@jridgewell/trace-mapping": "^0.3.12",
@@ -23946,6 +25327,8 @@
           "dependencies": {
             "convert-source-map": {
               "version": "1.9.0",
+              "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
+              "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
               "dev": true
             }
           }
@@ -24192,7 +25575,7 @@
         "@apollo/client": "^3.8.0",
         "@apollo/experimental-nextjs-app-support": "^0.4.1",
         "@faustwp/cli": "^1.1.1",
-        "@faustwp/core": "^1.1.1",
+        "@faustwp/core": "^1.1.2",
         "@testing-library/jest-dom": "^5.17.0",
         "@types/node": "^20.4.6",
         "concurrently": "^8.2.0",
@@ -25514,7 +26897,7 @@
       "requires": {
         "@apollo/client": "^3.6.6",
         "@faustwp/cli": "1.1.1",
-        "@faustwp/core": "1.1.1",
+        "@faustwp/core": "1.1.2",
         "@wordpress/base-styles": "^4.26.0",
         "@wordpress/block-library": "^7.19.0",
         "classnames": "^2.3.1",
@@ -25542,6 +26925,11 @@
       "requires": {
         "@floating-ui/dom": "^1.2.1"
       }
+    },
+    "@floating-ui/utils": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.1.2.tgz",
+      "integrity": "sha512-ou3elfqG/hZsbmF4bxeJhPHIf3G2pm0ujc39hYEZrfVqt7Vk/Zji6CXc3W0pmYM8BW1g40U+akTl9DKZhFhInQ=="
     },
     "@gqty/cli": {
       "version": "3.3.0",
@@ -25784,28 +27172,32 @@
       }
     },
     "@jest/expect": {
-      "version": "29.6.2",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-29.7.0.tgz",
+      "integrity": "sha512-8uMeAMycttpva3P1lBHB8VciS9V0XAr3GymPpipdyQXbBcuhkLQOSe8E/p92RyAdToS6ZD1tFkX+CkhoECE0dQ==",
       "dev": true,
       "requires": {
-        "expect": "^29.6.2",
-        "jest-snapshot": "^29.6.2"
+        "expect": "^29.7.0",
+        "jest-snapshot": "^29.7.0"
       },
       "dependencies": {
         "@jest/transform": {
-          "version": "29.6.2",
+          "version": "29.7.0",
+          "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.7.0.tgz",
+          "integrity": "sha512-ok/BTPFzFKVMwO5eOHRrvnBVHdRy9IrsrW1GpMaQ9MCnilNLXQKmAX8s1YXDFaai9xJpac2ySzV0YeRRECr2Vw==",
           "dev": true,
           "requires": {
             "@babel/core": "^7.11.6",
-            "@jest/types": "^29.6.1",
+            "@jest/types": "^29.6.3",
             "@jridgewell/trace-mapping": "^0.3.18",
             "babel-plugin-istanbul": "^6.1.1",
             "chalk": "^4.0.0",
             "convert-source-map": "^2.0.0",
             "fast-json-stable-stringify": "^2.1.0",
             "graceful-fs": "^4.2.9",
-            "jest-haste-map": "^29.6.2",
-            "jest-regex-util": "^29.4.3",
-            "jest-util": "^29.6.2",
+            "jest-haste-map": "^29.7.0",
+            "jest-regex-util": "^29.6.3",
+            "jest-util": "^29.7.0",
             "micromatch": "^4.0.4",
             "pirates": "^4.0.4",
             "slash": "^3.0.0",
@@ -25813,10 +27205,12 @@
           }
         },
         "@jest/types": {
-          "version": "29.6.1",
+          "version": "29.6.3",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
+          "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
           "dev": true,
           "requires": {
-            "@jest/schemas": "^29.6.0",
+            "@jest/schemas": "^29.6.3",
             "@types/istanbul-lib-coverage": "^2.0.0",
             "@types/istanbul-reports": "^3.0.0",
             "@types/node": "*",
@@ -25826,6 +27220,8 @@
         },
         "@types/yargs": {
           "version": "17.0.24",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.24.tgz",
+          "integrity": "sha512-6i0aC7jV6QzQB8ne1joVZ0eSFIstHsCrobmOtghM11yGlH0j43FKL2UhWdELkyps0zuf7qVTUVCCR+tgSlyLLw==",
           "dev": true,
           "requires": {
             "@types/yargs-parser": "*"
@@ -25833,6 +27229,8 @@
         },
         "ansi-styles": {
           "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
           "dev": true,
           "requires": {
             "color-convert": "^2.0.1"
@@ -25840,6 +27238,8 @@
         },
         "chalk": {
           "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
           "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
@@ -25848,6 +27248,8 @@
         },
         "color-convert": {
           "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
           "dev": true,
           "requires": {
             "color-name": "~1.1.4"
@@ -25855,95 +27257,118 @@
         },
         "color-name": {
           "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
           "dev": true
         },
         "convert-source-map": {
           "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+          "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
           "dev": true
         },
         "diff-sequences": {
-          "version": "29.4.3",
+          "version": "29.6.3",
+          "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
+          "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
           "dev": true
         },
         "expect": {
-          "version": "29.6.2",
+          "version": "29.7.0",
+          "resolved": "https://registry.npmjs.org/expect/-/expect-29.7.0.tgz",
+          "integrity": "sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==",
           "dev": true,
           "requires": {
-            "@jest/expect-utils": "^29.6.2",
-            "@types/node": "*",
-            "jest-get-type": "^29.4.3",
-            "jest-matcher-utils": "^29.6.2",
-            "jest-message-util": "^29.6.2",
-            "jest-util": "^29.6.2"
+            "@jest/expect-utils": "^29.7.0",
+            "jest-get-type": "^29.6.3",
+            "jest-matcher-utils": "^29.7.0",
+            "jest-message-util": "^29.7.0",
+            "jest-util": "^29.7.0"
           }
         },
         "has-flag": {
           "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
           "dev": true
         },
         "jest-diff": {
-          "version": "29.6.2",
+          "version": "29.7.0",
+          "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.7.0.tgz",
+          "integrity": "sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==",
           "dev": true,
           "requires": {
             "chalk": "^4.0.0",
-            "diff-sequences": "^29.4.3",
-            "jest-get-type": "^29.4.3",
-            "pretty-format": "^29.6.2"
+            "diff-sequences": "^29.6.3",
+            "jest-get-type": "^29.6.3",
+            "pretty-format": "^29.7.0"
           }
         },
         "jest-get-type": {
-          "version": "29.4.3",
+          "version": "29.6.3",
+          "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.6.3.tgz",
+          "integrity": "sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==",
           "dev": true
         },
         "jest-haste-map": {
-          "version": "29.6.2",
+          "version": "29.7.0",
+          "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-29.7.0.tgz",
+          "integrity": "sha512-fP8u2pyfqx0K1rGn1R9pyE0/KTn+G7PxktWidOBTqFPLYX0b9ksaMFkhK5vrS3DVun09pckLdlx90QthlW7AmA==",
           "dev": true,
           "requires": {
-            "@jest/types": "^29.6.1",
+            "@jest/types": "^29.6.3",
             "@types/graceful-fs": "^4.1.3",
             "@types/node": "*",
             "anymatch": "^3.0.3",
             "fb-watchman": "^2.0.0",
             "fsevents": "^2.3.2",
             "graceful-fs": "^4.2.9",
-            "jest-regex-util": "^29.4.3",
-            "jest-util": "^29.6.2",
-            "jest-worker": "^29.6.2",
+            "jest-regex-util": "^29.6.3",
+            "jest-util": "^29.7.0",
+            "jest-worker": "^29.7.0",
             "micromatch": "^4.0.4",
             "walker": "^1.0.8"
           }
         },
         "jest-matcher-utils": {
-          "version": "29.6.2",
+          "version": "29.7.0",
+          "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.7.0.tgz",
+          "integrity": "sha512-sBkD+Xi9DtcChsI3L3u0+N0opgPYnCRPtGcQYrgXmR+hmt/fYfWAL0xRXYU8eWOdfuLgBe0YCW3AFtnRLagq/g==",
           "dev": true,
           "requires": {
             "chalk": "^4.0.0",
-            "jest-diff": "^29.6.2",
-            "jest-get-type": "^29.4.3",
-            "pretty-format": "^29.6.2"
+            "jest-diff": "^29.7.0",
+            "jest-get-type": "^29.6.3",
+            "pretty-format": "^29.7.0"
           }
         },
         "jest-message-util": {
-          "version": "29.6.2",
+          "version": "29.7.0",
+          "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.7.0.tgz",
+          "integrity": "sha512-GBEV4GRADeP+qtB2+6u61stea8mGcOT4mCtrYISZwfu9/ISHFJ/5zOMXYbpBE9RsS5+Gb63DW4FgmnKJ79Kf6w==",
           "dev": true,
           "requires": {
             "@babel/code-frame": "^7.12.13",
-            "@jest/types": "^29.6.1",
+            "@jest/types": "^29.6.3",
             "@types/stack-utils": "^2.0.0",
             "chalk": "^4.0.0",
             "graceful-fs": "^4.2.9",
             "micromatch": "^4.0.4",
-            "pretty-format": "^29.6.2",
+            "pretty-format": "^29.7.0",
             "slash": "^3.0.0",
             "stack-utils": "^2.0.3"
           }
         },
         "jest-regex-util": {
-          "version": "29.4.3",
+          "version": "29.6.3",
+          "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-29.6.3.tgz",
+          "integrity": "sha512-KJJBsRCyyLNWCNBOvZyRDnAIfUiRJ8v+hOBQYGn8gDyF3UegwiP4gwRR3/SDa42g1YbVycTidUF3rKjyLFDWbg==",
           "dev": true
         },
         "jest-snapshot": {
-          "version": "29.6.2",
+          "version": "29.7.0",
+          "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-29.7.0.tgz",
+          "integrity": "sha512-Rm0BMWtxBcioHr1/OX5YCP8Uov4riHvKPknOGs804Zg9JGZgmIBkbtlxJC/7Z4msKYVbIJtfU+tKb8xlYNfdkw==",
           "dev": true,
           "requires": {
             "@babel/core": "^7.11.6",
@@ -25951,28 +27376,30 @@
             "@babel/plugin-syntax-jsx": "^7.7.2",
             "@babel/plugin-syntax-typescript": "^7.7.2",
             "@babel/types": "^7.3.3",
-            "@jest/expect-utils": "^29.6.2",
-            "@jest/transform": "^29.6.2",
-            "@jest/types": "^29.6.1",
+            "@jest/expect-utils": "^29.7.0",
+            "@jest/transform": "^29.7.0",
+            "@jest/types": "^29.6.3",
             "babel-preset-current-node-syntax": "^1.0.0",
             "chalk": "^4.0.0",
-            "expect": "^29.6.2",
+            "expect": "^29.7.0",
             "graceful-fs": "^4.2.9",
-            "jest-diff": "^29.6.2",
-            "jest-get-type": "^29.4.3",
-            "jest-matcher-utils": "^29.6.2",
-            "jest-message-util": "^29.6.2",
-            "jest-util": "^29.6.2",
+            "jest-diff": "^29.7.0",
+            "jest-get-type": "^29.6.3",
+            "jest-matcher-utils": "^29.7.0",
+            "jest-message-util": "^29.7.0",
+            "jest-util": "^29.7.0",
             "natural-compare": "^1.4.0",
-            "pretty-format": "^29.6.2",
-            "semver": "^7.5.3"
+            "pretty-format": "^29.7.0",
+            "semver": "~7.5.2"
           }
         },
         "jest-util": {
-          "version": "29.6.2",
+          "version": "29.7.0",
+          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
+          "integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
           "dev": true,
           "requires": {
-            "@jest/types": "^29.6.1",
+            "@jest/types": "^29.6.3",
             "@types/node": "*",
             "chalk": "^4.0.0",
             "ci-info": "^3.2.0",
@@ -25981,17 +27408,21 @@
           }
         },
         "jest-worker": {
-          "version": "29.6.2",
+          "version": "29.7.0",
+          "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.7.0.tgz",
+          "integrity": "sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==",
           "dev": true,
           "requires": {
             "@types/node": "*",
-            "jest-util": "^29.6.2",
+            "jest-util": "^29.7.0",
             "merge-stream": "^2.0.0",
             "supports-color": "^8.0.0"
           },
           "dependencies": {
             "supports-color": {
               "version": "8.1.1",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+              "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
               "dev": true,
               "requires": {
                 "has-flag": "^4.0.0"
@@ -26000,26 +27431,34 @@
           }
         },
         "pretty-format": {
-          "version": "29.6.2",
+          "version": "29.7.0",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+          "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
           "dev": true,
           "requires": {
-            "@jest/schemas": "^29.6.0",
+            "@jest/schemas": "^29.6.3",
             "ansi-styles": "^5.0.0",
             "react-is": "^18.0.0"
           },
           "dependencies": {
             "ansi-styles": {
               "version": "5.2.0",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+              "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
               "dev": true
             }
           }
         },
         "react-is": {
           "version": "18.2.0",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+          "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
           "dev": true
         },
         "supports-color": {
           "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
           "dev": true,
           "requires": {
             "has-flag": "^4.0.0"
@@ -26027,6 +27466,8 @@
         },
         "write-file-atomic": {
           "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.2.tgz",
+          "integrity": "sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==",
           "dev": true,
           "requires": {
             "imurmurhash": "^0.1.4",
@@ -26036,14 +27477,18 @@
       }
     },
     "@jest/expect-utils": {
-      "version": "29.6.2",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-29.7.0.tgz",
+      "integrity": "sha512-GlsNBWiFQFCVi9QVSx7f5AgMeLxe9YCCs5PuP2O2LdjDAA8Jh9eX7lA1Jq/xdXw3Wb3hyvlFNfZIfcRetSzYcA==",
       "dev": true,
       "requires": {
-        "jest-get-type": "^29.4.3"
+        "jest-get-type": "^29.6.3"
       },
       "dependencies": {
         "jest-get-type": {
-          "version": "29.4.3",
+          "version": "29.6.3",
+          "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.6.3.tgz",
+          "integrity": "sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==",
           "dev": true
         }
       }
@@ -26140,7 +27585,9 @@
       }
     },
     "@jest/schemas": {
-      "version": "29.6.0",
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
+      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
       "dev": true,
       "requires": {
         "@sinclair/typebox": "^0.27.8"
@@ -26442,8 +27889,80 @@
         }
       }
     },
+    "@next/swc-android-arm-eabi": {
+      "version": "12.3.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-12.3.0.tgz",
+      "integrity": "sha512-/PuirPnAKsYBw93w/7Q9hqy+KGOU9mjYprZ/faxMUJh/dc6v3rYLxkZKNG9nFPIW4QKNTCnhP40xF9hLnxO+xg==",
+      "optional": true
+    },
+    "@next/swc-android-arm64": {
+      "version": "12.3.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-12.3.0.tgz",
+      "integrity": "sha512-OaI+FhAM6P9B6Ybwbn0Zl8YwWido0lLwhDBi9WiYCh4RQmIXAyVIoIJPHo4fP05+mXaJ/k1trvDvuURvHOq2qw==",
+      "optional": true
+    },
+    "@next/swc-darwin-arm64": {
+      "version": "13.4.20-canary.18",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.4.20-canary.18.tgz",
+      "integrity": "sha512-/pI6Dm8EN0hnEyyIl0ABeXSU2RKaV87XJPz1fy2wU+ccsQrb1lK8RWqapR/5nSM/2B7HcSB8pUDjzX51bwQfYg==",
+      "optional": true
+    },
     "@next/swc-darwin-x64": {
       "version": "12.3.0",
+      "optional": true
+    },
+    "@next/swc-freebsd-x64": {
+      "version": "12.3.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-freebsd-x64/-/swc-freebsd-x64-12.3.0.tgz",
+      "integrity": "sha512-xAlruUREij/bFa+qsE1tmsP28t7vz02N4ZDHt2lh3uJUniE0Ne9idyIDLc1Ed0IF2RjfgOp4ZVunuS3OM0sngw==",
+      "optional": true
+    },
+    "@next/swc-linux-arm-gnueabihf": {
+      "version": "12.3.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-12.3.0.tgz",
+      "integrity": "sha512-jin2S4VT/cugc2dSZEUIabhYDJNgrUh7fufbdsaAezgcQzqfdfJqfxl4E9GuafzB4cbRPTaqA0V5uqbp0IyGkQ==",
+      "optional": true
+    },
+    "@next/swc-linux-arm64-gnu": {
+      "version": "13.4.20-canary.18",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-13.4.20-canary.18.tgz",
+      "integrity": "sha512-W7VQhzNK7elzFzzUCvO92gdtCVhZgU19FPdWma5HpCxvK4O03lakeGpEnxKzWyLDjy4LryUutLI2G/wyuT/cww==",
+      "optional": true
+    },
+    "@next/swc-linux-arm64-musl": {
+      "version": "13.4.20-canary.18",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-13.4.20-canary.18.tgz",
+      "integrity": "sha512-tiDRcKQJsQLBrA/xKk2FxZmQiqbzCweY6xQM3e8dXcUiP3Ou7zn5Cl5GGMld2BQolnuh/UrUj605PoO6gpEauA==",
+      "optional": true
+    },
+    "@next/swc-linux-x64-gnu": {
+      "version": "13.4.20-canary.18",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-13.4.20-canary.18.tgz",
+      "integrity": "sha512-9KcUvZNGrl8bXgu/rh/Fpd6wZM+H+m0pJv62U+pu467u59dFsp9T3QwoCPSIK1NFGQy0SqsrUwJXoBLz0K4P+Q==",
+      "optional": true
+    },
+    "@next/swc-linux-x64-musl": {
+      "version": "13.4.20-canary.18",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-13.4.20-canary.18.tgz",
+      "integrity": "sha512-LR2ygXB+we+vFjBieWHziy6A0i1PFepG2f/+nVHdvYGKH2musGUvP+2SfalgdbLMmdfAbdlfzlp+/kXAo6iRWA==",
+      "optional": true
+    },
+    "@next/swc-win32-arm64-msvc": {
+      "version": "13.4.20-canary.18",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-13.4.20-canary.18.tgz",
+      "integrity": "sha512-fnoInsl1nmRXbAEMp24edyLNBvL+7eptptXGt9on+klP21zNSclJmYoJUcW13z0BZWw9XJrmcGPOe79NbpwIlA==",
+      "optional": true
+    },
+    "@next/swc-win32-ia32-msvc": {
+      "version": "13.4.20-canary.18",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-13.4.20-canary.18.tgz",
+      "integrity": "sha512-fNAoxBQsnV+GiTWcS7RG0nZPqCUnj9MszKAH6Lf5HA1fITkWN5Dp7R0ZRKF5xaeTUIJQPlzIHlhBg2cF9ZBTQA==",
+      "optional": true
+    },
+    "@next/swc-win32-x64-msvc": {
+      "version": "13.4.20-canary.18",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-13.4.20-canary.18.tgz",
+      "integrity": "sha512-hI85vIDhZE44Exnvz/cqezz/yU0YrEyDPB1XbiRKXK8mWUwc4XQ/EE/0/Iofp4aT0+SzAZ+AmAFT0bwZJ75Gdw==",
       "optional": true
     },
     "@nodelib/fs.scandir": {
@@ -27985,17 +29504,21 @@
       }
     },
     "@wordpress/deprecated": {
-      "version": "3.39.0",
+      "version": "3.41.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-3.41.0.tgz",
+      "integrity": "sha512-8so9fJC6MvMeMxaRqEJYtzXm1RP2i+nq3NXG9DW4fbo8ICEIe1QqBpCFqV4FbkHs8PRqyJ8IJ7C6NnAvL3BWKw==",
       "requires": {
         "@babel/runtime": "^7.16.0",
-        "@wordpress/hooks": "^3.39.0"
+        "@wordpress/hooks": "^3.41.0"
       }
     },
     "@wordpress/dom": {
-      "version": "3.39.0",
+      "version": "3.41.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-3.41.0.tgz",
+      "integrity": "sha512-0FKG4c33G7jOElzy1adqgNjowYBaWX98Q99X9WjpjtF+AY7/Sljq4zOGh5iZXSM/1dpKLPs4f/frFEqueq6MGg==",
       "requires": {
         "@babel/runtime": "^7.16.0",
-        "@wordpress/deprecated": "^3.39.0"
+        "@wordpress/deprecated": "^3.41.0"
       }
     },
     "@wordpress/dom-ready": {
@@ -28018,13 +29541,17 @@
       }
     },
     "@wordpress/escape-html": {
-      "version": "2.39.0",
+      "version": "2.41.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-2.41.0.tgz",
+      "integrity": "sha512-fFDuAO/csLVemQrJKTrwxjmR7d2a6zEuDVCKi2jUt7j9rpLpz9IZnEVD2q/icOj2+u6joeDwvCyyPyTreqEZHA==",
       "requires": {
         "@babel/runtime": "^7.16.0"
       }
     },
     "@wordpress/hooks": {
-      "version": "3.39.0",
+      "version": "3.41.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-3.41.0.tgz",
+      "integrity": "sha512-o3fC6Z0kCLzZNFUT5W7C1d2mR+qjVwLaWjrwuJngJG92wly4IzKgAUDs/iJZojxtePFMP8JOFCg4FMuzG/VhWw==",
       "requires": {
         "@babel/runtime": "^7.16.0"
       }
@@ -28036,10 +29563,12 @@
       }
     },
     "@wordpress/i18n": {
-      "version": "4.39.0",
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-4.41.0.tgz",
+      "integrity": "sha512-MXA+DiVSF2CS0ZhFEBq/eJjfHuKMcu3FUuiF/Dpc1YZRD1X7N6xPlfo4xKJZVUWIAsfgpc8oA2YMLw1VTFzrRA==",
       "requires": {
         "@babel/runtime": "^7.16.0",
-        "@wordpress/hooks": "^3.39.0",
+        "@wordpress/hooks": "^3.41.0",
         "gettext-parser": "^1.3.1",
         "memize": "^2.1.0",
         "sprintf-js": "^1.1.1",
@@ -28111,7 +29640,9 @@
       }
     },
     "@wordpress/is-shallow-equal": {
-      "version": "4.39.0",
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-4.41.0.tgz",
+      "integrity": "sha512-z0+bdJvjOcbPf7vGiC0Zfoff+2WyFRFwsJex9d9N9CTVvr87kaVHBZuZlPX6iFmS22RzM2tLeppBKlOSRtSI4w==",
       "requires": {
         "@babel/runtime": "^7.16.0"
       }
@@ -28127,10 +29658,12 @@
       }
     },
     "@wordpress/keycodes": {
-      "version": "3.39.0",
+      "version": "3.41.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-3.41.0.tgz",
+      "integrity": "sha512-0DY07PV5qATrvWLc5jWgrgUGpeFrqvY+K0qF0gLDw1rpIZBxLre+N3K7ANC/iZzSsPLbYxxVF0SSFDIVI23Pug==",
       "requires": {
         "@babel/runtime": "^7.16.0",
-        "@wordpress/i18n": "^4.39.0",
+        "@wordpress/i18n": "^4.41.0",
         "change-case": "^4.1.2"
       }
     },
@@ -28284,7 +29817,9 @@
       }
     },
     "@wordpress/priority-queue": {
-      "version": "2.39.0",
+      "version": "2.41.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-2.41.0.tgz",
+      "integrity": "sha512-OntRPhdybFO5da+MO0/pvnRYG+D+c1kU0KRPDuEa+ArZmmQ/lQC+z+/du9nP/cgvQCAzLHJo2/VKCSQZVyewKw==",
       "requires": {
         "@babel/runtime": "^7.16.0",
         "requestidlecallback": "^0.3.0"
@@ -29135,6 +30670,723 @@
         "yaml": "^1.10.0"
       }
     },
+    "create-jest": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/create-jest/-/create-jest-29.7.0.tgz",
+      "integrity": "sha512-Adz2bdH0Vq3F53KEMJOoftQFutWCukm6J24wbPWRO4k1kMY7gS7ds/uoJkNuV8wDCtWWnuwGcJwpWcih+zEW1Q==",
+      "dev": true,
+      "requires": {
+        "@jest/types": "^29.6.3",
+        "chalk": "^4.0.0",
+        "exit": "^0.1.2",
+        "graceful-fs": "^4.2.9",
+        "jest-config": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "prompts": "^2.0.1"
+      },
+      "dependencies": {
+        "@jest/console": {
+          "version": "29.7.0",
+          "resolved": "https://registry.npmjs.org/@jest/console/-/console-29.7.0.tgz",
+          "integrity": "sha512-5Ni4CU7XHQi32IJ398EEP4RrB8eV09sXP2ROqD4bksHrnTree52PsxvX8tpL8LvTZ3pFzXyPbNQReSN41CAhOg==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^29.6.3",
+            "@types/node": "*",
+            "chalk": "^4.0.0",
+            "jest-message-util": "^29.7.0",
+            "jest-util": "^29.7.0",
+            "slash": "^3.0.0"
+          }
+        },
+        "@jest/environment": {
+          "version": "29.7.0",
+          "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.7.0.tgz",
+          "integrity": "sha512-aQIfHDq33ExsN4jP1NWGXhxgQ/wixs60gDiKO+XVMd8Mn0NWPWgc34ZQDTb2jKaUWQ7MuwoitXAsN2XVXNMpAw==",
+          "dev": true,
+          "requires": {
+            "@jest/fake-timers": "^29.7.0",
+            "@jest/types": "^29.6.3",
+            "@types/node": "*",
+            "jest-mock": "^29.7.0"
+          }
+        },
+        "@jest/fake-timers": {
+          "version": "29.7.0",
+          "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-29.7.0.tgz",
+          "integrity": "sha512-q4DH1Ha4TTFPdxLsqDXK1d3+ioSL7yL5oCMJZgDYm6i+6CygW5E5xVr/D1HdsGxjt1ZWSfUAs9OxSB/BNelWrQ==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^29.6.3",
+            "@sinonjs/fake-timers": "^10.0.2",
+            "@types/node": "*",
+            "jest-message-util": "^29.7.0",
+            "jest-mock": "^29.7.0",
+            "jest-util": "^29.7.0"
+          }
+        },
+        "@jest/globals": {
+          "version": "29.7.0",
+          "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-29.7.0.tgz",
+          "integrity": "sha512-mpiz3dutLbkW2MNFubUGUEVLkTGiqW6yLVTA+JbP6fI6J5iL9Y0Nlg8k95pcF8ctKwCS7WVxteBs29hhfAotzQ==",
+          "dev": true,
+          "requires": {
+            "@jest/environment": "^29.7.0",
+            "@jest/expect": "^29.7.0",
+            "@jest/types": "^29.6.3",
+            "jest-mock": "^29.7.0"
+          }
+        },
+        "@jest/source-map": {
+          "version": "29.6.3",
+          "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-29.6.3.tgz",
+          "integrity": "sha512-MHjT95QuipcPrpLM+8JMSzFx6eHp5Bm+4XeFDJlwsvVBjmKNiIAvasGK2fxz2WbGRlnvqehFbh07MMa7n3YJnw==",
+          "dev": true,
+          "requires": {
+            "@jridgewell/trace-mapping": "^0.3.18",
+            "callsites": "^3.0.0",
+            "graceful-fs": "^4.2.9"
+          }
+        },
+        "@jest/test-result": {
+          "version": "29.7.0",
+          "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-29.7.0.tgz",
+          "integrity": "sha512-Fdx+tv6x1zlkJPcWXmMDAG2HBnaR9XPSd5aDWQVsfrZmLVT3lU1cwyxLgRmXR9yrq4NBoEm9BMsfgFzTQAbJYA==",
+          "dev": true,
+          "requires": {
+            "@jest/console": "^29.7.0",
+            "@jest/types": "^29.6.3",
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "collect-v8-coverage": "^1.0.0"
+          }
+        },
+        "@jest/test-sequencer": {
+          "version": "29.7.0",
+          "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-29.7.0.tgz",
+          "integrity": "sha512-GQwJ5WZVrKnOJuiYiAF52UNUJXgTZx1NHjFSEB0qEMmSZKAkdMoIzw/Cj6x6NF4AvV23AUqDpFzQkN/eYCYTxw==",
+          "dev": true,
+          "requires": {
+            "@jest/test-result": "^29.7.0",
+            "graceful-fs": "^4.2.9",
+            "jest-haste-map": "^29.7.0",
+            "slash": "^3.0.0"
+          }
+        },
+        "@jest/transform": {
+          "version": "29.7.0",
+          "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.7.0.tgz",
+          "integrity": "sha512-ok/BTPFzFKVMwO5eOHRrvnBVHdRy9IrsrW1GpMaQ9MCnilNLXQKmAX8s1YXDFaai9xJpac2ySzV0YeRRECr2Vw==",
+          "dev": true,
+          "requires": {
+            "@babel/core": "^7.11.6",
+            "@jest/types": "^29.6.3",
+            "@jridgewell/trace-mapping": "^0.3.18",
+            "babel-plugin-istanbul": "^6.1.1",
+            "chalk": "^4.0.0",
+            "convert-source-map": "^2.0.0",
+            "fast-json-stable-stringify": "^2.1.0",
+            "graceful-fs": "^4.2.9",
+            "jest-haste-map": "^29.7.0",
+            "jest-regex-util": "^29.6.3",
+            "jest-util": "^29.7.0",
+            "micromatch": "^4.0.4",
+            "pirates": "^4.0.4",
+            "slash": "^3.0.0",
+            "write-file-atomic": "^4.0.2"
+          }
+        },
+        "@jest/types": {
+          "version": "29.6.3",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
+          "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
+          "dev": true,
+          "requires": {
+            "@jest/schemas": "^29.6.3",
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^17.0.8",
+            "chalk": "^4.0.0"
+          }
+        },
+        "@sinonjs/commons": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.0.tgz",
+          "integrity": "sha512-jXBtWAF4vmdNmZgD5FoKsVLv3rPgDnLgPbU84LIJ3otV44vJlDRokVng5v8NFJdCf/da9legHcKaRuZs4L7faA==",
+          "dev": true,
+          "requires": {
+            "type-detect": "4.0.8"
+          }
+        },
+        "@sinonjs/fake-timers": {
+          "version": "10.3.0",
+          "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.3.0.tgz",
+          "integrity": "sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==",
+          "dev": true,
+          "requires": {
+            "@sinonjs/commons": "^3.0.0"
+          }
+        },
+        "@types/yargs": {
+          "version": "17.0.24",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.24.tgz",
+          "integrity": "sha512-6i0aC7jV6QzQB8ne1joVZ0eSFIstHsCrobmOtghM11yGlH0j43FKL2UhWdELkyps0zuf7qVTUVCCR+tgSlyLLw==",
+          "dev": true,
+          "requires": {
+            "@types/yargs-parser": "*"
+          }
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "babel-jest": {
+          "version": "29.7.0",
+          "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.7.0.tgz",
+          "integrity": "sha512-BrvGY3xZSwEcCzKvKsCi2GgHqDqsYkOP4/by5xCgIwGXQxIEh+8ew3gmrE1y7XRR6LHZIj6yLYnUi/mm2KXKBg==",
+          "dev": true,
+          "requires": {
+            "@jest/transform": "^29.7.0",
+            "@types/babel__core": "^7.1.14",
+            "babel-plugin-istanbul": "^6.1.1",
+            "babel-preset-jest": "^29.6.3",
+            "chalk": "^4.0.0",
+            "graceful-fs": "^4.2.9",
+            "slash": "^3.0.0"
+          }
+        },
+        "babel-plugin-jest-hoist": {
+          "version": "29.6.3",
+          "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-29.6.3.tgz",
+          "integrity": "sha512-ESAc/RJvGTFEzRwOTT4+lNDk/GNHMkKbNzsvT0qKRfDyyYTskxB5rnU2njIDYVxXCBHHEI1c0YwHob3WaYujOg==",
+          "dev": true,
+          "requires": {
+            "@babel/template": "^7.3.3",
+            "@babel/types": "^7.3.3",
+            "@types/babel__core": "^7.1.14",
+            "@types/babel__traverse": "^7.0.6"
+          }
+        },
+        "babel-preset-jest": {
+          "version": "29.6.3",
+          "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-29.6.3.tgz",
+          "integrity": "sha512-0B3bhxR6snWXJZtR/RliHTDPRgn1sNHOR0yVtq/IiQFyuOVjFS+wuio/R4gSNkyYmKmJB4wGZv2NZanmKmTnNA==",
+          "dev": true,
+          "requires": {
+            "babel-plugin-jest-hoist": "^29.6.3",
+            "babel-preset-current-node-syntax": "^1.0.0"
+          }
+        },
+        "camelcase": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+          "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+          "dev": true
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "convert-source-map": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+          "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+          "dev": true
+        },
+        "dedent": {
+          "version": "1.5.1",
+          "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.5.1.tgz",
+          "integrity": "sha512-+LxW+KLWxu3HW3M2w2ympwtqPrqYRzU8fqi6Fhd18fBALe15blJPI/I4+UHveMVG6lJqB4JNd4UG0S5cnVHwIg==",
+          "dev": true,
+          "requires": {}
+        },
+        "diff-sequences": {
+          "version": "29.6.3",
+          "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
+          "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
+          "dev": true
+        },
+        "emittery": {
+          "version": "0.13.1",
+          "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.13.1.tgz",
+          "integrity": "sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==",
+          "dev": true
+        },
+        "expect": {
+          "version": "29.7.0",
+          "resolved": "https://registry.npmjs.org/expect/-/expect-29.7.0.tgz",
+          "integrity": "sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==",
+          "dev": true,
+          "requires": {
+            "@jest/expect-utils": "^29.7.0",
+            "jest-get-type": "^29.6.3",
+            "jest-matcher-utils": "^29.7.0",
+            "jest-message-util": "^29.7.0",
+            "jest-util": "^29.7.0"
+          }
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "jest-circus": {
+          "version": "29.7.0",
+          "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-29.7.0.tgz",
+          "integrity": "sha512-3E1nCMgipcTkCocFwM90XXQab9bS+GMsjdpmPrlelaxwD93Ad8iVEjX/vvHPdLPnFf+L40u+5+iutRdA1N9myw==",
+          "dev": true,
+          "requires": {
+            "@jest/environment": "^29.7.0",
+            "@jest/expect": "^29.7.0",
+            "@jest/test-result": "^29.7.0",
+            "@jest/types": "^29.6.3",
+            "@types/node": "*",
+            "chalk": "^4.0.0",
+            "co": "^4.6.0",
+            "dedent": "^1.0.0",
+            "is-generator-fn": "^2.0.0",
+            "jest-each": "^29.7.0",
+            "jest-matcher-utils": "^29.7.0",
+            "jest-message-util": "^29.7.0",
+            "jest-runtime": "^29.7.0",
+            "jest-snapshot": "^29.7.0",
+            "jest-util": "^29.7.0",
+            "p-limit": "^3.1.0",
+            "pretty-format": "^29.7.0",
+            "pure-rand": "^6.0.0",
+            "slash": "^3.0.0",
+            "stack-utils": "^2.0.3"
+          }
+        },
+        "jest-config": {
+          "version": "29.7.0",
+          "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-29.7.0.tgz",
+          "integrity": "sha512-uXbpfeQ7R6TZBqI3/TxCU4q4ttk3u0PJeC+E0zbfSoSjq6bJ7buBPxzQPL0ifrkY4DNu4JUdk0ImlBUYi840eQ==",
+          "dev": true,
+          "requires": {
+            "@babel/core": "^7.11.6",
+            "@jest/test-sequencer": "^29.7.0",
+            "@jest/types": "^29.6.3",
+            "babel-jest": "^29.7.0",
+            "chalk": "^4.0.0",
+            "ci-info": "^3.2.0",
+            "deepmerge": "^4.2.2",
+            "glob": "^7.1.3",
+            "graceful-fs": "^4.2.9",
+            "jest-circus": "^29.7.0",
+            "jest-environment-node": "^29.7.0",
+            "jest-get-type": "^29.6.3",
+            "jest-regex-util": "^29.6.3",
+            "jest-resolve": "^29.7.0",
+            "jest-runner": "^29.7.0",
+            "jest-util": "^29.7.0",
+            "jest-validate": "^29.7.0",
+            "micromatch": "^4.0.4",
+            "parse-json": "^5.2.0",
+            "pretty-format": "^29.7.0",
+            "slash": "^3.0.0",
+            "strip-json-comments": "^3.1.1"
+          }
+        },
+        "jest-diff": {
+          "version": "29.7.0",
+          "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.7.0.tgz",
+          "integrity": "sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==",
+          "dev": true,
+          "requires": {
+            "chalk": "^4.0.0",
+            "diff-sequences": "^29.6.3",
+            "jest-get-type": "^29.6.3",
+            "pretty-format": "^29.7.0"
+          }
+        },
+        "jest-docblock": {
+          "version": "29.7.0",
+          "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-29.7.0.tgz",
+          "integrity": "sha512-q617Auw3A612guyaFgsbFeYpNP5t2aoUNLwBUbc/0kD1R4t9ixDbyFTHd1nok4epoVFpr7PmeWHrhvuV3XaJ4g==",
+          "dev": true,
+          "requires": {
+            "detect-newline": "^3.0.0"
+          }
+        },
+        "jest-each": {
+          "version": "29.7.0",
+          "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-29.7.0.tgz",
+          "integrity": "sha512-gns+Er14+ZrEoC5fhOfYCY1LOHHr0TI+rQUHZS8Ttw2l7gl+80eHc/gFf2Ktkw0+SIACDTeWvpFcv3B04VembQ==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^29.6.3",
+            "chalk": "^4.0.0",
+            "jest-get-type": "^29.6.3",
+            "jest-util": "^29.7.0",
+            "pretty-format": "^29.7.0"
+          }
+        },
+        "jest-environment-node": {
+          "version": "29.7.0",
+          "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-29.7.0.tgz",
+          "integrity": "sha512-DOSwCRqXirTOyheM+4d5YZOrWcdu0LNZ87ewUoywbcb2XR4wKgqiG8vNeYwhjFMbEkfju7wx2GYH0P2gevGvFw==",
+          "dev": true,
+          "requires": {
+            "@jest/environment": "^29.7.0",
+            "@jest/fake-timers": "^29.7.0",
+            "@jest/types": "^29.6.3",
+            "@types/node": "*",
+            "jest-mock": "^29.7.0",
+            "jest-util": "^29.7.0"
+          }
+        },
+        "jest-get-type": {
+          "version": "29.6.3",
+          "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.6.3.tgz",
+          "integrity": "sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==",
+          "dev": true
+        },
+        "jest-haste-map": {
+          "version": "29.7.0",
+          "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-29.7.0.tgz",
+          "integrity": "sha512-fP8u2pyfqx0K1rGn1R9pyE0/KTn+G7PxktWidOBTqFPLYX0b9ksaMFkhK5vrS3DVun09pckLdlx90QthlW7AmA==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^29.6.3",
+            "@types/graceful-fs": "^4.1.3",
+            "@types/node": "*",
+            "anymatch": "^3.0.3",
+            "fb-watchman": "^2.0.0",
+            "fsevents": "^2.3.2",
+            "graceful-fs": "^4.2.9",
+            "jest-regex-util": "^29.6.3",
+            "jest-util": "^29.7.0",
+            "jest-worker": "^29.7.0",
+            "micromatch": "^4.0.4",
+            "walker": "^1.0.8"
+          }
+        },
+        "jest-leak-detector": {
+          "version": "29.7.0",
+          "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-29.7.0.tgz",
+          "integrity": "sha512-kYA8IJcSYtST2BY9I+SMC32nDpBT3J2NvWJx8+JCuCdl/CR1I4EKUJROiP8XtCcxqgTTBGJNdbB1A8XRKbTetw==",
+          "dev": true,
+          "requires": {
+            "jest-get-type": "^29.6.3",
+            "pretty-format": "^29.7.0"
+          }
+        },
+        "jest-matcher-utils": {
+          "version": "29.7.0",
+          "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.7.0.tgz",
+          "integrity": "sha512-sBkD+Xi9DtcChsI3L3u0+N0opgPYnCRPtGcQYrgXmR+hmt/fYfWAL0xRXYU8eWOdfuLgBe0YCW3AFtnRLagq/g==",
+          "dev": true,
+          "requires": {
+            "chalk": "^4.0.0",
+            "jest-diff": "^29.7.0",
+            "jest-get-type": "^29.6.3",
+            "pretty-format": "^29.7.0"
+          }
+        },
+        "jest-message-util": {
+          "version": "29.7.0",
+          "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.7.0.tgz",
+          "integrity": "sha512-GBEV4GRADeP+qtB2+6u61stea8mGcOT4mCtrYISZwfu9/ISHFJ/5zOMXYbpBE9RsS5+Gb63DW4FgmnKJ79Kf6w==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.12.13",
+            "@jest/types": "^29.6.3",
+            "@types/stack-utils": "^2.0.0",
+            "chalk": "^4.0.0",
+            "graceful-fs": "^4.2.9",
+            "micromatch": "^4.0.4",
+            "pretty-format": "^29.7.0",
+            "slash": "^3.0.0",
+            "stack-utils": "^2.0.3"
+          }
+        },
+        "jest-mock": {
+          "version": "29.7.0",
+          "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.7.0.tgz",
+          "integrity": "sha512-ITOMZn+UkYS4ZFh83xYAOzWStloNzJFO2s8DWrE4lhtGD+AorgnbkiKERe4wQVBydIGPx059g6riW5Btp6Llnw==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^29.6.3",
+            "@types/node": "*",
+            "jest-util": "^29.7.0"
+          }
+        },
+        "jest-regex-util": {
+          "version": "29.6.3",
+          "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-29.6.3.tgz",
+          "integrity": "sha512-KJJBsRCyyLNWCNBOvZyRDnAIfUiRJ8v+hOBQYGn8gDyF3UegwiP4gwRR3/SDa42g1YbVycTidUF3rKjyLFDWbg==",
+          "dev": true
+        },
+        "jest-resolve": {
+          "version": "29.7.0",
+          "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-29.7.0.tgz",
+          "integrity": "sha512-IOVhZSrg+UvVAshDSDtHyFCCBUl/Q3AAJv8iZ6ZjnZ74xzvwuzLXid9IIIPgTnY62SJjfuupMKZsZQRsCvxEgA==",
+          "dev": true,
+          "requires": {
+            "chalk": "^4.0.0",
+            "graceful-fs": "^4.2.9",
+            "jest-haste-map": "^29.7.0",
+            "jest-pnp-resolver": "^1.2.2",
+            "jest-util": "^29.7.0",
+            "jest-validate": "^29.7.0",
+            "resolve": "^1.20.0",
+            "resolve.exports": "^2.0.0",
+            "slash": "^3.0.0"
+          }
+        },
+        "jest-runner": {
+          "version": "29.7.0",
+          "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-29.7.0.tgz",
+          "integrity": "sha512-fsc4N6cPCAahybGBfTRcq5wFR6fpLznMg47sY5aDpsoejOcVYFb07AHuSnR0liMcPTgBsA3ZJL6kFOjPdoNipQ==",
+          "dev": true,
+          "requires": {
+            "@jest/console": "^29.7.0",
+            "@jest/environment": "^29.7.0",
+            "@jest/test-result": "^29.7.0",
+            "@jest/transform": "^29.7.0",
+            "@jest/types": "^29.6.3",
+            "@types/node": "*",
+            "chalk": "^4.0.0",
+            "emittery": "^0.13.1",
+            "graceful-fs": "^4.2.9",
+            "jest-docblock": "^29.7.0",
+            "jest-environment-node": "^29.7.0",
+            "jest-haste-map": "^29.7.0",
+            "jest-leak-detector": "^29.7.0",
+            "jest-message-util": "^29.7.0",
+            "jest-resolve": "^29.7.0",
+            "jest-runtime": "^29.7.0",
+            "jest-util": "^29.7.0",
+            "jest-watcher": "^29.7.0",
+            "jest-worker": "^29.7.0",
+            "p-limit": "^3.1.0",
+            "source-map-support": "0.5.13"
+          }
+        },
+        "jest-runtime": {
+          "version": "29.7.0",
+          "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-29.7.0.tgz",
+          "integrity": "sha512-gUnLjgwdGqW7B4LvOIkbKs9WGbn+QLqRQQ9juC6HndeDiezIwhDP+mhMwHWCEcfQ5RUXa6OPnFF8BJh5xegwwQ==",
+          "dev": true,
+          "requires": {
+            "@jest/environment": "^29.7.0",
+            "@jest/fake-timers": "^29.7.0",
+            "@jest/globals": "^29.7.0",
+            "@jest/source-map": "^29.6.3",
+            "@jest/test-result": "^29.7.0",
+            "@jest/transform": "^29.7.0",
+            "@jest/types": "^29.6.3",
+            "@types/node": "*",
+            "chalk": "^4.0.0",
+            "cjs-module-lexer": "^1.0.0",
+            "collect-v8-coverage": "^1.0.0",
+            "glob": "^7.1.3",
+            "graceful-fs": "^4.2.9",
+            "jest-haste-map": "^29.7.0",
+            "jest-message-util": "^29.7.0",
+            "jest-mock": "^29.7.0",
+            "jest-regex-util": "^29.6.3",
+            "jest-resolve": "^29.7.0",
+            "jest-snapshot": "^29.7.0",
+            "jest-util": "^29.7.0",
+            "slash": "^3.0.0",
+            "strip-bom": "^4.0.0"
+          }
+        },
+        "jest-snapshot": {
+          "version": "29.7.0",
+          "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-29.7.0.tgz",
+          "integrity": "sha512-Rm0BMWtxBcioHr1/OX5YCP8Uov4riHvKPknOGs804Zg9JGZgmIBkbtlxJC/7Z4msKYVbIJtfU+tKb8xlYNfdkw==",
+          "dev": true,
+          "requires": {
+            "@babel/core": "^7.11.6",
+            "@babel/generator": "^7.7.2",
+            "@babel/plugin-syntax-jsx": "^7.7.2",
+            "@babel/plugin-syntax-typescript": "^7.7.2",
+            "@babel/types": "^7.3.3",
+            "@jest/expect-utils": "^29.7.0",
+            "@jest/transform": "^29.7.0",
+            "@jest/types": "^29.6.3",
+            "babel-preset-current-node-syntax": "^1.0.0",
+            "chalk": "^4.0.0",
+            "expect": "^29.7.0",
+            "graceful-fs": "^4.2.9",
+            "jest-diff": "^29.7.0",
+            "jest-get-type": "^29.6.3",
+            "jest-matcher-utils": "^29.7.0",
+            "jest-message-util": "^29.7.0",
+            "jest-util": "^29.7.0",
+            "natural-compare": "^1.4.0",
+            "pretty-format": "^29.7.0",
+            "semver": "~7.5.2"
+          }
+        },
+        "jest-util": {
+          "version": "29.7.0",
+          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
+          "integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^29.6.3",
+            "@types/node": "*",
+            "chalk": "^4.0.0",
+            "ci-info": "^3.2.0",
+            "graceful-fs": "^4.2.9",
+            "picomatch": "^2.2.3"
+          }
+        },
+        "jest-validate": {
+          "version": "29.7.0",
+          "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-29.7.0.tgz",
+          "integrity": "sha512-ZB7wHqaRGVw/9hST/OuFUReG7M8vKeq0/J2egIGLdvjHCmYqGARhzXmtgi+gVeZ5uXFF219aOc3Ls2yLg27tkw==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^29.6.3",
+            "camelcase": "^6.2.0",
+            "chalk": "^4.0.0",
+            "jest-get-type": "^29.6.3",
+            "leven": "^3.1.0",
+            "pretty-format": "^29.7.0"
+          }
+        },
+        "jest-watcher": {
+          "version": "29.7.0",
+          "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-29.7.0.tgz",
+          "integrity": "sha512-49Fg7WXkU3Vl2h6LbLtMQ/HyB6rXSIX7SqvBLQmssRBGN9I0PNvPmAmCWSOY6SOvrjhI/F7/bGAv9RtnsPA03g==",
+          "dev": true,
+          "requires": {
+            "@jest/test-result": "^29.7.0",
+            "@jest/types": "^29.6.3",
+            "@types/node": "*",
+            "ansi-escapes": "^4.2.1",
+            "chalk": "^4.0.0",
+            "emittery": "^0.13.1",
+            "jest-util": "^29.7.0",
+            "string-length": "^4.0.1"
+          }
+        },
+        "jest-worker": {
+          "version": "29.7.0",
+          "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.7.0.tgz",
+          "integrity": "sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==",
+          "dev": true,
+          "requires": {
+            "@types/node": "*",
+            "jest-util": "^29.7.0",
+            "merge-stream": "^2.0.0",
+            "supports-color": "^8.0.0"
+          },
+          "dependencies": {
+            "supports-color": {
+              "version": "8.1.1",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+              "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+              "dev": true,
+              "requires": {
+                "has-flag": "^4.0.0"
+              }
+            }
+          }
+        },
+        "p-limit": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+          "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+          "dev": true,
+          "requires": {
+            "yocto-queue": "^0.1.0"
+          }
+        },
+        "pretty-format": {
+          "version": "29.7.0",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+          "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+          "dev": true,
+          "requires": {
+            "@jest/schemas": "^29.6.3",
+            "ansi-styles": "^5.0.0",
+            "react-is": "^18.0.0"
+          },
+          "dependencies": {
+            "ansi-styles": {
+              "version": "5.2.0",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+              "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+              "dev": true
+            }
+          }
+        },
+        "react-is": {
+          "version": "18.2.0",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+          "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
+          "dev": true
+        },
+        "resolve.exports": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-2.0.2.tgz",
+          "integrity": "sha512-X2UW6Nw3n/aMgDVy+0rSqgHlv39WZAlZrXCdnbyEiKm17DSqHX4MmQMaST3FbeWR5FTuRcUwYAziZajji0Y7mg==",
+          "dev": true
+        },
+        "source-map-support": {
+          "version": "0.5.13",
+          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
+          "integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
+          "dev": true,
+          "requires": {
+            "buffer-from": "^1.0.0",
+            "source-map": "^0.6.0"
+          }
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        },
+        "write-file-atomic": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.2.tgz",
+          "integrity": "sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==",
+          "dev": true,
+          "requires": {
+            "imurmurhash": "^0.1.4",
+            "signal-exit": "^3.0.7"
+          }
+        }
+      }
+    },
     "cross-spawn": {
       "version": "7.0.3",
       "dev": true,
@@ -29277,6 +31529,32 @@
       "version": "0.7.0",
       "dev": true
     },
+    "deep-equal": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.2.2.tgz",
+      "integrity": "sha512-xjVyBf0w5vH0I42jdAZzOKVldmPgSulmiyPRywoyq7HXC9qdgo17kxJE+rdnif5Tz6+pIrpJI8dCpMNLIGkUiA==",
+      "dev": true,
+      "requires": {
+        "array-buffer-byte-length": "^1.0.0",
+        "call-bind": "^1.0.2",
+        "es-get-iterator": "^1.1.3",
+        "get-intrinsic": "^1.2.1",
+        "is-arguments": "^1.1.1",
+        "is-array-buffer": "^3.0.2",
+        "is-date-object": "^1.0.5",
+        "is-regex": "^1.1.4",
+        "is-shared-array-buffer": "^1.0.2",
+        "isarray": "^2.0.5",
+        "object-is": "^1.1.5",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.4",
+        "regexp.prototype.flags": "^1.5.0",
+        "side-channel": "^1.0.4",
+        "which-boxed-primitive": "^1.0.2",
+        "which-collection": "^1.0.1",
+        "which-typed-array": "^1.1.9"
+      }
+    },
     "deep-extend": {
       "version": "0.6.0"
     },
@@ -29295,7 +31573,9 @@
       }
     },
     "define-properties": {
-      "version": "1.1.4",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.0.tgz",
+      "integrity": "sha512-xvqAVKGfT1+UAvPwKTVw/njhdQ8ZhXK4lI0bCIuCMrp2up9nPnaDftrLtmpTazqd1o+UY4zgzU+avtMbDP+ldA==",
       "dev": true,
       "requires": {
         "has-property-descriptors": "^1.0.0",
@@ -29557,6 +31837,23 @@
         "which-typed-array": "^1.1.9"
       }
     },
+    "es-get-iterator": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.3.tgz",
+      "integrity": "sha512-sPZmqHBe6JIiTfN5q2pEi//TwxmAFHwj/XEuYjTuse78i8KxaqMTTzxPoFKuzRpDpTJ+0NAbpfenkmH2rePtuw==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.1.3",
+        "has-symbols": "^1.0.3",
+        "is-arguments": "^1.1.1",
+        "is-map": "^2.0.2",
+        "is-set": "^2.0.2",
+        "is-string": "^1.0.7",
+        "isarray": "^2.0.5",
+        "stop-iteration-iterator": "^1.0.0"
+      }
+    },
     "es-set-tostringtag": {
       "version": "2.0.1",
       "dev": true,
@@ -29599,7 +31896,7 @@
         "esprima": "^4.0.1",
         "estraverse": "^5.2.0",
         "esutils": "^2.0.2",
-        "optionator": "^0.8.1",
+        "optionator": "0.9.3",
         "source-map": "~0.6.1"
       }
     },
@@ -30646,6 +32943,16 @@
         "loose-envify": "^1.0.0"
       }
     },
+    "is-arguments": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
+      "integrity": "sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "has-tostringtag": "^1.0.0"
+      }
+    },
     "is-array-buffer": {
       "version": "3.0.2",
       "dev": true,
@@ -30720,6 +33027,12 @@
         "is-extglob": "^2.1.1"
       }
     },
+    "is-map": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.2.tgz",
+      "integrity": "sha512-cOZFQQozTha1f4MxLFzlgKYPTyj26picdZTx82hbc/Xf4K/tZOOXSCkMvU4pKioRXGDLJRn0GM7Upe7kR721yg==",
+      "dev": true
+    },
     "is-negative-zero": {
       "version": "2.0.2",
       "dev": true
@@ -30777,6 +33090,12 @@
         "has-tostringtag": "^1.0.0"
       }
     },
+    "is-set": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.2.tgz",
+      "integrity": "sha512-+2cnTEZeY5z/iXGbLhPrOAaK/Mau5k5eXq9j14CpRTftq0pAJu2MwVRSZhyZWBzx3o6X795Lz6Bpb6R0GKf37g==",
+      "dev": true
+    },
     "is-shared-array-buffer": {
       "version": "1.0.2",
       "dev": true,
@@ -30827,6 +33146,12 @@
     "is-typedarray": {
       "version": "1.0.0"
     },
+    "is-weakmap": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.1.tgz",
+      "integrity": "sha512-NSBR4kH5oVj1Uwvv970ruUkCV7O1mzgVFO4/rev2cLRda9Tm9HrL70ZPut4rOHgY0FNrUu9BCbXA2sdQ+x0chA==",
+      "dev": true
+    },
     "is-weakref": {
       "version": "1.0.2",
       "dev": true,
@@ -30834,11 +33159,27 @@
         "call-bind": "^1.0.2"
       }
     },
+    "is-weakset": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.2.tgz",
+      "integrity": "sha512-t2yVvttHkQktwnNNmBQ98AhENLdPUTDTE21uPqAQ0ARwQfGeQKRVS0NNurH7bTf7RrvcVn1OOge45CnBeHCSmg==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.1.1"
+      }
+    },
     "is-what": {
       "version": "4.1.15"
     },
     "is-windows": {
       "version": "1.0.2",
+      "dev": true
+    },
+    "isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
       "dev": true
     },
     "isexe": {
@@ -30864,7 +33205,7 @@
         "@babel/parser": "^7.14.7",
         "@istanbuljs/schema": "^0.1.2",
         "istanbul-lib-coverage": "^3.2.0",
-        "semver": "^6.3.0"
+        "semver": "~7.5.2"
       }
     },
     "istanbul-lib-report": {
@@ -31713,7 +34054,7 @@
         "jest-util": "^27.5.1",
         "natural-compare": "^1.4.0",
         "pretty-format": "^27.5.1",
-        "semver": "^7.3.2"
+        "semver": "~7.5.2"
       },
       "dependencies": {
         "ansi-styles": {
@@ -32150,7 +34491,7 @@
       "version": "3.1.0",
       "dev": true,
       "requires": {
-        "semver": "^6.0.0"
+        "semver": "~7.5.2"
       }
     },
     "make-error": {
@@ -32317,6 +34658,56 @@
         "postcss": "8.4.14",
         "styled-jsx": "5.0.6",
         "use-sync-external-store": "1.2.0"
+      },
+      "dependencies": {
+        "@next/swc-darwin-arm64": {
+          "version": "12.3.0",
+          "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-12.3.0.tgz",
+          "integrity": "sha512-9s4d3Mhii+WFce8o8Jok7WC3Bawkr9wEUU++SJRptjU1L5tsfYJMrSYCACHLhZujziNDLyExe4Hwwsccps1sfg==",
+          "optional": true
+        },
+        "@next/swc-linux-arm64-gnu": {
+          "version": "12.3.0",
+          "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-12.3.0.tgz",
+          "integrity": "sha512-RqJHDKe0WImeUrdR0kayTkRWgp4vD/MS7g0r6Xuf8+ellOFH7JAAJffDW3ayuVZeMYOa7RvgNFcOoWnrTUl9Nw==",
+          "optional": true
+        },
+        "@next/swc-linux-arm64-musl": {
+          "version": "12.3.0",
+          "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-12.3.0.tgz",
+          "integrity": "sha512-nvNWoUieMjvDjpYJ/4SQe9lQs2xMj6ZRs8N+bmTrVu9leY2Fg3WD6W9p/1uU9hGO8u+OdF13wc4iRShu/WYIHg==",
+          "optional": true
+        },
+        "@next/swc-linux-x64-gnu": {
+          "version": "12.3.0",
+          "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-12.3.0.tgz",
+          "integrity": "sha512-4ajhIuVU9PeQCMMhdDgZTLrHmjbOUFuIyg6J19hZqwEwDTSqQyrSLkbJs2Nd7IRiM6Ul/XyrtEFCpk4k+xD2+w==",
+          "optional": true
+        },
+        "@next/swc-linux-x64-musl": {
+          "version": "12.3.0",
+          "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-12.3.0.tgz",
+          "integrity": "sha512-U092RBYbaGxoMAwpauePJEu2PuZSEoUCGJBvsptQr2/2XIMwAJDYM4c/M5NfYEsBr+yjvsYNsOpYfeQ88D82Yg==",
+          "optional": true
+        },
+        "@next/swc-win32-arm64-msvc": {
+          "version": "12.3.0",
+          "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-12.3.0.tgz",
+          "integrity": "sha512-pzSzaxjDEJe67bUok9Nxf9rykbJfHXW0owICFsPBsqHyc+cr8vpF7g9e2APTCddtVhvjkga9ILoZJ9NxWS7Yiw==",
+          "optional": true
+        },
+        "@next/swc-win32-ia32-msvc": {
+          "version": "12.3.0",
+          "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-12.3.0.tgz",
+          "integrity": "sha512-MQGUpMbYhQmTZ06a9e0hPQJnxFMwETo2WtyAotY3GEzbNCQVbCGhsvqEKcl+ZEHgShlHXUWvSffq1ZscY6gK7A==",
+          "optional": true
+        },
+        "@next/swc-win32-x64-msvc": {
+          "version": "12.3.0",
+          "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-12.3.0.tgz",
+          "integrity": "sha512-C/nw6OgQpEULWqs+wgMHXGvlJLguPRFFGqR2TAqWBerQ8J+Sg3z1ZTqwelkSi4FoqStGuZ2UdFHIDN1ySmR1xA==",
+          "optional": true
+        }
       }
     },
     "no-case": {
@@ -32329,7 +34720,7 @@
     "node-abi": {
       "version": "3.24.0",
       "requires": {
-        "semver": "^7.3.5"
+        "semver": "~7.5.2"
       }
     },
     "node-addon-api": {
@@ -32397,6 +34788,16 @@
     "object-inspect": {
       "version": "1.12.3",
       "dev": true
+    },
+    "object-is": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.5.tgz",
+      "integrity": "sha512-3cyDsyHgtmi7I7DfSSI2LDp6SK2lwvtbg0p0R1e0RvTqF5ceGx+K2dfSjm1bKDMVCFEDAQvy+o8c6a7VujOddw==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3"
+      }
     },
     "object-keys": {
       "version": "1.1.1",
@@ -33018,12 +35419,14 @@
       "version": "0.13.11"
     },
     "regexp.prototype.flags": {
-      "version": "1.4.3",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.0.tgz",
+      "integrity": "sha512-0SutC3pNudRKgquxGoRGIz946MZVHqbNfPjBdxeOhBrdgDKlRoXmYLQN9xRbrR09ZXWeGAdPuif7egofn6v5LA==",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3",
-        "functions-have-names": "^1.2.2"
+        "define-properties": "^1.2.0",
+        "functions-have-names": "^1.2.3"
       }
     },
     "regexpp": {
@@ -33167,7 +35570,7 @@
         "detect-libc": "^2.0.1",
         "node-addon-api": "^5.0.0",
         "prebuild-install": "^7.1.1",
-        "semver": "^7.3.7",
+        "semver": "~7.5.2",
         "simple-get": "^4.0.1",
         "tar-fs": "^2.1.1",
         "tunnel-agent": "^0.6.0"
@@ -33541,6 +35944,15 @@
         }
       }
     },
+    "stop-iteration-iterator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.0.0.tgz",
+      "integrity": "sha512-iCGQj+0l0HOdZ2AEeBADlsRC+vsnDsZsbdSiH1yNSjcfKM7fdpCMfqAL/dwF5BLiw/XhRft/Wax6zQbhq2BcjQ==",
+      "dev": true,
+      "requires": {
+        "internal-slot": "^1.0.4"
+      }
+    },
     "stream-transform": {
       "version": "2.1.3",
       "dev": true,
@@ -33869,7 +36281,7 @@
         "json5": "2.x",
         "lodash.memoize": "4.x",
         "make-error": "1.x",
-        "semver": "7.x",
+        "semver": "~7.5.2",
         "yargs-parser": "20.x"
       },
       "dependencies": {
@@ -33886,7 +36298,7 @@
         "chalk": "^4.1.0",
         "enhanced-resolve": "^5.0.0",
         "micromatch": "^4.0.0",
-        "semver": "^7.3.4"
+        "semver": "~7.5.2"
       },
       "dependencies": {
         "ansi-styles": {
@@ -34347,6 +36759,18 @@
         "is-symbol": "^1.0.3"
       }
     },
+    "which-collection": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.1.tgz",
+      "integrity": "sha512-W8xeTUwaln8i3K/cY1nGXzdnVZlidBcagyNFtBdD5kxnb4TvGKR7FfSIS3mYpwWS1QUCutfKz8IY8RjftB0+1A==",
+      "dev": true,
+      "requires": {
+        "is-map": "^2.0.1",
+        "is-set": "^2.0.1",
+        "is-weakmap": "^2.0.1",
+        "is-weakset": "^2.0.1"
+      }
+    },
     "which-module": {
       "version": "2.0.0"
     },
@@ -34508,54 +36932,6 @@
     },
     "zod": {
       "version": "3.21.4"
-    },
-    "@next/swc-darwin-arm64": {
-      "version": "13.4.13",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.4.13.tgz",
-      "integrity": "sha512-ZptVhHjzUuivnXMNCJ6lER33HN7lC+rZ01z+PM10Ows21NHFYMvGhi5iXkGtBDk6VmtzsbqnAjnx4Oz5um0FjA==",
-      "optional": true
-    },
-    "@next/swc-linux-arm64-gnu": {
-      "version": "13.4.13",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-13.4.13.tgz",
-      "integrity": "sha512-xEHUqC8eqR5DHe8SOmMnDU1K3ggrJ28uIKltrQAwqFSSSmzjnN/XMocZkcVhuncuxYrpbri0iMQstRyRVdQVWg==",
-      "optional": true
-    },
-    "@next/swc-linux-arm64-musl": {
-      "version": "13.4.13",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-13.4.13.tgz",
-      "integrity": "sha512-sNf3MnLAm8rquSSAoeD9nVcdaDeRYOeey4stOWOyWIgbBDtP+C93amSgH/LPTDoUV7gNiU6f+ghepTjTjRgIUQ==",
-      "optional": true
-    },
-    "@next/swc-linux-x64-gnu": {
-      "version": "13.4.13",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-13.4.13.tgz",
-      "integrity": "sha512-WhcRaJJSHyx9OWmKjjz+OWHumiPZWRqmM/09Bt7Up4UqUJFFhGExeztR4trtv3rflvULatu9IH/nTV8fUUgaMA==",
-      "optional": true
-    },
-    "@next/swc-linux-x64-musl": {
-      "version": "13.4.13",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-13.4.13.tgz",
-      "integrity": "sha512-+Y4LLhOWWZQIDKVwr2R17lq2KSN0F1c30QVgGIWfnjjHpH8nrIWHEndhqYU+iFuW8It78CiJjQKTw4f51HD7jA==",
-      "optional": true
-    },
-    "@next/swc-win32-arm64-msvc": {
-      "version": "13.4.13",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-13.4.13.tgz",
-      "integrity": "sha512-rWurdOR20uxjfqd1X9vDAgv0Jb26KjyL8akF9CBeFqX8rVaBAnW/Wf6A2gYEwyYY4Bai3T7p1kro6DFrsvBAAw==",
-      "optional": true
-    },
-    "@next/swc-win32-ia32-msvc": {
-      "version": "13.4.13",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-13.4.13.tgz",
-      "integrity": "sha512-E8bSPwRuY5ibJ3CzLQmJEt8qaWrPYuUTwnrwygPUEWoLzD5YRx9SD37oXRdU81TgGwDzCxpl7z5Nqlfk50xAog==",
-      "optional": true
-    },
-    "@next/swc-win32-x64-msvc": {
-      "version": "13.4.13",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-13.4.13.tgz",
-      "integrity": "sha512-4KlyC6jWRubPnppgfYsNTPeWfGCxtWLh5vaOAW/kdzAk9widqho8Qb5S4K2vHmal1tsURi7Onk2MMCV1phvyqA==",
-      "optional": true
     }
   }
 }

--- a/plugins/faustwp/includes/replacement/callbacks.php
+++ b/plugins/faustwp/includes/replacement/callbacks.php
@@ -233,8 +233,15 @@ add_action( 'enqueue_block_editor_assets', __NAMESPACE__ . '\\enqueue_preview_sc
  * XXX: Please remove this once this issue is resolved: https://github.com/WordPress/gutenberg/issues/13998
  */
 function enqueue_preview_scripts() {
-	wp_enqueue_script( 'faustwp-gutenberg-filters', plugins_url( '/previewlinks.js', __FILE__ ), array( 'jquery' ), plugin_version(), true );
-	wp_localize_script( 'faustwp-gutenberg-filters', '_faustwp_preview_link', array( '_preview_link' => get_preview_post_link() ) );
+	wp_enqueue_script( 'faustwp-gutenberg-filters', plugins_url( '/previewlinks.js', __FILE__ ), array(), plugin_version(), true );
+	wp_localize_script(
+		'faustwp-gutenberg-filters',
+		'_faustwp_preview_data',
+		array(
+			'_preview_link' => get_preview_post_link(),
+			'_wp_version'   => get_bloginfo( 'version' ),
+		)
+	);
 }
 
 add_filter( 'wp_sitemaps_posts_entry', __NAMESPACE__ . '\\sitemaps_posts_entry' );


### PR DESCRIPTION
## Tasks

- [X] I have signed a [Contributor License Agreement (CLA)](https://github.com/wpengine/faustjs#contributor-license-agreement) with WP Engine.
- [X] If a code change, I have written testing instructions that the whole team & outside contributors can understand.
- [X] I have written and included a comprehensive [changeset](https://github.com/wpengine/faustjs/blob/canary/DEVELOPMENT.md#deployment) to properly document the changes I've made.

## Description

These changes include a proposed fix for https://github.com/wpengine/faustjs/issues/1561.

<img width="1698" alt="wp-admin block editor interface showing preview button locations" src="https://github.com/wpengine/faustjs/assets/6676674/1d300657-a3be-462d-b51a-e5f070c6d486">

## Testing

1. Checkout this branch that includes changes to the **faustwp** plugin: `MERL-1205-refactor-custom-preview`
2. Using the updated **faustwp** plugin, create a new post & save as draft (do not publish)
3. Observe that both preview links correctly resolve to display draft content