### PR TITLE
Only update peer deps when out of range (Fixes peer deps causing major bump)

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -14,5 +14,8 @@
   "baseBranch": "canary",
   "updateInternalDependencies": "patch",
   "ignore": ["@faustjs/next-headless-getting-started", "@faustwp/getting-started-example", "@faustwp/app-router-example"],
-  "onlyUpdatePeerDependentsWhenOutOfRange": true
+  "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
+    "onlyUpdatePeerDependentsWhenOutOfRange": true
+  }
+  
 }


### PR DESCRIPTION
## Tasks

- [x] I have signed a [Contributor License Agreement (CLA)](https://github.com/wpengine/faustjs#contributor-license-agreement) with WP Engine.
- [x] If a code change, I have written testing instructions that the whole team & outside contributors can understand.
- [x] I have written and included a comprehensive [changeset](https://github.com/wpengine/faustjs/blob/canary/DEVELOPMENT.md#deployment) to properly document the changes I've made.

## Description

This PR fixes deep deps causing major bumps by using the `onlyUpdatePeerDependentsWhenOutOfRange` changesets flag. We had defined it before, but it looks like it had to be wrapped in a `___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH` object.

Reference:

Changesets decisions on versioning packages with peer deps:
https://github.com/changesets/changesets/blob/main/docs/decisions.md#the-versioning-of-peer-dependencies

Reference package that is using `onlyUpdatePeerDependentsWhenOutOfRange`:
https://github.com/statelyai/xstate/blob/c967791c82756b8c743c70a4a0b66b2e9e1d7d41/.changeset/config.json#L10

Some related issues:
https://github.com/changesets/changesets/issues/822
<!--
Include a summary of the change and some contextual information.
-->

## Related Issue(s):

<!--
Provide the GitHub issue(s) number for issue tracking purposes, use the following syntax:

- #1234
-->

## Testing

<!--
Describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Also list any relevant details for your test configuration such as how to test the changes locally or in staging.
-->

## Screenshots

<!--
If this is a visual change include relevant screenshots about the behavior of the application before and after this change.
-->

## Documentation Changes

<!--
List corresponding changes to the documentation.
-->

## Dependant PRs

<!--
List any dependent PR's that are awaiting review. Use the following syntax:

- #1234
-->
