### PR TITLE
Fix deploy to wordpress.org workflow

### DIFF
--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -51,7 +51,7 @@ jobs:
         # If there is a published package named "@faustwp/wordpress-plugin"
         # Then deploy the WordPress plugin
         # https://github.com/changesets/action#outputs
-        if: contains(steps.changesets.outputs.publishedPackages.*.name, '@faustwp/wordpress-plugin')
+        if: steps.changesets.outputs.published && contains(steps.changesets.outputs.publishedPackages, '"@faustwp/wordpress-plugin"')
         # Use a variant of 10up/action-wordpress-plugin-deploy that allows us to specify a PLUGIN_DIR
         # to support our monorepo structure.
         uses: ./.github/actions/release-plugin


### PR DESCRIPTION
## Tasks

- [ ] I have signed a [Contributor License Agreement (CLA)](https://github.com/wpengine/faustjs#contributor-license-agreement) with WP Engine.
- [ ] If a code change, I have written testing instructions that the whole team & outside contributors can understand.
- [ ] I have written and included a comprehensive [changeset](https://github.com/wpengine/faustjs/blob/canary/DEVELOPMENT.md#deployment) to properly document the changes I've made.

## Description

This PR fixes the `if` statement when versioning packages/deploying the WordPress plugin to wordpress.org. 

![Screenshot 2023-10-24 at 9 06 09 PM](https://github.com/wpengine/faustjs/assets/5946219/c13003b4-5109-4925-8730-0217b1baffd4)

These changes were confirmed in a test repo available here:

https://github.com/blakewilson/deploy-wp-changesets-test

You can see the test version packages action results in the repo here that confirm that the variables are set properly, and that the if statement functions as expected:

https://github.com/blakewilson/deploy-wp-changesets-test/actions/runs/6634836225/job/18024831461

Additionally, here is the test/example workflow file:

https://github.com/blakewilson/deploy-wp-changesets-test/blob/main/.github/workflows/release.yml

<!--
Include a summary of the change and some contextual information.
-->

## Related Issue(s):

<!--
Provide the GitHub issue(s) number for issue tracking purposes, use the following syntax:

- #1234
-->

## Testing

<!--
Describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Also list any relevant details for your test configuration such as how to test the changes locally or in staging.
-->

## Screenshots

<!--
If this is a visual change include relevant screenshots about the behavior of the application before and after this change.
-->

## Documentation Changes

<!--
List corresponding changes to the documentation.
-->

## Dependant PRs

<!--
List any dependent PR's that are awaiting review. Use the following syntax:

- #1234
-->
