### PR TITLE
Override `axios` dependency in legacy docs for dependabot

### DIFF
--- a/internal/legacy.faustjs.org/package-lock.json
+++ b/internal/legacy.faustjs.org/package-lock.json
@@ -3930,6 +3930,11 @@
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
       "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA=="
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
     "node_modules/at-least-node": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
@@ -3971,11 +3976,13 @@
       }
     },
     "node_modules/axios": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.25.0.tgz",
-      "integrity": "sha512-cD8FOb0tRH3uuEe6+evtAbgJtfxr7ly3fQjYcMcuPlgkwVS9xboaVIpcDV+cYQe+yGykgwZCs1pzjntcGa6l5g==",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.2.tgz",
+      "integrity": "sha512-7i24Ri4pmDRfJTR7LDBhsOTtcm+9kjX5WiY1X3wIisx6G9So3pfMkEiU7emUBe46oceVImccTEM3k6C5dbVW8A==",
       "dependencies": {
-        "follow-redirects": "^1.14.7"
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/babel-loader": {
@@ -4658,6 +4665,17 @@
       "integrity": "sha512-ZI9jvcLDxqwaXEixOhArm3r7ReIivsXkpbyEWyeOhzz1QS0iSgBPnWvEqvIQtYyamGCYA88gFhmUrs9hrrQ0pg==",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/comma-separated-tokens": {
@@ -5413,6 +5431,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/depd": {
@@ -6295,6 +6321,19 @@
       "integrity": "sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/forwarded": {
@@ -9307,6 +9346,11 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "node_modules/pump": {
       "version": "3.0.0",

--- a/internal/legacy.faustjs.org/package.json
+++ b/internal/legacy.faustjs.org/package.json
@@ -42,5 +42,8 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
+  },
+  "overrides": {
+    "axios": "^1.6.2"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,9 +51,9 @@
       "dependencies": {
         "@apollo/client": "^3.8.0",
         "@apollo/experimental-nextjs-app-support": "^0.5.1",
-        "@faustwp/cli": "^1.2.0",
+        "@faustwp/cli": "^1.2.1",
         "@faustwp/core": "^1.2.0",
-        "@faustwp/experimental-app-router": "^0.2.1",
+        "@faustwp/experimental-app-router": "^0.2.2",
         "graphql": "^16.7.1",
         "next": "^14.0.1",
         "react": "^18.3.0-canary-ce2bc58a9-20231102",
@@ -253,7 +253,7 @@
       "dependencies": {
         "@apollo/client": "^3.8.8",
         "@faustwp/blocks": "2.0.0",
-        "@faustwp/cli": "^1.2.0",
+        "@faustwp/cli": "^1.2.1",
         "@faustwp/core": "^1.2.0",
         "@wordpress/base-styles": "^4.38.0",
         "@wordpress/block-library": "^8.24.0",
@@ -2108,7 +2108,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@apollo/client": "^3.6.6",
-        "@faustwp/cli": "^1.2.0",
+        "@faustwp/cli": "^1.2.1",
         "@faustwp/core": "^1.2.0",
         "@wordpress/base-styles": "^4.36.0",
         "@wordpress/block-library": "^7.19.0",
@@ -30799,12 +30799,12 @@
     },
     "packages/experimental-app-router": {
       "name": "@faustwp/experimental-app-router",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "MIT",
       "devDependencies": {
         "@apollo/client": "^3.8.0",
         "@apollo/experimental-nextjs-app-support": "^0.5.1",
-        "@faustwp/cli": "^1.1.3",
+        "@faustwp/cli": "^1.2.1",
         "@faustwp/core": "^1.1.2",
         "@testing-library/jest-dom": "^5.17.0",
         "@types/node": "^20.4.6",
@@ -31293,7 +31293,7 @@
     },
     "packages/faustwp-cli": {
       "name": "@faustwp/cli",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "license": "MIT",
       "dependencies": {
         "archiver": "^6.0.1",
@@ -35720,7 +35720,7 @@
     },
     "plugins/faustwp": {
       "name": "@faustwp/wordpress-plugin",
-      "version": "1.1.1"
+      "version": "1.1.2"
     }
   }
 }


### PR DESCRIPTION
## Tasks

- [x] I have signed a [Contributor License Agreement (CLA)](https://github.com/wpengine/faustjs#contributor-license-agreement) with WP Engine.
- [ ] If a code change, I have written testing instructions that the whole team & outside contributors can understand.
- [ ] I have written and included a comprehensive [changeset](https://github.com/wpengine/faustjs/blob/canary/DEVELOPMENT.md#deployment) to properly document the changes I've made.

## Description

Use the latest version of Axios in legacy docs site.

<!--
Include a summary of the change and some contextual information.
-->

## Related Issue(s):

<!--
Provide the GitHub issue(s) number for issue tracking purposes, use the following syntax:

- #1234
-->

## Testing

<!--
Describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Also list any relevant details for your test configuration such as how to test the changes locally or in staging.
-->

## Screenshots

<!--
If this is a visual change include relevant screenshots about the behavior of the application before and after this change.
-->

## Documentation Changes

<!--
List corresponding changes to the documentation.
-->

## Dependant PRs

<!--
List any dependent PR's that are awaiting review. Use the following syntax:

- #1234
-->
