### PR TITLE
Create process telemetry rest route

### DIFF
--- a/plugins/faustwp/includes/rest/callbacks.php
+++ b/plugins/faustwp/includes/rest/callbacks.php
@@ -110,11 +110,11 @@ function register_rest_routes() {
 		'faustwp/v1',
 		'/process_telemetry',
 		array(
-			'methods' => 'POST',
-			'callback' => __NAMESPACE__ . '\\handle_rest_process_telemetry_callback',
+			'methods'             => 'POST',
+			'callback'            => __NAMESPACE__ . '\\handle_rest_process_telemetry_callback',
 			'permission_callback' => __NAMESPACE__ . '\\rest_process_telemetry_permission_callback',
 		)
-		);
+	);
 
 	/**
 	 * Faust.js packages now use `faustwp/v1/authorize`.
@@ -200,68 +200,76 @@ function handle_rest_telemetry_callback( \WP_REST_Request $request ) {
  * @return mixed A \WP_REST_Response, array, or \WP_Error.
  */
 function handle_rest_process_telemetry_callback( \WP_REST_Request $request ) {
-	if(!get_telemetry_client_id()) {
-		return new \WP_REST_Response(null, 204);
+	if ( ! get_telemetry_client_id() ) {
+		return new \WP_REST_Response( null, 204 );
 	}
 
 	$body = $request->get_json_params();
 
-	$faust_plugin_data = get_anonymous_faustwp_data();
+	$faust_plugin_data          = get_anonymous_faustwp_data();
 	$content_blocks_plugin_data = get_anonymous_wpgraphql_content_blocks_data();
 
-	$GA_TRACKING_ENDPOINT = 'https://www.google-analytics.com/mp/collect';
-	$GA_TRACKING_ID = 'G-KPVSTHK1G4';
-	$GA_API_SECRET = '-SLuZb8JTbWkWcT5BD032w';
+	$ga_tracking_endpoint = 'https://www.google-analytics.com/mp/collect';
+	$ga_tracking_id       = 'G-KPVSTHK1G4';
+	$ga_key               = '-SLuZb8JTbWkWcT5BD032w';
 
-	$telemetry_data = [
-		'node_faustwp_core_version' => $body['node_faustwp_core_version'] ?? null,
-		'node_faustwp_cli_version' => $body['node_faustwp_cli_version'] ?? null,
-		'node_faustwp_blocks_version' => $body['node_faustwp_blocks_version'] ?? null,
-		'node_apollo_client_version' => $body['node_apollo_client_version'] ?? null,
-		'node_version' => $body['node_version'] ?? null,
-		'node_next_version' => $body['node_next_version'] ?? null,
-		'node_is_development' => $body['node_is_development'] ?? null,
-		'command' => $body['command'] ?? null,
+	$telemetry_data = array(
+		'node_faustwp_core_version'           => $body['node_faustwp_core_version'] ?? null,
+		'node_faustwp_cli_version'            => $body['node_faustwp_cli_version'] ?? null,
+		'node_faustwp_blocks_version'         => $body['node_faustwp_blocks_version'] ?? null,
+		'node_apollo_client_version'          => $body['node_apollo_client_version'] ?? null,
+		'node_version'                        => $body['node_version'] ?? null,
+		'node_next_version'                   => $body['node_next_version'] ?? null,
+		'node_is_development'                 => $body['node_is_development'] ?? null,
+		'command'                             => $body['command'] ?? null,
 
-		'setting_has_frontend_uri' => $faust_plugin_data['has_frontend_uri'],
-		'setting_redirects_enabled' => $faust_plugin_data['redirects_enabled'],
-		'setting_rewrites_enabled' => $faust_plugin_data['rewrites_enabled'],
-		'setting_themes_disabled' => $faust_plugin_data['themes_disabled'],
+		'setting_has_frontend_uri'            => $faust_plugin_data['has_frontend_uri'],
+		'setting_redirects_enabled'           => $faust_plugin_data['redirects_enabled'],
+		'setting_rewrites_enabled'            => $faust_plugin_data['rewrites_enabled'],
+		'setting_themes_disabled'             => $faust_plugin_data['themes_disabled'],
 		'setting_img_src_replacement_enabled' => $faust_plugin_data['image_source_replacement_enabled'],
-		'faustwp_version' => $faust_plugin_data['version'],
+		'faustwp_version'                     => $faust_plugin_data['version'],
 
-		'wpgraphql_content_blocks_version' => $content_blocks_plugin_data['version'],
+		'wpgraphql_content_blocks_version'    => $content_blocks_plugin_data['version'],
 
-		'is_wpe' => is_wpe(),
-		'multisite' => is_multisite(),
-		'php_version' => PHP_VERSION,
-		'wp_version' => get_wp_version(),
-	];
+		'is_wpe'                              => is_wpe(),
+		'multisite'                           => is_multisite(),
+		'php_version'                         => PHP_VERSION,
+		'wp_version'                          => get_wp_version(),
+	);
 
-	$ga_telemetry_url = add_query_arg([
-		'measurement_id' => $GA_TRACKING_ID,
-		'api_secret' => $GA_API_SECRET
-	], $GA_TRACKING_ENDPOINT);
+	$ga_telemetry_url = add_query_arg(
+		array(
+			'measurement_id' => $ga_tracking_id,
+			'api_secret'     => $ga_key,
+		),
+		$ga_tracking_endpoint
+	);
 
-	$telemetry_body = [
-			'client_id' => get_telemetry_client_id(),
-			'events' => [
-				[
-					'name' => 'telemetry_event',
-					'params' => $telemetry_data
-				]
-			]
-	];
+	$telemetry_body = array(
+		'client_id' => get_telemetry_client_id(),
+		'events'    => array(
+			array(
+				'name'   => 'telemetry_event',
+				'params' => $telemetry_data,
+			),
+		),
+	);
 
 	/**
-	 * @TODO This code should be uncommented once we can accept/decline the 
+	 * This code should be uncommented once we can accept/decline the
 	 * telemetry option and an appropriate clientID is generated for the site.
+	 *
+	 * @TODO
 	 */
-	// wp_remote_post($ga_telemetry_url, [
-	// 	'body' => $telemetry_body,
-	// ]);
 
-	return new \WP_REST_Response([$telemetry_body, $ga_telemetry_url], 201);
+	// @codingStandardsIgnoreStart
+	// wp_remote_post($ga_telemetry_url, [
+	// 'body' => $telemetry_body,
+	// ]);
+  // @codingStandardsIgnoreEnd
+
+	return new \WP_REST_Response( array( $telemetry_body, $ga_telemetry_url ), 201 );
 }
 
 /**

--- a/plugins/faustwp/includes/rest/callbacks.php
+++ b/plugins/faustwp/includes/rest/callbacks.php
@@ -20,6 +20,7 @@ use function WPE\FaustWP\Telemetry\{
 	is_wpe,
 	get_anonymous_faustwp_data,
 	get_anonymous_wpgraphql_content_blocks_data,
+	get_telemetry_client_id
 };
 use function WPE\FaustWP\Blocks\handle_uploaded_blockset;
 
@@ -105,6 +106,16 @@ function register_rest_routes() {
 		)
 	);
 
+	register_rest_route(
+		'faustwp/v1',
+		'/process_telemetry',
+		array(
+			'methods' => 'POST',
+			'callback' => __NAMESPACE__ . '\\handle_rest_process_telemetry_callback',
+			'permission_callback' => __NAMESPACE__ . '\\rest_process_telemetry_permission_callback',
+		)
+		);
+
 	/**
 	 * Faust.js packages now use `faustwp/v1/authorize`.
 	 *
@@ -177,6 +188,83 @@ function handle_rest_telemetry_callback( \WP_REST_Request $request ) {
 }
 
 /**
+ * Callback for WordPress register_rest_route() 'callback' parameter.
+ *
+ * Handle POST /faustwp/v1/process_telemetry response.
+ *
+ * @link https://developer.wordpress.org/reference/functions/register_rest_route/
+ * @link https://developer.wordpress.org/rest-api/extending-the-rest-api/routes-and-endpoints/#endpoint-callback
+ *
+ * @param \WP_REST_Request $request Current \WP_REST_Request object.
+ *
+ * @return mixed A \WP_REST_Response, array, or \WP_Error.
+ */
+function handle_rest_process_telemetry_callback( \WP_REST_Request $request ) {
+	if(!get_telemetry_client_id()) {
+		return new \WP_REST_Response(null, 204);
+	}
+
+	$body = $request->get_json_params();
+
+	$faust_plugin_data = get_anonymous_faustwp_data();
+	$content_blocks_plugin_data = get_anonymous_wpgraphql_content_blocks_data();
+
+	$GA_TRACKING_ENDPOINT = 'https://www.google-analytics.com/mp/collect';
+	$GA_TRACKING_ID = 'G-KPVSTHK1G4';
+	$GA_API_SECRET = '-SLuZb8JTbWkWcT5BD032w';
+
+	$telemetry_data = [
+		'node_faustwp_core_version' => $body['node_faustwp_core_version'] ?? null,
+		'node_faustwp_cli_version' => $body['node_faustwp_cli_version'] ?? null,
+		'node_faustwp_blocks_version' => $body['node_faustwp_blocks_version'] ?? null,
+		'node_apollo_client_version' => $body['node_apollo_client_version'] ?? null,
+		'node_version' => $body['node_version'] ?? null,
+		'node_next_version' => $body['node_next_version'] ?? null,
+		'node_is_development' => $body['node_is_development'] ?? null,
+		'command' => $body['command'] ?? null,
+
+		'setting_has_frontend_uri' => $faust_plugin_data['has_frontend_uri'],
+		'setting_redirects_enabled' => $faust_plugin_data['redirects_enabled'],
+		'setting_rewrites_enabled' => $faust_plugin_data['rewrites_enabled'],
+		'setting_themes_disabled' => $faust_plugin_data['themes_disabled'],
+		'setting_img_src_replacement_enabled' => $faust_plugin_data['image_source_replacement_enabled'],
+		'faustwp_version' => $faust_plugin_data['version'],
+
+		'wpgraphql_content_blocks_version' => $content_blocks_plugin_data['version'],
+
+		'is_wpe' => is_wpe(),
+		'multisite' => is_multisite(),
+		'php_version' => PHP_VERSION,
+		'wp_version' => get_wp_version(),
+	];
+
+	$ga_telemetry_url = add_query_arg([
+		'measurement_id' => $GA_TRACKING_ID,
+		'api_secret' => $GA_API_SECRET
+	], $GA_TRACKING_ENDPOINT);
+
+	$telemetry_body = [
+			'client_id' => get_telemetry_client_id(),
+			'events' => [
+				[
+					'name' => 'telemetry_event',
+					'params' => $telemetry_data
+				]
+			]
+	];
+
+	/**
+	 * @TODO This code should be uncommented once we can accept/decline the 
+	 * telemetry option and an appropriate clientID is generated for the site.
+	 */
+	// wp_remote_post($ga_telemetry_url, [
+	// 	'body' => $telemetry_body,
+	// ]);
+
+	return new \WP_REST_Response([$telemetry_body, $ga_telemetry_url], 201);
+}
+
+/**
  * Callback to check permissions for requests to `faustwp/v1/blockset`.
  *
  * Authorized if the 'secret_key' settings value and http header 'x-faustwp-secret' match.
@@ -199,6 +287,19 @@ function rest_blockset_permission_callback( \WP_REST_Request $request ) {
  * @return bool True if current user can, false if else.
  */
 function rest_telemetry_permission_callback( \WP_REST_Request $request ) {
+	return rest_authorize_permission_callback( $request );
+}
+
+/**
+ * Callback to check permissions for requests to `faustwp/v1/process_telemetry`.
+ *
+ * Authorized if the 'secret_key' settings value and http header 'x-faustwp-secret' match.
+ *
+ * @param \WP_REST_Request $request The current \WP_REST_Request object.
+ *
+ * @return bool True if current user can, false if else.
+ */
+function rest_process_telemetry_permission_callback( \WP_REST_Request $request ) {
 	return rest_authorize_permission_callback( $request );
 }
 

--- a/plugins/faustwp/includes/telemetry/functions.php
+++ b/plugins/faustwp/includes/telemetry/functions.php
@@ -103,3 +103,18 @@ function get_plugin_version() {
 function get_wpgraphql_content_blocks_plugin_version() {
 	return defined( 'WPGRAPHQL_CONTENT_BLOCKS_VERSION' ) ? WPGRAPHQL_CONTENT_BLOCKS_VERSION : null;
 }
+
+/**
+ * Returns the anonymous client id for this site that has opted in for telemetry
+ */
+function get_telemetry_client_id(): string|null  {
+	/**
+	 * @TODO Upon saving the site's telemetry decision, if they accept, we'll
+	 * also need to generate a unique, anonymous client ID for them to be sent 
+	 * with GA requests.
+	 * 
+	 * If a string is returned, telemetry is enabled and a client id has been generated.
+	 * If this function returns null, either telemetry is off, or a client ID is not created.
+	 */
+ return null;
+}

--- a/plugins/faustwp/includes/telemetry/functions.php
+++ b/plugins/faustwp/includes/telemetry/functions.php
@@ -105,16 +105,20 @@ function get_wpgraphql_content_blocks_plugin_version() {
 }
 
 /**
- * Returns the anonymous client id for this site that has opted in for telemetry
+ * Returns the anonymous client id for this site that has opted in for telemetry.
+ *
+ * @return string|null
  */
-function get_telemetry_client_id(): string|null  {
+function get_telemetry_client_id(): string|null {
 	/**
-	 * @TODO Upon saving the site's telemetry decision, if they accept, we'll
-	 * also need to generate a unique, anonymous client ID for them to be sent 
+	 * Upon saving the site's telemetry decision, if they accept, we'll
+	 * also need to generate a unique, anonymous client ID for them to be sent
 	 * with GA requests.
-	 * 
+	 *
 	 * If a string is returned, telemetry is enabled and a client id has been generated.
 	 * If this function returns null, either telemetry is off, or a client ID is not created.
+	 *
+	 * @TODO
 	 */
- return null;
+	return null;
 }

--- a/plugins/faustwp/tests/integration/ProcessTelemetryRouteTests.php
+++ b/plugins/faustwp/tests/integration/ProcessTelemetryRouteTests.php
@@ -20,9 +20,21 @@ class ProcessTelemetryRouteTest extends WP_UnitTestCase
       "command" => "xxxx"
   ];
 
+  protected $option = 'faustwp_settings';
+	protected $init_settings = [
+		'frontend_uri' => 'http://localhost:3000',
+		'secret_key' => 'valid-secret-key',
+		'menu_locations' => 'Primary, Footer',
+		'enable_redirects' => '1',
+		'enable_rewrites' => '1',
+		'disable_theme' => '1',
+	];
+
   public function setUp(): void
   {
     parent::setUp();
+
+    update_option( $this->option, $this->init_settings );
 
     // Set up a REST server instance.
     global $wp_rest_server;
@@ -67,9 +79,12 @@ class ProcessTelemetryRouteTest extends WP_UnitTestCase
   public function testRequestWithTelemetryDisabled()
   {
     $this->request->add_header('Content-Type', 'application/json');
+    $this->request->add_header('x-faustwp-secret', 'valid-secret-key');
     $this->request->set_body(json_encode($this->valid_body));
 
     $response = $this->server->dispatch( $this->request );
+
+    var_dump($response->status);
 
     var_dump($response);
 

--- a/plugins/faustwp/tests/integration/ProcessTelemetryRouteTests.php
+++ b/plugins/faustwp/tests/integration/ProcessTelemetryRouteTests.php
@@ -59,6 +59,8 @@ class ProcessTelemetryRouteTest extends WP_UnitTestCase
     $response = $this->server->dispatch( $this->request );
     $data = $response->get_data();
 
+    $response->
+
     $this->assertEquals( $data['http_response'], 401 );
   }
 
@@ -68,7 +70,12 @@ class ProcessTelemetryRouteTest extends WP_UnitTestCase
     $this->request->set_body(json_encode($this->valid_body));
 
     $response = $this->server->dispatch( $this->request );
+
+    var_dump($response);
+
     $data = $response->get_data();
+
+    var_dump($data);
 
     $this->assertEquals( $data['http_response'], 204 );
   }

--- a/plugins/faustwp/tests/integration/ProcessTelemetryRouteTests.php
+++ b/plugins/faustwp/tests/integration/ProcessTelemetryRouteTests.php
@@ -55,6 +55,8 @@ class ProcessTelemetryRouteTest extends WP_UnitTestCase
     $wp_rest_server = null;
 
     parent::tearDown();
+
+    delete_option( 'faustwp_settings' );
   }
 
   public function testRouteIsRegistered()
@@ -79,6 +81,8 @@ class ProcessTelemetryRouteTest extends WP_UnitTestCase
     $this->request->add_header('Content-Type', 'application/json');
     $this->request->add_header('x-faustwp-secret', 'valid-secret-key');
     $this->request->set_body(json_encode($this->valid_body));
+
+    var_dump(get_option($this->option));
 
     var_dump(get_secret_key());
 

--- a/plugins/faustwp/tests/integration/ProcessTelemetryRouteTests.php
+++ b/plugins/faustwp/tests/integration/ProcessTelemetryRouteTests.php
@@ -24,7 +24,7 @@ class ProcessTelemetryRouteTest extends WP_UnitTestCase
   protected $option = 'faustwp_settings';
 	protected $init_settings = [
 		'frontend_uri' => 'http://localhost:3000',
-		'secret_key' => 'valid-secret-key',
+		'secret_key' => '2b9b7ec9-73f8-407d-b5b3-6f3e56bb555d',
 		'menu_locations' => 'Primary, Footer',
 		'enable_redirects' => '1',
 		'enable_rewrites' => '1',

--- a/plugins/faustwp/tests/integration/ProcessTelemetryRouteTests.php
+++ b/plugins/faustwp/tests/integration/ProcessTelemetryRouteTests.php
@@ -92,15 +92,15 @@ class ProcessTelemetryRouteTest extends WP_UnitTestCase
    * @TODO This test should be uncommented once get_telemetry_client_id()
    * function has been properly setup.
    */
-  public function testRequestWithTelemetryEnabled()
-  {
-    $this->request->add_header('Content-Type', 'application/json');
-    $this->request->add_header('x-faustwp-secret', $this->init_settings['secret_key']);
-    $this->request->set_body(json_encode($this->valid_body));
+  // public function testRequestWithTelemetryEnabled()
+  // {
+  //   $this->request->add_header('Content-Type', 'application/json');
+  //   $this->request->add_header('x-faustwp-secret', $this->init_settings['secret_key']);
+  //   $this->request->set_body(json_encode($this->valid_body));
 
-    $response = $this->server->dispatch( $this->request );
+  //   $response = $this->server->dispatch( $this->request );
 
-    $this->assertEquals( $response->status, 201 );
-  }
+  //   $this->assertEquals( $response->status, 201 );
+  // }
 
 }

--- a/plugins/faustwp/tests/integration/ProcessTelemetryRouteTests.php
+++ b/plugins/faustwp/tests/integration/ProcessTelemetryRouteTests.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Tests\WPUnit\Routes;
+namespace WPE\FaustWP\Tests\Integration;
 
-use Codeception\TestCase\WPTestCase;
+use \WP_UnitTestCase;
 
-class ProcessTelemetryRouteTest extends WPTestCase
+class ProcessTelemetryRouteTest extends WP_UnitTestCase
 {
   private $request;
   private $route_name;

--- a/plugins/faustwp/tests/integration/ProcessTelemetryRouteTests.php
+++ b/plugins/faustwp/tests/integration/ProcessTelemetryRouteTests.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Tests\WPUnit\Routes;
+
+use Codeception\TestCase\WPTestCase;
+
+class ProcessTelemetryRouteTest extends WPTestCase
+{
+  private $request;
+  private $route_name;
+
+  private $valid_body = [
+      "node_faustwp_core_version" => "xxxx",
+      "node_faustwp_cli_version" => "xxxx",
+      "node_faustwp_blocks_version" => "xxxx",
+      "node_apollo_client_version" => "xxxx",
+      "node_version" => "xxxx",
+      "node_next_version" => "xxxx",
+      "node_is_development" => "xxxx",
+      "command" => "xxxx"
+  ];
+
+  public function setUp(): void
+  {
+    parent::setUp();
+
+    // Set up a REST server instance.
+    global $wp_rest_server;
+
+    $this->server = $wp_rest_server = new \WP_REST_Server;
+    do_action( 'rest_api_init' );
+
+    // Helper.
+    $this->route_name = '/faustwp/v1/process_telemetry';
+    $this->request = new \WP_REST_Request( 'POST', $this->route_name );
+  }
+
+  public function tearDown(): void
+  {
+    // Test cleanup.
+    global $wp_rest_server;
+    $wp_rest_server = null;
+
+    parent::tearDown();
+  }
+
+  public function testRouteIsRegistered()
+  {
+    $routes = $this->server->get_routes();
+
+    $this->assertArrayHasKey($this->route_name, $routes);
+  }
+
+  public function testRequestWithNoAuthHeaderReturnsForbidden()
+  {
+    $this->request->add_header('Content-Type', 'application/json');
+    $this->request->set_body(json_encode($this->valid_body));
+
+    $response = $this->server->dispatch( $this->request );
+    $data = $response->get_data();
+
+    $this->assertEquals( $data['http_response'], 401 );
+  }
+
+  public function testRequestWithTelemetryDisabled()
+  {
+    $this->request->add_header('Content-Type', 'application/json');
+    $this->request->set_body(json_encode($this->valid_body));
+
+    $response = $this->server->dispatch( $this->request );
+    $data = $response->get_data();
+
+    $this->assertEquals( $data['http_response'], 204 );
+  }
+
+  public function testRequestWithTelemetryEnabled()
+  {
+    $this->request->add_header('Content-Type', 'application/json');
+    $this->request->set_body(json_encode($this->valid_body));
+
+    $response = $this->server->dispatch( $this->request );
+    $data = $response->get_data();
+
+    $this->assertEquals( $data['http_response'], 201 );
+  }
+
+}

--- a/plugins/faustwp/tests/integration/ProcessTelemetryRouteTests.php
+++ b/plugins/faustwp/tests/integration/ProcessTelemetryRouteTests.php
@@ -79,16 +79,10 @@ class ProcessTelemetryRouteTest extends WP_UnitTestCase
   public function testRequestWithTelemetryDisabled()
   {
     $this->request->add_header('Content-Type', 'application/json');
-    $this->request->add_header('x-faustwp-secret', 'valid-secret-key');
+    $this->request->add_header('x-faustwp-secret', $this->init_settings['secret_key']);
     $this->request->set_body(json_encode($this->valid_body));
 
-    var_dump(get_option($this->option));
-
-    var_dump(get_secret_key());
-
     $response = $this->server->dispatch( $this->request );
-
-    var_dump($response);
 
     $this->assertEquals( $response->status, 204 );
   }
@@ -96,7 +90,7 @@ class ProcessTelemetryRouteTest extends WP_UnitTestCase
   public function testRequestWithTelemetryEnabled()
   {
     $this->request->add_header('Content-Type', 'application/json');
-    $this->request->add_header('x-faustwp-secret', 'valid-secret-key');
+    $this->request->add_header('x-faustwp-secret', $this->init_settings['secret_key']);
     $this->request->set_body(json_encode($this->valid_body));
 
     $response = $this->server->dispatch( $this->request );

--- a/plugins/faustwp/tests/integration/ProcessTelemetryRouteTests.php
+++ b/plugins/faustwp/tests/integration/ProcessTelemetryRouteTests.php
@@ -87,6 +87,11 @@ class ProcessTelemetryRouteTest extends WP_UnitTestCase
     $this->assertEquals( $response->status, 204 );
   }
 
+
+  /**
+   * @TODO This test should be uncommented once get_telemetry_client_id()
+   * function has been properly setup.
+   */
   public function testRequestWithTelemetryEnabled()
   {
     $this->request->add_header('Content-Type', 'application/json');

--- a/plugins/faustwp/tests/integration/ProcessTelemetryRouteTests.php
+++ b/plugins/faustwp/tests/integration/ProcessTelemetryRouteTests.php
@@ -3,6 +3,7 @@
 namespace WPE\FaustWP\Tests\Integration;
 
 use \WP_UnitTestCase;
+use function WPE\FaustWP\Settings\get_secret_key;
 
 class ProcessTelemetryRouteTest extends WP_UnitTestCase
 {
@@ -69,11 +70,8 @@ class ProcessTelemetryRouteTest extends WP_UnitTestCase
     $this->request->set_body(json_encode($this->valid_body));
 
     $response = $this->server->dispatch( $this->request );
-    $data = $response->get_data();
 
-    $response->
-
-    $this->assertEquals( $data['http_response'], 401 );
+    $this->assertEquals( $response->status, 401 );
   }
 
   public function testRequestWithTelemetryDisabled()
@@ -82,28 +80,24 @@ class ProcessTelemetryRouteTest extends WP_UnitTestCase
     $this->request->add_header('x-faustwp-secret', 'valid-secret-key');
     $this->request->set_body(json_encode($this->valid_body));
 
-    $response = $this->server->dispatch( $this->request );
+    var_dump(get_secret_key());
 
-    var_dump($response->status);
+    $response = $this->server->dispatch( $this->request );
 
     var_dump($response);
 
-    $data = $response->get_data();
-
-    var_dump($data);
-
-    $this->assertEquals( $data['http_response'], 204 );
+    $this->assertEquals( $response->status, 204 );
   }
 
   public function testRequestWithTelemetryEnabled()
   {
     $this->request->add_header('Content-Type', 'application/json');
+    $this->request->add_header('x-faustwp-secret', 'valid-secret-key');
     $this->request->set_body(json_encode($this->valid_body));
 
     $response = $this->server->dispatch( $this->request );
-    $data = $response->get_data();
 
-    $this->assertEquals( $data['http_response'], 201 );
+    $this->assertEquals( $response->status, 201 );
   }
 
 }


### PR DESCRIPTION
## Tasks

- [x] I have signed a [Contributor License Agreement (CLA)](https://github.com/wpengine/faustjs#contributor-license-agreement) with WP Engine.
- [x] If a code change, I have written testing instructions that the whole team & outside contributors can understand.
- [ ] I have written and included a comprehensive [changeset](https://github.com/wpengine/faustjs/blob/canary/DEVELOPMENT.md#deployment) to properly document the changes I've made.

## Description

This PR creates a REST endpoint that accepts a body from the CLI, merges that data with data from WordPress, and then sends it off to GA if the user has Faust telemetry activated on WordPress.

The body looks like:

```
{
    "node_faustwp_core_version": "xxxx",
    "node_faustwp_cli_version": "xxxx",
    "node_faustwp_blocks_version": "xxxx",
    "node_apollo_client_version": "xxxx",
    "node_version": "xxxx",
    "node_next_version": "xxxx",
    "node_is_development": "xxxx",
    "command": "xxxx"
}
```

<!--
Include a summary of the change and some contextual information.
-->

## Related Issue(s):

<!--
Provide the GitHub issue(s) number for issue tracking purposes, use the following syntax:

- #1234
-->

## Testing

1. Checkout this branch
2. Make a request to `/wp-json/faustwp/v1/process_telemetry` and see the `401` response since you didn't pass a secret key
3. Add the secret key as the header `x-faustwp-secret` and verify you got a `204` response (no content).
4. Modify the `get_telemetry_client_id` function to return a string and notice a `201` is returned (created).
5. Try to break it

<!--
Describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Also list any relevant details for your test configuration such as how to test the changes locally or in staging.
-->

## Screenshots

<!--
If this is a visual change include relevant screenshots about the behavior of the application before and after this change.
-->

## Documentation Changes

<!--
List corresponding changes to the documentation.
-->

## Dependant PRs

<!--
List any dependent PR's that are awaiting review. Use the following syntax:

- #1234
-->
