### PR TITLE
ci: use `create-next-app@13` in e2e test workflows

### DIFF
--- a/.github/workflows/e2e-next-example.yml
+++ b/.github/workflows/e2e-next-example.yml
@@ -37,7 +37,7 @@ jobs:
       # and use the PR branch to pull the correct example URL
       - name: npx create next app
         run: |
-          npx create-next-app \
+          npx create-next-app@13 \
             -e https://github.com/${PR_REPO}/tree/${PR_BRANCH} \
             --example-path examples/next/getting-started \
             --use-npm \

--- a/.github/workflows/e2e-next-faustwp-example.yml
+++ b/.github/workflows/e2e-next-faustwp-example.yml
@@ -37,7 +37,7 @@ jobs:
       # and use the PR branch to pull the correct example URL
       - name: npx create next app
         run: |
-          npx create-next-app \
+          npx create-next-app@13 \
             -e https://github.com/${PR_REPO}/tree/${PR_BRANCH} \
             --example-path examples/next/faustwp-getting-started \
             --use-npm \

--- a/.github/workflows/e2e-nightly-build.yml
+++ b/.github/workflows/e2e-nightly-build.yml
@@ -28,11 +28,11 @@ jobs:
       # Install faust-scaffold-ts via npx create next app
       - name: npx create next app
         run: |
-          npx create-next-app \
+          npx create-next-app@13 \
             -e https://github.com/wpengine/faust-scaffold-ts/tree/main \
             --use-npm \
             e2e-app
-        
+
       - name: Install nightly versions
         working-directory: e2e-app
         run: |


### PR DESCRIPTION
## Description
Updates GitHub Actions workflows to specify v13 of `create-next-app`, to fix test failures [like these](https://github.com/wpengine/faustjs/actions/runs/6709125031) happening on all PRs right now.

## Testing

Automated tests pass again

