### PR TITLE
Support for multiple queries in a Faust template

### DIFF
--- a/examples/next/faustwp-getting-started/wp-templates/single.js
+++ b/examples/next/faustwp-getting-started/wp-templates/single.js
@@ -58,17 +58,6 @@ const GET_POST_QUERY = gql`
 export default function Component(props) {
   const context = useContext(FaustContext);
 
-  /**
-   * @TODO I'm not sure why context is shortly undefined before we
-   * get to our Faust component. The default value is set as undefined
-   * but the value is updated in the FaustProvider way before this component
-   * is reached. Will need to do some more digging. Otherwise, context is not
-   * found in `useFaustQuery` and the hook fails.
-   */
-  if (!context) {
-    return null;
-  }
-
   const { post } = useFaustQuery(GET_POST_QUERY);
   const { generalSettings, headerMenuItems, footerMenuItems } =
     useFaustQuery(GET_LAYOUT_QUERY);

--- a/examples/next/faustwp-getting-started/wp-templates/single.js
+++ b/examples/next/faustwp-getting-started/wp-templates/single.js
@@ -113,13 +113,19 @@ export default function Component(props) {
   );
 }
 
-Component.queries = [GET_LAYOUT_QUERY, GET_POST_QUERY];
-
-Component.variables = ({ databaseId }, ctx) => {
-  return {
-    databaseId,
-    headerLocation: MENUS.PRIMARY_LOCATION,
-    footerLocation: MENUS.FOOTER_LOCATION,
-    asPreview: ctx?.asPreview,
-  };
-};
+Component.queries = [
+  {
+    query: GET_LAYOUT_QUERY,
+    variables: (seedNode, ctx) => ({
+      headerLocation: MENUS.PRIMARY_LOCATION,
+      footerLocation: MENUS.FOOTER_LOCATION,
+    }),
+  },
+  {
+    query: GET_POST_QUERY,
+    variables: ({ databaseId }, ctx) => ({
+      databaseId,
+      asPreview: ctx?.asPreview,
+    }),
+  },
+];

--- a/package-lock.json
+++ b/package-lock.json
@@ -32158,6 +32158,186 @@
     "plugins/faustwp": {
       "name": "@faustwp/wordpress-plugin",
       "version": "1.0.4"
+    },
+    "packages/experimental-app-router/node_modules/@next/swc-android-arm-eabi": {
+      "version": "12.3.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-12.3.4.tgz",
+      "integrity": "sha512-cM42Cw6V4Bz/2+j/xIzO8nK/Q3Ly+VSlZJTa1vHzsocJRYz8KT6MrreXaci2++SIZCF1rVRCDgAg5PpqRibdIA==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "packages/experimental-app-router/node_modules/@next/swc-android-arm64": {
+      "version": "12.3.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-12.3.4.tgz",
+      "integrity": "sha512-5jf0dTBjL+rabWjGj3eghpLUxCukRhBcEJgwLedewEA/LJk2HyqCvGIwj5rH+iwmq1llCWbOky2dO3pVljrapg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "packages/experimental-app-router/node_modules/@next/swc-darwin-arm64": {
+      "version": "12.3.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-12.3.4.tgz",
+      "integrity": "sha512-DqsSTd3FRjQUR6ao0E1e2OlOcrF5br+uegcEGPVonKYJpcr0MJrtYmPxd4v5T6UCJZ+XzydF7eQo5wdGvSZAyA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "packages/experimental-app-router/node_modules/@next/swc-freebsd-x64": {
+      "version": "12.3.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-freebsd-x64/-/swc-freebsd-x64-12.3.4.tgz",
+      "integrity": "sha512-KM9JXRXi/U2PUM928z7l4tnfQ9u8bTco/jb939pdFUHqc28V43Ohd31MmZD1QzEK4aFlMRaIBQOWQZh4D/E5lQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "packages/experimental-app-router/node_modules/@next/swc-linux-arm-gnueabihf": {
+      "version": "12.3.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-12.3.4.tgz",
+      "integrity": "sha512-3zqD3pO+z5CZyxtKDTnOJ2XgFFRUBciOox6EWkoZvJfc9zcidNAQxuwonUeNts6Xbm8Wtm5YGIRC0x+12YH7kw==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "packages/experimental-app-router/node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "12.3.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-12.3.4.tgz",
+      "integrity": "sha512-kiX0vgJGMZVv+oo1QuObaYulXNvdH/IINmvdZnVzMO/jic/B8EEIGlZ8Bgvw8LCjH3zNVPO3mGrdMvnEEPEhKA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "packages/experimental-app-router/node_modules/@next/swc-linux-arm64-musl": {
+      "version": "12.3.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-12.3.4.tgz",
+      "integrity": "sha512-EETZPa1juczrKLWk5okoW2hv7D7WvonU+Cf2CgsSoxgsYbUCZ1voOpL4JZTOb6IbKMDo6ja+SbY0vzXZBUMvkQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "packages/experimental-app-router/node_modules/@next/swc-linux-x64-gnu": {
+      "version": "12.3.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-12.3.4.tgz",
+      "integrity": "sha512-4csPbRbfZbuWOk3ATyWcvVFdD9/Rsdq5YHKvRuEni68OCLkfy4f+4I9OBpyK1SKJ00Cih16NJbHE+k+ljPPpag==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "packages/experimental-app-router/node_modules/@next/swc-linux-x64-musl": {
+      "version": "12.3.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-12.3.4.tgz",
+      "integrity": "sha512-YeBmI+63Ro75SUiL/QXEVXQ19T++58aI/IINOyhpsRL1LKdyfK/35iilraZEFz9bLQrwy1LYAR5lK200A9Gjbg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "packages/experimental-app-router/node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "12.3.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-12.3.4.tgz",
+      "integrity": "sha512-Sd0qFUJv8Tj0PukAYbCCDbmXcMkbIuhnTeHm9m4ZGjCf6kt7E/RMs55Pd3R5ePjOkN7dJEuxYBehawTR/aPDSQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "packages/experimental-app-router/node_modules/@next/swc-win32-ia32-msvc": {
+      "version": "12.3.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-12.3.4.tgz",
+      "integrity": "sha512-rt/vv/vg/ZGGkrkKcuJ0LyliRdbskQU+91bje+PgoYmxTZf/tYs6IfbmgudBJk6gH3QnjHWbkphDdRQrseRefQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "packages/experimental-app-router/node_modules/@next/swc-win32-x64-msvc": {
+      "version": "12.3.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-12.3.4.tgz",
+      "integrity": "sha512-DQ20JEfTBZAgF8QCjYfJhv2/279M6onxFjdG/+5B0Cyj00/EdBxiWb2eGGFgQhrBbNv/lsvzFbbi0Ptf8Vw/bg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
     }
   }
 }

--- a/packages/faustwp-core/src/components/FaustProvider.tsx
+++ b/packages/faustwp-core/src/components/FaustProvider.tsx
@@ -1,5 +1,5 @@
+import React from 'react';
 import { ApolloProvider } from '@apollo/client';
-import React, { createContext } from 'react';
 // eslint-disable-next-line import/extensions
 import { useRouter } from 'next/router';
 // eslint-disable-next-line import/extensions

--- a/packages/faustwp-core/src/components/FaustProvider.tsx
+++ b/packages/faustwp-core/src/components/FaustProvider.tsx
@@ -1,5 +1,5 @@
 import { ApolloProvider } from '@apollo/client';
-import React from 'react';
+import React, { createContext } from 'react';
 // eslint-disable-next-line import/extensions
 import { useRouter } from 'next/router';
 // eslint-disable-next-line import/extensions
@@ -8,6 +8,7 @@ import { useApollo } from '../client.js';
 import { Toolbar } from './Toolbar/index.js';
 import { SeedNode } from '../queries/seedQuery.js';
 import { getConfig } from '../config/index.js';
+import { FaustContext } from '../store/FaustContext.js';
 
 export type FaustPageProps = AppProps['pageProps'] & {
   __SEED_NODE__?: SeedNode;
@@ -23,15 +24,17 @@ export function FaustProvider(props: {
   const apolloClient = useApollo(pageProps);
 
   return (
-    <ApolloProvider client={apolloClient}>
-      {experimentalToolbar && (
-        <Toolbar
-          key={`faust-toolbar-${router.asPath}`} // Required in order to load each route's own seed node.
-          // eslint-disable-next-line no-underscore-dangle
-          seedNode={pageProps.__SEED_NODE__}
-        />
-      )}
-      {children}
-    </ApolloProvider>
+    <FaustContext.Provider value={pageProps}>
+      <ApolloProvider client={apolloClient}>
+        {experimentalToolbar && (
+          <Toolbar
+            key={`faust-toolbar-${router.asPath}`} // Required in order to load each route's own seed node.
+            // eslint-disable-next-line no-underscore-dangle
+            seedNode={pageProps.__SEED_NODE__}
+          />
+        )}
+        {children}
+      </ApolloProvider>
+    </FaustContext.Provider>
   );
 }

--- a/packages/faustwp-core/src/hooks/useFaustContext.tsx
+++ b/packages/faustwp-core/src/hooks/useFaustContext.tsx
@@ -5,7 +5,7 @@ import { sha256 } from 'js-sha256';
 import { useContext } from 'react';
 import { FaustContext } from '../store/FaustContext.js';
 
-export function useFaustQuery(query: DocumentNode) {
+export function useFaustQuery<TData>(query: DocumentNode): TData {
   const context = useContext(FaustContext);
 
   if (context === undefined) {
@@ -15,5 +15,5 @@ export function useFaustQuery(query: DocumentNode) {
   const sha = sha256(print(query));
 
   // eslint-disable-next-line no-underscore-dangle
-  return context?.__FAUST_QUERIES__?.[sha];
+  return context?.__FAUST_QUERIES__?.[sha] as TData;
 }

--- a/packages/faustwp-core/src/hooks/useFaustContext.tsx
+++ b/packages/faustwp-core/src/hooks/useFaustContext.tsx
@@ -1,0 +1,18 @@
+import { DocumentNode } from '@apollo/client';
+// eslint-disable-next-line import/extensions
+import { print } from '@apollo/client/utilities';
+import { sha256 } from 'js-sha256';
+import { useContext } from 'react';
+import { FaustContext } from '../store/FaustContext.js';
+
+export function useFaustQuery(query: DocumentNode) {
+  const context = useContext(FaustContext);
+
+  if (context === undefined) {
+    throw new Error('useFaustQuery must be used within a FaustProvider');
+  }
+
+  const sha = sha256(print(query));
+
+  return context?.queries?.[sha];
+}

--- a/packages/faustwp-core/src/hooks/useFaustContext.tsx
+++ b/packages/faustwp-core/src/hooks/useFaustContext.tsx
@@ -14,5 +14,5 @@ export function useFaustQuery(query: DocumentNode) {
 
   const sha = sha256(print(query));
 
-  return context?.queries?.[sha];
+  return context?.__FAUST_QUERIES__?.[sha];
 }

--- a/packages/faustwp-core/src/hooks/useFaustContext.tsx
+++ b/packages/faustwp-core/src/hooks/useFaustContext.tsx
@@ -14,5 +14,6 @@ export function useFaustQuery(query: DocumentNode) {
 
   const sha = sha256(print(query));
 
+  // eslint-disable-next-line no-underscore-dangle
   return context?.__FAUST_QUERIES__?.[sha];
 }

--- a/packages/faustwp-core/src/index.ts
+++ b/packages/faustwp-core/src/index.ts
@@ -31,6 +31,8 @@ import {
 import { useAuth } from './hooks/useAuth.js';
 import { useLogin } from './hooks/useLogin.js';
 import { useLogout } from './hooks/useLogout.js';
+import { useFaustQuery } from './hooks/useFaustContext.js';
+import { FaustContext } from './store/FaustContext.js';
 
 import {
   FaustToolbarNodes,
@@ -83,4 +85,6 @@ export {
   FaustTemplate,
   FaustPage,
   hooks,
+  useFaustQuery,
+  FaustContext,
 };

--- a/packages/faustwp-core/src/store/FaustContext.tsx
+++ b/packages/faustwp-core/src/store/FaustContext.tsx
@@ -4,7 +4,7 @@ import { FaustPageProps } from '../components/FaustProvider.js';
 export const FaustContext = createContext<
   | ({
       __FAUST_QUERIES__?: {
-        [key: string]: string;
+        [key: string]: any;
       };
     } & FaustPageProps)
   | undefined

--- a/packages/faustwp-core/src/store/FaustContext.tsx
+++ b/packages/faustwp-core/src/store/FaustContext.tsx
@@ -1,0 +1,11 @@
+import { createContext } from 'react';
+import { FaustPageProps } from '../components/FaustProvider.js';
+
+export const FaustContext = createContext<
+  | ({
+      queries?: {
+        [key: string]: string;
+      };
+    } & FaustPageProps)
+  | undefined
+>(undefined);

--- a/packages/faustwp-core/src/store/FaustContext.tsx
+++ b/packages/faustwp-core/src/store/FaustContext.tsx
@@ -3,7 +3,7 @@ import { FaustPageProps } from '../components/FaustProvider.js';
 
 export const FaustContext = createContext<
   | ({
-      queries?: {
+      __FAUST_QUERIES__?: {
         [key: string]: string;
       };
     } & FaustPageProps)


### PR DESCRIPTION
## Tasks

- [ ] I have signed a [Contributor License Agreement (CLA)](https://github.com/wpengine/faustjs#contributor-license-agreement) with WP Engine.
- [ ] If a code change, I have written testing instructions that the whole team & outside contributors can understand.
- [ ] I have written and included a comprehensive [changeset](https://github.com/wpengine/faustjs/blob/canary/DEVELOPMENT.md#deployment) to properly document the changes I've made.

## Description

Provide a way to use multiple queries in a Faust template.

Introduces the new `Component.queries` property to execute multiple queries, and the `useFaustQuery` hook to retrieve the data.

<!--
Include a summary of the change and some contextual information.
-->

## Related Issue(s):

<!--
Provide the GitHub issue(s) number for issue tracking purposes, use the following syntax:

- #1234
-->

## Testing

1. Checkout this repo
2. Install dependencies `npm install`
3. Build the packages `npm run build`
4. Start the example project `npm run dev -w @faustwp/getting-started-example`
5. Navigate to a single post, and notice it renders as expected with the two queries provided in `wp-templates/single.js`

<!--
Describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Also list any relevant details for your test configuration such as how to test the changes locally or in staging.
-->

## Screenshots

<!--
If this is a visual change include relevant screenshots about the behavior of the application before and after this change.
-->

## Documentation Changes

<!--
List corresponding changes to the documentation.
-->

## Dependant PRs

<!--
List any dependent PR's that are awaiting review. Use the following syntax:

- #1234
-->
