### PR TITLE
Bug: Fix blockset cli failing when path contains spaces

### DIFF
--- a/.changeset/shy-pumas-grab.md
+++ b/.changeset/shy-pumas-grab.md
@@ -1,0 +1,5 @@
+---
+'@faustwp/cli': patch
+---
+
+Bug: Quote blockset "output-path" to prevent issues with space in paths.

--- a/packages/faustwp-cli/src/blockset.ts
+++ b/packages/faustwp-cli/src/blockset.ts
@@ -149,7 +149,7 @@ export async function compileBlocks(): Promise<void> {
   args = args.concat([
     '--no-watch',
     `--webpack-src-dir=${FAUST_BLOCKS_SRC_DIR}`,
-    `--output-path=${FAUST_BUILD_DIR}`,
+    `--output-path="${FAUST_BUILD_DIR}"`,
   ]);
   const res = spawnSync(command, args, {
     shell: true,


### PR DESCRIPTION
## Tasks

- [ ] I have signed a [Contributor License Agreement (CLA)](https://github.com/wpengine/faustjs#contributor-license-agreement) with WP Engine.
- [ ] If a code change, I have written testing instructions that the whole team & outside contributors can understand.
- [ ] I have written and included a comprehensive [changeset](https://github.com/wpengine/faustjs/blob/canary/DEVELOPMENT.md#deployment) to properly document the changes I've made.

## Description

Fixes a bug when blockset cli command fails to complete when a path to the output-folder contains spaces:


## Reproduction


The following error happens when you use `faust blockset` command when running the project root that contains a space in the path:
```
❯ npm run blockset

> @faustwp/block-support-example@0.1.0 blockset
> faust blockset

warn - Could not find FAUST_SECRET_KEY environment variable.
warn - Some functionality may be limited.
info - Faust: Compiling Blocks into /Users/theo.despoudis/Local Sites/my-app/.faust/build
...
ERROR in build
Module not found: Error: Can't resolve './Sites/my-app/.faust/build' in '/Users/theo.despoudis/Local Sites/my-app'
resolve './Sites/my-app/.faust/build' in '/Users/theo.despoudis/Local Sites/my-app'
  using description file: /Users/theo.despoudis/Local Sites/my-app/package.json (relative path: .)
    Field 'browser' doesn't contain a valid alias configuration
    using description file: /Users/theo.despoudis/Local Sites/my-app/package.json (relative path: ./Sites/my-app/.faust/build)
      no extension
        Field 'browser' doesn't contain a valid alias configuration
        /Users/theo.despoudis/Local Sites/my-app/Sites/my-app/.faust/build doesn't exist
      .jsx
        Field 'browser' doesn't contain a valid alias configuration
        /Users/theo.despoudis/Local Sites/my-app/Sites/my-app/.faust/build.jsx doesn't exist
      .ts
        Field 'browser' doesn't contain a valid alias configuration
        /Users/theo.despoudis/Local Sites/my-app/Sites/my-app/.faust/build.ts doesn't exist
      .tsx
        Field 'browser' doesn't contain a valid alias configuration
        /Users/theo.despoudis/Local Sites/my-app/Sites/my-app/.faust/build.tsx doesn't exist
      .js
        Field 'browser' doesn't contain a valid alias configuration
        /Users/theo.despoudis/Local Sites/my-app/Sites/my-app/.faust/build.js doesn't exist
      .json
        Field 'browser' doesn't contain a valid alias configuration
        /Users/theo.despoudis/Local Sites/my-app/Sites/my-app/.faust/build.json doesn't exist
      .wasm
        Field 'browser' doesn't contain a valid alias configuration
        /Users/theo.despoudis/Local Sites/my-app/Sites/my-app/.faust/build.wasm doesn't exist
      as directory
        /Users/theo.despoudis/Local Sites/my-app/Sites/my-app/.faust/build doesn't exist
```

`exec` command is tokenizing the  --output-path causing the issue:

```
npm verb argv "exec" "wp-scripts" "start" "--package" "@wordpress/scripts" "--loglevel" "verbose" "--" "--no-watch" "--webpack-src-dir=wp-blocks" "--output-path=/Users/theo.despoudis/Local" "Sites/my-app/.faust/build"
```

## Related Issue(s):

<!--
Provide the GitHub issue(s) number for issue tracking purposes, use the following syntax:

- #1234
-->

## Testing

<!--
Describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Also list any relevant details for your test configuration such as how to test the changes locally or in staging.
-->

## Screenshots

<!--
If this is a visual change include relevant screenshots about the behavior of the application before and after this change.
-->

## Documentation Changes

<!--
List corresponding changes to the documentation.
-->

## Dependant PRs

<!--
List any dependent PR's that are awaiting review. Use the following syntax:

- #1234
-->
