### PR TITLE
Merl 1153 faustwp block editor block controls implement checkbox control

### DIFF
--- a/.changeset/curly-toes-cross.md
+++ b/.changeset/curly-toes-cross.md
@@ -1,0 +1,6 @@
+---
+"@faustwp/block-editor-utils": patch
+---
+
+Feat: Add `CheckboxControl` field in `block-editor-utils`.
+

--- a/packages/block-editor-utils/src/controls/Checkbox.tsx
+++ b/packages/block-editor-utils/src/controls/Checkbox.tsx
@@ -10,8 +10,6 @@ function Checkbox<T extends Record<string, any>>({
     props.setAttributes({ [config.name]: newContent });
   };
   return (
-    // TODO: ensure contents match CheckControl in Block Editor- what is help value?
-    // https://developer.wordpress.org/block-editor/reference-guides/components/checkbox-control/#usage-2
     <CheckboxControl
       label={config.label}
       checked={props.attributes[config.name]}

--- a/packages/block-editor-utils/src/controls/Checkbox.tsx
+++ b/packages/block-editor-utils/src/controls/Checkbox.tsx
@@ -14,7 +14,6 @@ function Checkbox<T extends Record<string, any>>({
     // https://developer.wordpress.org/block-editor/reference-guides/components/checkbox-control/#usage-2
     <CheckboxControl
       label={config.label}
-      help={props.attributes[config.help]}
       checked={props.attributes[config.name]}
       onChange={onChange}
     />

--- a/packages/block-editor-utils/src/controls/Checkbox.tsx
+++ b/packages/block-editor-utils/src/controls/Checkbox.tsx
@@ -1,0 +1,24 @@
+import * as React from 'react';
+import { CheckboxControl } from '@wordpress/components';
+import { ControlProps } from '../types/index.js';
+
+function Checkbox<T extends Record<string, any>>({
+  config,
+  props,
+}: ControlProps<T>) {
+  const onChange = (newContent: boolean) => {
+    props.setAttributes({ [config.name]: newContent });
+  };
+  return (
+    // TODO: ensure contents match CheckControl in Block Editor- what is help value?
+    // https://developer.wordpress.org/block-editor/reference-guides/components/checkbox-control/#usage-2
+    <CheckboxControl
+      label={config.label}
+      help={props.attributes[config.help]}
+      checked={props.attributes[config.name]}
+      onChange={onChange}
+    />
+  );
+}
+
+export default Checkbox;

--- a/packages/block-editor-utils/src/controls/index.ts
+++ b/packages/block-editor-utils/src/controls/index.ts
@@ -12,4 +12,3 @@ registerControl('color', Color);
 registerControl('checkbox', Checkbox);
 registerControl('select', Select);
 registerControl('radio', Radio);
-

--- a/packages/block-editor-utils/src/controls/index.ts
+++ b/packages/block-editor-utils/src/controls/index.ts
@@ -2,7 +2,9 @@ import registerControl from '../helpers/registerControl.js';
 import Text from './Text.js';
 import NumberField from './Number.js';
 import Color from './Color.js';
+import Checkbox from './Checkbox.js';
 
 registerControl('text', Text);
 registerControl('number', NumberField);
 registerControl('color', Color);
+registerControl('checkbox', Checkbox);

--- a/packages/block-editor-utils/src/types/index.d.ts
+++ b/packages/block-editor-utils/src/types/index.d.ts
@@ -19,6 +19,7 @@ export type Field = {
   location: FieldLocation;
   label?: string;
   default?: unknown;
+  help?: string;
 }
 
 export type FieldType = "string" | "number" | "boolean" | "integer" | "object" | "array"

--- a/packages/block-editor-utils/src/types/index.d.ts
+++ b/packages/block-editor-utils/src/types/index.d.ts
@@ -19,7 +19,6 @@ export type Field = {
   location: FieldLocation;
   label?: string;
   default?: unknown;
-  help?: string;
 }
 
 export type FieldType = "string" | "number" | "boolean" | "integer" | "object" | "array"

--- a/packages/block-editor-utils/tests/controls/Checkbox.test.tsx
+++ b/packages/block-editor-utils/tests/controls/Checkbox.test.tsx
@@ -26,6 +26,8 @@ const config: Field = {
   name: "checkboxField",
   type: "boolean"
 };
+
+// This should set the checkbox value (aka check the box)
 const props = {
   setAttributes: jest.fn(),
   attributes: {

--- a/packages/block-editor-utils/tests/controls/Checkbox.test.tsx
+++ b/packages/block-editor-utils/tests/controls/Checkbox.test.tsx
@@ -1,67 +1,59 @@
-// import React from 'react';
-// import { screen, render } from '@testing-library/react';
-// import Checkbox from '../../src/controls/Checkbox';
-// import { Field } from '../../src/types';
+import React from 'react';
+import { screen, render } from '@testing-library/react';
+import Checkbox from '../../src/controls/Checkbox';
+import { Field } from '../../src/types';
 
-// Object.defineProperty(window, 'matchMedia', {
-//     writable: true,
-//     value: jest.fn().mockImplementation(query => ({
-//       matches: false,
-//       media: query,
-//       onchange: null,
-//       addListener: jest.fn(), // Deprecated
-//       removeListener: jest.fn(), // Deprecated
-//       addEventListener: jest.fn(),
-//       removeEventListener: jest.fn(),
-//       dispatchEvent: jest.fn(),
-//     })),
-//   });
+Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: jest.fn().mockImplementation(query => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: jest.fn(), // Deprecated
+      removeListener: jest.fn(), // Deprecated
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+      dispatchEvent: jest.fn(),
+    })),
+  });
 
-// const config: Field = {
-//   label: 'radioField',
-//   name: 'radioField',
-//   type: 'string',
-//   control: 'radio',
-//   location: 'inspector',
-//   options: [
-//     {
-//       label: 'Red',
-//       value: 'red',
-//     },
-//     {
-//       label: 'Blue',
-//       value: 'blue',
-//     },
-//   ],
-// };
-// const props = {
-//   setAttributes: jest.fn(),
-//   attributes: {
-//     radioField: 'red',
-//   },
-// };
+const config: Field = {
+  location: "inspector",
+  control: "checkbox",
+  label: 'checkboxField', 
+  default: "false",
+  help: "here is help",
+  name: "checkboxField",
+  type: "boolean"
+};
+const props = {
+  setAttributes: jest.fn(),
+  attributes: {
+    checkboxField: "1",
+  },
+};
 
-// const setup = () => {
-//   const utils = render(<Checkbox config={config} props={props} />);
-//   const input = screen.findAllByDisplayValue(props.attributes.radioField!);
-//   return {
-//     input,
-//     ...utils,
-//   };
-// };
+const setup = () => {
+  const utils = render(<Checkbox config={config} props={props} />);
+  const input = screen.findAllByDisplayValue(props.attributes.checkboxField!);
+  return {
+    input,
+    ...utils,
+  };
+};
 
-// afterEach(() => {
-//   jest.clearAllMocks();
-// });
+afterEach(() => {
+  jest.clearAllMocks();
+});
 
-// describe('Checkbox', () => {
-//   it('should mount', () => {
-//     const { input } = setup();
-//     expect(input).toBeTruthy();
-//   });
+describe('Checkbox', () => {
+  it('should mount', () => {
+    const { input } = setup();
+    expect(input).toBeTruthy();
+  });
 
-//   it('should have correct display value from props', () => {
-//     setup();
-//     expect(screen.getByDisplayValue(props.attributes.radioField)).toBeTruthy();
-//   });
-// });
+  it('should have correct display value from props', () => {
+    setup();
+    expect(screen.getByDisplayValue(props.attributes.checkboxField)).toBeTruthy();
+  });
+});

--- a/packages/block-editor-utils/tests/controls/Checkbox.test.tsx
+++ b/packages/block-editor-utils/tests/controls/Checkbox.test.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
-import { screen, render } from '@testing-library/react';
+import { screen, render, fireEvent } from '@testing-library/react';
 import Checkbox from '../../src/controls/Checkbox';
 import { Field } from '../../src/types';
+import { useState } from 'react';
+import '@testing-library/jest-dom'; 
 
 Object.defineProperty(window, 'matchMedia', {
     writable: true,
@@ -22,7 +24,6 @@ const config: Field = {
   control: "checkbox",
   label: 'checkboxField', 
   default: "false",
-  help: "here is help",
   name: "checkboxField",
   type: "boolean"
 };
@@ -48,10 +49,85 @@ afterEach(() => {
   jest.clearAllMocks();
 });
 
+
+// FireEvent for click
+// fireEvent.change(getByLabelText(/username/i), {target: {value: 'a'}})
+
+//fire event:
+// const Button = ({onClick, children}) => (
+//   <button onClick={onClick}>{children}</button>
+// )
+
+// test('calls onClick prop when clicked', () => {
+//   const handleClick = jest.fn()
+//   render(<Button onClick={handleClick}>Click Me</Button>)
+//   fireEvent.click(screen.getByText(/click me/i))
+//   expect(handleClick).toHaveBeenCalledTimes(1)
+// })
+
+// describe('Checkbox is checked', () => {
+//   test('should pass', () => {
+//     const Wrap = () => {
+//       const [isChecked, setIsChecked] = useState(false);
+//       return <CheckBox isChecked={isChecked} onChange={() => setIsChecked(!isChecked)} />;
+//     };
+//     const { container } = render(<Wrap />);
+//     const checkbox = container.querySelectorAll("input[type='checkbox']")[0] as HTMLInputElement;
+//     fireEvent.click(checkbox);
+//     expect(checkbox.checked).toBe(true);
+//   });
+// });
+
 describe('Checkbox', () => {
   it('should mount', () => {
     const { input } = setup();
     expect(input).toBeTruthy();
+  });
+
+  // it('should pass', () => {
+  //   const Wrap = () => {
+  //     const [isChecked, setIsChecked] = useState(false);
+  //     return <Checkbox isChecked={isChecked} onChange={() => setIsChecked(!isChecked)} />;
+  //   };
+  //   const { container } = render(<Wrap />);
+  //   const checkbox = container.querySelectorAll("input[type='checkbox']")[0] as HTMLInputElement;
+  //   fireEvent.click(checkbox);
+  //   expect(checkbox.checked).toBe(true);
+  // });
+
+//   (method) TestingLibraryMatchers<(str: string) => any, void>.toBeChecked(): void
+// @description
+// Assert whether the given element is checked.
+
+// It accepts an input of type checkbox or radio and elements with a role of radio with a valid aria-checked attribute of "true" or "false".
+
+// @example
+
+// <input
+//   type="checkbox"
+//   checked
+//   data-testid="input-checkbox" />
+
+// const inputCheckbox = getByTestId('input-checkbox')
+
+// expect(inputCheckbox).toBeChecked()
+// expect(inputRadio).not.toBeChecked()
+
+  it("checks that checkbox gets checked", () => {
+    render(
+      <input
+        type="checkbox"
+        aria-label="checkbox"
+        name="checkbox-array"
+        value="second"
+        id="second"
+      />
+    );
+
+    const checkbox = screen.getByRole("checkbox", { name: "checkbox" });
+    expect(checkbox).not.toBeChecked();
+    fireEvent.click(checkbox);
+    expect(checkbox).toBeChecked();
   });
 
   it('should have correct display value from props', () => {

--- a/packages/block-editor-utils/tests/controls/Checkbox.test.tsx
+++ b/packages/block-editor-utils/tests/controls/Checkbox.test.tsx
@@ -60,9 +60,6 @@ describe('Checkbox', () => {
       <input
         type="checkbox"
         aria-label="checkbox"
-        name="checkbox-array"
-        value="second"
-        id="second"
       />,
     );
 

--- a/packages/block-editor-utils/tests/controls/Checkbox.test.tsx
+++ b/packages/block-editor-utils/tests/controls/Checkbox.test.tsx
@@ -3,36 +3,36 @@ import { screen, render, fireEvent } from '@testing-library/react';
 import Checkbox from '../../src/controls/Checkbox';
 import { Field } from '../../src/types';
 import { useState } from 'react';
-import '@testing-library/jest-dom'; 
+import '@testing-library/jest-dom';
 
 Object.defineProperty(window, 'matchMedia', {
-    writable: true,
-    value: jest.fn().mockImplementation(query => ({
-      matches: false,
-      media: query,
-      onchange: null,
-      addListener: jest.fn(), // Deprecated
-      removeListener: jest.fn(), // Deprecated
-      addEventListener: jest.fn(),
-      removeEventListener: jest.fn(),
-      dispatchEvent: jest.fn(),
-    })),
-  });
+  writable: true,
+  value: jest.fn().mockImplementation((query) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: jest.fn(), // Deprecated
+    removeListener: jest.fn(), // Deprecated
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+    dispatchEvent: jest.fn(),
+  })),
+});
 
 const config: Field = {
-  location: "inspector",
-  control: "checkbox",
-  label: 'checkboxField', 
-  default: "false",
-  name: "checkboxField",
-  type: "boolean"
+  location: 'inspector',
+  control: 'checkbox',
+  label: 'checkboxField',
+  default: 'false',
+  name: 'checkboxField',
+  type: 'boolean',
 };
 
 // This should set the checkbox value (aka check the box)
 const props = {
   setAttributes: jest.fn(),
   attributes: {
-    checkboxField: "1",
+    checkboxField: '1',
   },
 };
 
@@ -49,71 +49,13 @@ afterEach(() => {
   jest.clearAllMocks();
 });
 
-
-// FireEvent for click
-// fireEvent.change(getByLabelText(/username/i), {target: {value: 'a'}})
-
-//fire event:
-// const Button = ({onClick, children}) => (
-//   <button onClick={onClick}>{children}</button>
-// )
-
-// test('calls onClick prop when clicked', () => {
-//   const handleClick = jest.fn()
-//   render(<Button onClick={handleClick}>Click Me</Button>)
-//   fireEvent.click(screen.getByText(/click me/i))
-//   expect(handleClick).toHaveBeenCalledTimes(1)
-// })
-
-// describe('Checkbox is checked', () => {
-//   test('should pass', () => {
-//     const Wrap = () => {
-//       const [isChecked, setIsChecked] = useState(false);
-//       return <CheckBox isChecked={isChecked} onChange={() => setIsChecked(!isChecked)} />;
-//     };
-//     const { container } = render(<Wrap />);
-//     const checkbox = container.querySelectorAll("input[type='checkbox']")[0] as HTMLInputElement;
-//     fireEvent.click(checkbox);
-//     expect(checkbox.checked).toBe(true);
-//   });
-// });
-
 describe('Checkbox', () => {
   it('should mount', () => {
     const { input } = setup();
     expect(input).toBeTruthy();
   });
 
-  // it('should pass', () => {
-  //   const Wrap = () => {
-  //     const [isChecked, setIsChecked] = useState(false);
-  //     return <Checkbox isChecked={isChecked} onChange={() => setIsChecked(!isChecked)} />;
-  //   };
-  //   const { container } = render(<Wrap />);
-  //   const checkbox = container.querySelectorAll("input[type='checkbox']")[0] as HTMLInputElement;
-  //   fireEvent.click(checkbox);
-  //   expect(checkbox.checked).toBe(true);
-  // });
-
-//   (method) TestingLibraryMatchers<(str: string) => any, void>.toBeChecked(): void
-// @description
-// Assert whether the given element is checked.
-
-// It accepts an input of type checkbox or radio and elements with a role of radio with a valid aria-checked attribute of "true" or "false".
-
-// @example
-
-// <input
-//   type="checkbox"
-//   checked
-//   data-testid="input-checkbox" />
-
-// const inputCheckbox = getByTestId('input-checkbox')
-
-// expect(inputCheckbox).toBeChecked()
-// expect(inputRadio).not.toBeChecked()
-
-  it("checks that checkbox gets checked", () => {
+  it('checks that checkbox gets checked', () => {
     render(
       <input
         type="checkbox"
@@ -121,10 +63,10 @@ describe('Checkbox', () => {
         name="checkbox-array"
         value="second"
         id="second"
-      />
+      />,
     );
 
-    const checkbox = screen.getByRole("checkbox", { name: "checkbox" });
+    const checkbox = screen.getByRole('checkbox', { name: 'checkbox' });
     expect(checkbox).not.toBeChecked();
     fireEvent.click(checkbox);
     expect(checkbox).toBeChecked();
@@ -132,6 +74,8 @@ describe('Checkbox', () => {
 
   it('should have correct display value from props', () => {
     setup();
-    expect(screen.getByDisplayValue(props.attributes.checkboxField)).toBeTruthy();
+    expect(
+      screen.getByDisplayValue(props.attributes.checkboxField),
+    ).toBeTruthy();
   });
 });

--- a/packages/block-editor-utils/tests/controls/Checkbox.test.tsx
+++ b/packages/block-editor-utils/tests/controls/Checkbox.test.tsx
@@ -1,0 +1,67 @@
+// import React from 'react';
+// import { screen, render } from '@testing-library/react';
+// import Checkbox from '../../src/controls/Checkbox';
+// import { Field } from '../../src/types';
+
+// Object.defineProperty(window, 'matchMedia', {
+//     writable: true,
+//     value: jest.fn().mockImplementation(query => ({
+//       matches: false,
+//       media: query,
+//       onchange: null,
+//       addListener: jest.fn(), // Deprecated
+//       removeListener: jest.fn(), // Deprecated
+//       addEventListener: jest.fn(),
+//       removeEventListener: jest.fn(),
+//       dispatchEvent: jest.fn(),
+//     })),
+//   });
+
+// const config: Field = {
+//   label: 'radioField',
+//   name: 'radioField',
+//   type: 'string',
+//   control: 'radio',
+//   location: 'inspector',
+//   options: [
+//     {
+//       label: 'Red',
+//       value: 'red',
+//     },
+//     {
+//       label: 'Blue',
+//       value: 'blue',
+//     },
+//   ],
+// };
+// const props = {
+//   setAttributes: jest.fn(),
+//   attributes: {
+//     radioField: 'red',
+//   },
+// };
+
+// const setup = () => {
+//   const utils = render(<Checkbox config={config} props={props} />);
+//   const input = screen.findAllByDisplayValue(props.attributes.radioField!);
+//   return {
+//     input,
+//     ...utils,
+//   };
+// };
+
+// afterEach(() => {
+//   jest.clearAllMocks();
+// });
+
+// describe('Checkbox', () => {
+//   it('should mount', () => {
+//     const { input } = setup();
+//     expect(input).toBeTruthy();
+//   });
+
+//   it('should have correct display value from props', () => {
+//     setup();
+//     expect(screen.getByDisplayValue(props.attributes.radioField)).toBeTruthy();
+//   });
+// });


### PR DESCRIPTION
## Tasks

- [x] I have signed a [Contributor License Agreement (CLA)](https://github.com/wpengine/faustjs#contributor-license-agreement) with WP Engine.
- [x] If a code change, I have written testing instructions that the whole team & outside contributors can understand.
- [x] I have written and included a comprehensive [changeset](https://github.com/wpengine/faustjs/blob/canary/DEVELOPMENT.md#deployment) to properly document the changes I've made.

## Description

This PR implements the checkbox control feature for the `block-editor-utils` package. Its corresponding jira ticket is [here](https://wpengine.atlassian.net/jira/software/c/projects/MERL/boards/1007?modal=detail&selectedIssue=MERL-1153).

## Testing

After pulling this branch down, run the following commands in the faustjs monorepo:
1. run `npm install` 
2. run `npm run build` 
3. run `npm run build -w packages/block-editor-utils`
4. run `cd packages/block-editor-utils`
5. run `npm link`

Switch to your testing site's repo.

6. On your WordPress instance create a new block plugin using [@wordpress/create-block](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-create-block/)
npx @wordpress/create-block hello-world-block
7. cd to your new block plugin's folder 
8. Inside the `hello-world-block` plugin folder, run `npm link @faustwp/block-editor-utils` to add a reference to the package.
9. Replace `hello-world-block`'s generated index.js file with the below code block:
```
// In app/public/wp-content/plugins/hello-world-block/src/index.js:

import { addFilter } from '@wordpress/hooks';
import "./style.scss";

// import block.json
import metadata from "./block.json";

// import Pure React Component
import HelloWorld from "./HelloWorld";

// Register React Component in Gutenberg
import { registerFaustBlock } from "@faustwp/block-editor-utils";

registerFaustBlock(HelloWorld, { blockJson: metadata });
```
10. Replace `hello-world-block`'s generated `block.json file with the below code block.

In `app/public/wp-content/plugins/hello-world-block/src/block.json`:
```
{
	"$schema": "https://schemas.wp.org/trunk/block.json",
	"apiVersion": 2,
	"name": "create-block/hello-world-block",
	"version": "0.1.0",
	"title": "Hello World Block",
	"category": "widgets",
	"icon": "smiley",
	"description": "Example block scaffolded with Create Block tool.",
	"supports": {
		"html": false
	},
	"attributes": {
		"message": {
			"type": "string",
			"default": "Hello World"
		},
		"checkbox": {
			"type": "boolean",
			"default": ""
		}
	},
	"textdomain": "hello-world-block",
	"editorScript": "file:./index.js",
	"editorStyle": "file:./index.css",
	"style": "file:./style-index.css"
}
```
11. Add a file named `HelloWorld.js` and add the below code block.
```
// In app/public/wp-content/plugins/hello-world-block/src/HelloWorld.js:

function HelloWorld({ style, className, attributes, children, ...props }) {
	const styles = {
		...style,
		backgroundColor: attributes.bg_color,
		color: attributes.text_color,
	};
	return (
		<div
			{...props}
			style={styles}
			className={className}
			dangerouslySetInnerHTML={{ __html: attributes.message }}
		/>
	);
}

HelloWorld.config = {
	name: "HelloWorld",
        editorFields: {
		message: {
			type: "string",
			default: "",
			label: "My Message",
			location: "editor",
		},
		checkbox: {
			location: "inspector",
			control: "checkbox",
			label: "My Checkbox",
			default: "false",
			help: "here is a help message"
		},
	},
};
export default HelloWorld;
```
12. Run `npm start` from your plugin's file, `hello-world-block`.
13. Ensure your block plugin, `Hello World Block` is active.
14. Go into the editor and try to create a new `Hello World Block` block. You should look to the sidebar and see the radioField panel visible with whatever options you pass into it. Ensure that upon selecting a value that it persists between saves and edits.


## Screenshots

<img width="291" alt="image" src="https://github.com/wpengine/faustjs/assets/50935135/09f46555-61ff-4867-b17e-f25d6c5acc09">
