### PR TITLE
fix: term_link filter

### DIFF
--- a/plugins/faustwp/includes/replacement/callbacks.php
+++ b/plugins/faustwp/includes/replacement/callbacks.php
@@ -223,6 +223,11 @@ function term_link( $term_link ) {
 		! is_rewrites_enabled()
 		|| ( function_exists( 'is_graphql_request' ) && is_graphql_request() )
 	) {
+		return equivalent_frontend_url( $term_link );
+	}
+		! is_rewrites_enabled()
+		|| ( function_exists( 'is_graphql_request' ) && is_graphql_request() )
+	) {
 
 	return equivalent_frontend_url( $term_link );
 }

--- a/plugins/faustwp/includes/replacement/callbacks.php
+++ b/plugins/faustwp/includes/replacement/callbacks.php
@@ -219,9 +219,10 @@ add_filter( 'term_link', __NAMESPACE__ . '\\term_link', 1000 );
  * @return string
  */
 function term_link( $term_link ) {
-	if ( ! is_rewrites_enabled() ) {
-		return $term_link;
-	}
+	if (
+		! is_rewrites_enabled()
+		|| ( function_exists( 'is_graphql_request' ) && is_graphql_request() )
+	) {
 
 	return equivalent_frontend_url( $term_link );
 }

--- a/plugins/faustwp/includes/replacement/callbacks.php
+++ b/plugins/faustwp/includes/replacement/callbacks.php
@@ -225,7 +225,7 @@ function term_link( $term_link ) {
 	) {
 		return $term_link;
 	}
-	
+
 	return equivalent_frontend_url( $term_link );
 }
 

--- a/plugins/faustwp/includes/replacement/callbacks.php
+++ b/plugins/faustwp/includes/replacement/callbacks.php
@@ -223,12 +223,9 @@ function term_link( $term_link ) {
 		! is_rewrites_enabled()
 		|| ( function_exists( 'is_graphql_request' ) && is_graphql_request() )
 	) {
-		return equivalent_frontend_url( $term_link );
+		return $term_link;
 	}
-		! is_rewrites_enabled()
-		|| ( function_exists( 'is_graphql_request' ) && is_graphql_request() )
-	) {
-
+	
 	return equivalent_frontend_url( $term_link );
 }
 


### PR DESCRIPTION
## Description

This fixes the term_link filter callback to not modify the term link urls for GraphQL requests. 

## Related Issue(s):

fixes: #1613

replaces: https://github.com/wpengine/faustjs/pull/1616

## Testing

#### BEFORE:

Term uri is absolute in the GraphQL Response

![CleanShot 2023-10-18 at 12 51 51](https://github.com/wpengine/faustjs/assets/1260765/bd81fe0e-8978-4374-968c-c4c7c76cd6f1)


#### AFTER:

The term uri is relative in the GraphQL response

![CleanShot 2023-10-18 at 12 53 00](https://github.com/wpengine/faustjs/assets/1260765/910f50ec-ae1b-4333-be84-0db538e95a99)

But in the admin UIs the term links are absolute with the alternate Faust front-end domain.

![CleanShot 2023-10-18 at 12 53 20](https://github.com/wpengine/faustjs/assets/1260765/7e0b2d94-477e-4913-835b-bb95cc2560a6)
