### PR TITLE
Fix app router build publish

### DIFF
--- a/.changeset/breezy-dragons-appear.md
+++ b/.changeset/breezy-dragons-appear.md
@@ -1,0 +1,5 @@
+---
+'@faustwp/experimental-app-router': patch
+---
+
+Fix broken build from 0.2.0

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "build:faust-cli": "npm run build --workspace=@faustwp/cli",
     "build:faust-core": "npm run build --workspace=@faustwp/core",
     "build:faust-blocks": "npm run build --workspace=@faustwp/blocks",
-    "build:experimentala-app-router": "npm run build --workspace=@faustwp/experimental-app-router",
+    "build:experimental-app-router": "npm run build --workspace=@faustwp/experimental-app-router",
     "clean": "npm run clean --workspace=@faustjs/core --workspace=@faustjs/react --workspace=@faustjs/next --workspace=@faustwp/cli --workspace=@faustwp/core --workspace=@faustwp/experimental-app-router --workspace=@faustwp/block-editor-utils",
     "clean:examples": "rimraf examples/**/node_modules",
     "format": "npm run format --workspace=@faustjs/core --workspace=@faustjs/react --workspace=@faustjs/next --workspace=@faustwp/cli --workspace=@faustwp/core --workspace=@faustwp/experimental-app-router --workspace=@faustwp/block-editor-utils",
@@ -54,7 +54,7 @@
     "version": "changeset version && node scripts/versionPlugin.js",
     "version:nightly": "changeset version --snapshot && node scripts/versionPlugin.js",
     "version:status": "changeset status",
-    "release": "npm run build && changeset publish",
+    "release": "npm run build && npm run build:experimental-app-router && changeset publish",
     "release:nightly": "npm run build && changeset publish --tag canary",
     "lint": "eslint ./packages --ext js,jsx,ts,tsx --max-warnings=0",
     "lint:fix": "eslint ./packages --ext js,jsx,ts,tsx --max-warnings=0 --fix"


### PR DESCRIPTION
## Tasks

- [ ] I have signed a [Contributor License Agreement (CLA)](https://github.com/wpengine/faustjs#contributor-license-agreement) with WP Engine.
- [ ] If a code change, I have written testing instructions that the whole team & outside contributors can understand.
- [ ] I have written and included a comprehensive [changeset](https://github.com/wpengine/faustjs/blob/canary/DEVELOPMENT.md#deployment) to properly document the changes I've made.

## Description

Since we removed the experimental app router package from the "build" step to not conflict with our workflows re:node/next required versions, the build was excluded from the release packages action, and thus published a broken build. This fixes the workflow and adds a changeset to make a corrective follow up release.

<!--
Include a summary of the change and some contextual information.
-->

## Related Issue(s):

<!--
Provide the GitHub issue(s) number for issue tracking purposes, use the following syntax:

- #1234
-->

## Testing

<!--
Describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Also list any relevant details for your test configuration such as how to test the changes locally or in staging.
-->

## Screenshots

<!--
If this is a visual change include relevant screenshots about the behavior of the application before and after this change.
-->

## Documentation Changes

<!--
List corresponding changes to the documentation.
-->

## Dependant PRs

<!--
List any dependent PR's that are awaiting review. Use the following syntax:

- #1234
-->
