### PR TITLE
chore: Update @faustwp/cli and @faustwp/core packages in examples.

### DIFF
--- a/examples/next/app-router/package.json
+++ b/examples/next/app-router/package.json
@@ -12,8 +12,8 @@
   "dependencies": {
     "@apollo/client": "^3.8.0",
     "@apollo/experimental-nextjs-app-support": "^0.5.1",
-    "@faustwp/cli": "1.2.0",
-    "@faustwp/core": "1.2.0",
+    "@faustwp/cli": "^1.2.0",
+    "@faustwp/core": "^1.2.0",
     "@faustwp/experimental-app-router": "^0.1.0",
     "graphql": "^16.7.1",
     "next": "^14.0.1",

--- a/examples/next/block-support/package.json
+++ b/examples/next/block-support/package.json
@@ -13,8 +13,8 @@
   "dependencies": {
     "@apollo/client": "^3.6.6",
     "@faustwp/blocks": "2.0.0",
-    "@faustwp/cli": "1.2.0",
-    "@faustwp/core": "1.2.0",
+    "@faustwp/cli": "^1.2.0",
+    "@faustwp/core": "^1.2.0",
     "@wordpress/base-styles": "^4.26.0",
     "@wordpress/block-library": "^7.19.0",
     "classnames": "^2.3.1",

--- a/examples/next/faustwp-getting-started/package.json
+++ b/examples/next/faustwp-getting-started/package.json
@@ -11,8 +11,8 @@
   },
   "dependencies": {
     "@apollo/client": "^3.6.6",
-    "@faustwp/cli": "1.2.0",
-    "@faustwp/core": "1.2.0",
+    "@faustwp/cli": "^1.2.0",
+    "@faustwp/core": "^1.2.0",
     "@wordpress/base-styles": "^4.26.0",
     "@wordpress/block-library": "^7.19.0",
     "classnames": "^2.3.1",


### PR DESCRIPTION
## Description
Adds the caret to allow updates that are compatible, instead of pinning to a single version that requires we update this all the time.


