### PR TITLE
Fix `x-using` header

### DIFF
--- a/.changeset/slimy-plants-enjoy.md
+++ b/.changeset/slimy-plants-enjoy.md
@@ -1,0 +1,5 @@
+---
+'@faustwp/core': patch
+---
+
+Fix `x-using` header not appearing when i18n options are set in `next.config.js`

--- a/examples/next/app-router/next.config.js
+++ b/examples/next/app-router/next.config.js
@@ -1,6 +1,8 @@
+import { withFaust } from '@faustwp/core';
+
 /** @type {import('next').NextConfig} */
-export default {
+export default withFaust({
   experimental: {
     serverActions: true,
   },
-};
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -20014,6 +20014,201 @@
       "integrity": "sha512-LGegJkMvRNw90WWphGJ3RMHMVplYcOfRWf2Be3td3sUa+1AaxmsYyANsA+znrGCBjXJNi4XAQlSoEfUxs/4kIQ==",
       "dev": true
     },
+    "packages/experimental-app-router/node_modules/@next/swc-android-arm-eabi": {
+      "version": "12.3.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-12.3.0.tgz",
+      "integrity": "sha512-/PuirPnAKsYBw93w/7Q9hqy+KGOU9mjYprZ/faxMUJh/dc6v3rYLxkZKNG9nFPIW4QKNTCnhP40xF9hLnxO+xg==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "packages/experimental-app-router/node_modules/@next/swc-android-arm64": {
+      "version": "12.3.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-12.3.0.tgz",
+      "integrity": "sha512-OaI+FhAM6P9B6Ybwbn0Zl8YwWido0lLwhDBi9WiYCh4RQmIXAyVIoIJPHo4fP05+mXaJ/k1trvDvuURvHOq2qw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "packages/experimental-app-router/node_modules/@next/swc-darwin-arm64": {
+      "version": "12.3.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-12.3.0.tgz",
+      "integrity": "sha512-9s4d3Mhii+WFce8o8Jok7WC3Bawkr9wEUU++SJRptjU1L5tsfYJMrSYCACHLhZujziNDLyExe4Hwwsccps1sfg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "packages/experimental-app-router/node_modules/@next/swc-darwin-x64": {
+      "version": "12.3.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-12.3.0.tgz",
+      "integrity": "sha512-2scC4MqUTwGwok+wpVxP+zWp7WcCAVOtutki2E1n99rBOTnUOX6qXkgxSy083yBN6GqwuC/dzHeN7hIKjavfRA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "packages/experimental-app-router/node_modules/@next/swc-freebsd-x64": {
+      "version": "12.3.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-freebsd-x64/-/swc-freebsd-x64-12.3.0.tgz",
+      "integrity": "sha512-xAlruUREij/bFa+qsE1tmsP28t7vz02N4ZDHt2lh3uJUniE0Ne9idyIDLc1Ed0IF2RjfgOp4ZVunuS3OM0sngw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "packages/experimental-app-router/node_modules/@next/swc-linux-arm-gnueabihf": {
+      "version": "12.3.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-12.3.0.tgz",
+      "integrity": "sha512-jin2S4VT/cugc2dSZEUIabhYDJNgrUh7fufbdsaAezgcQzqfdfJqfxl4E9GuafzB4cbRPTaqA0V5uqbp0IyGkQ==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "packages/experimental-app-router/node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "12.3.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-12.3.0.tgz",
+      "integrity": "sha512-RqJHDKe0WImeUrdR0kayTkRWgp4vD/MS7g0r6Xuf8+ellOFH7JAAJffDW3ayuVZeMYOa7RvgNFcOoWnrTUl9Nw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "packages/experimental-app-router/node_modules/@next/swc-linux-arm64-musl": {
+      "version": "12.3.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-12.3.0.tgz",
+      "integrity": "sha512-nvNWoUieMjvDjpYJ/4SQe9lQs2xMj6ZRs8N+bmTrVu9leY2Fg3WD6W9p/1uU9hGO8u+OdF13wc4iRShu/WYIHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "packages/experimental-app-router/node_modules/@next/swc-linux-x64-gnu": {
+      "version": "12.3.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-12.3.0.tgz",
+      "integrity": "sha512-4ajhIuVU9PeQCMMhdDgZTLrHmjbOUFuIyg6J19hZqwEwDTSqQyrSLkbJs2Nd7IRiM6Ul/XyrtEFCpk4k+xD2+w==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "packages/experimental-app-router/node_modules/@next/swc-linux-x64-musl": {
+      "version": "12.3.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-12.3.0.tgz",
+      "integrity": "sha512-U092RBYbaGxoMAwpauePJEu2PuZSEoUCGJBvsptQr2/2XIMwAJDYM4c/M5NfYEsBr+yjvsYNsOpYfeQ88D82Yg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "packages/experimental-app-router/node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "12.3.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-12.3.0.tgz",
+      "integrity": "sha512-pzSzaxjDEJe67bUok9Nxf9rykbJfHXW0owICFsPBsqHyc+cr8vpF7g9e2APTCddtVhvjkga9ILoZJ9NxWS7Yiw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "packages/experimental-app-router/node_modules/@next/swc-win32-ia32-msvc": {
+      "version": "12.3.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-12.3.0.tgz",
+      "integrity": "sha512-MQGUpMbYhQmTZ06a9e0hPQJnxFMwETo2WtyAotY3GEzbNCQVbCGhsvqEKcl+ZEHgShlHXUWvSffq1ZscY6gK7A==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "packages/experimental-app-router/node_modules/@next/swc-win32-x64-msvc": {
+      "version": "12.3.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-12.3.0.tgz",
+      "integrity": "sha512-C/nw6OgQpEULWqs+wgMHXGvlJLguPRFFGqR2TAqWBerQ8J+Sg3z1ZTqwelkSi4FoqStGuZ2UdFHIDN1ySmR1xA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "packages/experimental-app-router/node_modules/@sinonjs/commons": {
       "version": "3.0.0",
       "dev": true,
@@ -25237,6 +25432,71 @@
           "resolved": "https://registry.npmjs.org/@next/env/-/env-13.5.4.tgz",
           "integrity": "sha512-LGegJkMvRNw90WWphGJ3RMHMVplYcOfRWf2Be3td3sUa+1AaxmsYyANsA+znrGCBjXJNi4XAQlSoEfUxs/4kIQ==",
           "dev": true
+        },
+        "@next/swc-android-arm-eabi": {
+          "version": "https://registry.npmjs.org/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-12.3.0.tgz",
+          "integrity": "sha512-/PuirPnAKsYBw93w/7Q9hqy+KGOU9mjYprZ/faxMUJh/dc6v3rYLxkZKNG9nFPIW4QKNTCnhP40xF9hLnxO+xg==",
+          "optional": true
+        },
+        "@next/swc-android-arm64": {
+          "version": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-12.3.0.tgz",
+          "integrity": "sha512-OaI+FhAM6P9B6Ybwbn0Zl8YwWido0lLwhDBi9WiYCh4RQmIXAyVIoIJPHo4fP05+mXaJ/k1trvDvuURvHOq2qw==",
+          "optional": true
+        },
+        "@next/swc-darwin-arm64": {
+          "version": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-12.3.0.tgz",
+          "integrity": "sha512-9s4d3Mhii+WFce8o8Jok7WC3Bawkr9wEUU++SJRptjU1L5tsfYJMrSYCACHLhZujziNDLyExe4Hwwsccps1sfg==",
+          "optional": true
+        },
+        "@next/swc-darwin-x64": {
+          "version": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-12.3.0.tgz",
+          "integrity": "sha512-2scC4MqUTwGwok+wpVxP+zWp7WcCAVOtutki2E1n99rBOTnUOX6qXkgxSy083yBN6GqwuC/dzHeN7hIKjavfRA==",
+          "optional": true
+        },
+        "@next/swc-freebsd-x64": {
+          "version": "https://registry.npmjs.org/@next/swc-freebsd-x64/-/swc-freebsd-x64-12.3.0.tgz",
+          "integrity": "sha512-xAlruUREij/bFa+qsE1tmsP28t7vz02N4ZDHt2lh3uJUniE0Ne9idyIDLc1Ed0IF2RjfgOp4ZVunuS3OM0sngw==",
+          "optional": true
+        },
+        "@next/swc-linux-arm-gnueabihf": {
+          "version": "https://registry.npmjs.org/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-12.3.0.tgz",
+          "integrity": "sha512-jin2S4VT/cugc2dSZEUIabhYDJNgrUh7fufbdsaAezgcQzqfdfJqfxl4E9GuafzB4cbRPTaqA0V5uqbp0IyGkQ==",
+          "optional": true
+        },
+        "@next/swc-linux-arm64-gnu": {
+          "version": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-12.3.0.tgz",
+          "integrity": "sha512-RqJHDKe0WImeUrdR0kayTkRWgp4vD/MS7g0r6Xuf8+ellOFH7JAAJffDW3ayuVZeMYOa7RvgNFcOoWnrTUl9Nw==",
+          "optional": true
+        },
+        "@next/swc-linux-arm64-musl": {
+          "version": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-12.3.0.tgz",
+          "integrity": "sha512-nvNWoUieMjvDjpYJ/4SQe9lQs2xMj6ZRs8N+bmTrVu9leY2Fg3WD6W9p/1uU9hGO8u+OdF13wc4iRShu/WYIHg==",
+          "optional": true
+        },
+        "@next/swc-linux-x64-gnu": {
+          "version": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-12.3.0.tgz",
+          "integrity": "sha512-4ajhIuVU9PeQCMMhdDgZTLrHmjbOUFuIyg6J19hZqwEwDTSqQyrSLkbJs2Nd7IRiM6Ul/XyrtEFCpk4k+xD2+w==",
+          "optional": true
+        },
+        "@next/swc-linux-x64-musl": {
+          "version": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-12.3.0.tgz",
+          "integrity": "sha512-U092RBYbaGxoMAwpauePJEu2PuZSEoUCGJBvsptQr2/2XIMwAJDYM4c/M5NfYEsBr+yjvsYNsOpYfeQ88D82Yg==",
+          "optional": true
+        },
+        "@next/swc-win32-arm64-msvc": {
+          "version": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-12.3.0.tgz",
+          "integrity": "sha512-pzSzaxjDEJe67bUok9Nxf9rykbJfHXW0owICFsPBsqHyc+cr8vpF7g9e2APTCddtVhvjkga9ILoZJ9NxWS7Yiw==",
+          "optional": true
+        },
+        "@next/swc-win32-ia32-msvc": {
+          "version": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-12.3.0.tgz",
+          "integrity": "sha512-MQGUpMbYhQmTZ06a9e0hPQJnxFMwETo2WtyAotY3GEzbNCQVbCGhsvqEKcl+ZEHgShlHXUWvSffq1ZscY6gK7A==",
+          "optional": true
+        },
+        "@next/swc-win32-x64-msvc": {
+          "version": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-12.3.0.tgz",
+          "integrity": "sha512-C/nw6OgQpEULWqs+wgMHXGvlJLguPRFFGqR2TAqWBerQ8J+Sg3z1ZTqwelkSi4FoqStGuZ2UdFHIDN1ySmR1xA==",
+          "optional": true
         },
         "@sinonjs/commons": {
           "version": "3.0.0",

--- a/packages/faustwp-core/src/config/withFaust.ts
+++ b/packages/faustwp-core/src/config/withFaust.ts
@@ -72,7 +72,7 @@ export async function addHeaders(
   }
 
   headers.push({
-    source: '/(.*?)',
+    source: '/:path*',
     headers: [
       {
         key: 'x-using',

--- a/packages/faustwp-core/tests/config/withFaust.test.ts
+++ b/packages/faustwp-core/tests/config/withFaust.test.ts
@@ -17,7 +17,7 @@ describe('withFaust', () => {
     );
     const headers = await finalConfig.headers!();
     expect(headers).toEqual([
-      { headers: [{ key: 'x-using', value: 'faust' }], source: '/(.*?)' },
+      { headers: [{ key: 'x-using', value: 'faust' }], source: '/:path*' },
     ]);
   });
   test('it applies a default redirects config', async () => {


### PR DESCRIPTION
## Tasks

- [x] I have signed a [Contributor License Agreement (CLA)](https://github.com/wpengine/faustjs#contributor-license-agreement) with WP Engine.
- [x] If a code change, I have written testing instructions that the whole team & outside contributors can understand.
- [x] I have written and included a comprehensive [changeset](https://github.com/wpengine/faustjs/blob/canary/DEVELOPMENT.md#deployment) to properly document the changes I've made.

## Description

Currently the `x-using` Faust header will not render when i18n is set in `next.config.js` since we are using the `/(.*)` source regex. Next.js suggests we use the `/:path*` regex if you want to capture i18n routes as well:

```
  // this gets converted to /(en|fr|de)/(.*) so will not match the top-level
  // `/` or `/fr` routes like /:path* would
  source: '/(.*)',
```
See: https://nextjs.org/docs/pages/api-reference/next-config-js/headers#headers-with-i18n-support

This is likely why we thought SSG could not render this header in the og PR:
https://github.com/wpengine/faustjs/pull/1215

However, after testing with this new regex, both SSG and SSR pages show the proper header.

<!--
Include a summary of the change and some contextual information.
-->

## Related Issue(s):

<!--
Provide the GitHub issue(s) number for issue tracking purposes, use the following syntax:

- #1234
-->

## Testing

1. From the canary branch, run the example project `npm run dev -w @faustwp/getting-started-example`
2. Go to http://localhost:3000 and check out the localhost document network request in the network tab. Notice the response headers do not include `x-using`:
![Screenshot 2023-10-17 at 10 03 09 AM](https://github.com/wpengine/faustjs/assets/5946219/ad37cfdb-8443-4c36-836a-c6503cd911a8)
3. Checkout this branch (`fix-x-using-header`), and run the example project again `npm run dev -w @faustwp/getting-started-example`
4. Go to http://localhost:3000 and check out the localhost document network request in the network tab. Notice the response headers **do** include `x-using`:
![Screenshot 2023-10-17 at 10 05 12 AM](https://github.com/wpengine/faustjs/assets/5946219/609b948b-08e3-4e6e-b2d3-d3cdeb72c29e)
5. Finally, run the app router example project `npm run dev -w @faustwp/app-router-example`
6. Go to http://localhost:3000 and check out the localhost document network request in the network tab. Notice the response headers **do** include `x-using`:
![Screenshot 2023-10-17 at 10 06 04 AM](https://github.com/wpengine/faustjs/assets/5946219/400c2854-86e0-4868-85b8-b43b62eac1a2)


<!--
Describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Also list any relevant details for your test configuration such as how to test the changes locally or in staging.
-->

## Screenshots

<!--
If this is a visual change include relevant screenshots about the behavior of the application before and after this change.
-->

## Documentation Changes

<!--
List corresponding changes to the documentation.
-->

## Dependant PRs

<!--
List any dependent PR's that are awaiting review. Use the following syntax:

- #1234
-->
