### PR TITLE
Generate UUID v4 for telemetry ID

### DIFF
--- a/plugins/faustwp/includes/rest/callbacks.php
+++ b/plugins/faustwp/includes/rest/callbacks.php
@@ -223,9 +223,6 @@ function handle_rest_process_telemetry_callback( \WP_REST_Request $request ) {
 	if ( ! is_telemetry_enabled() ) {
 		return new \WP_REST_Response( null, 204 );
 	}
-	if ( ! get_telemetry_client_id() ) {
-		return new \WP_REST_Response( null, 204 );
-	}
 
 	$body = $request->get_json_params();
 

--- a/plugins/faustwp/includes/rest/callbacks.php
+++ b/plugins/faustwp/includes/rest/callbacks.php
@@ -25,6 +25,7 @@ use function WPE\FaustWP\Telemetry\{
 use function WPE\FaustWP\Blocks\handle_uploaded_blockset;
 use function WPE\FaustWP\Settings\faustwp_get_setting;
 use function WPE\FaustWP\Settings\faustwp_update_setting;
+use function WPE\FaustWP\Settings\is_telemetry_enabled;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -219,6 +220,9 @@ function handle_rest_telemetry_callback( \WP_REST_Request $request ) {
  * @return mixed A \WP_REST_Response, array, or \WP_Error.
  */
 function handle_rest_process_telemetry_callback( \WP_REST_Request $request ) {
+	if ( ! is_telemetry_enabled() ) {
+		return new \WP_REST_Response( null, 204 );
+	}
 	if ( ! get_telemetry_client_id() ) {
 		return new \WP_REST_Response( null, 204 );
 	}

--- a/plugins/faustwp/includes/settings/callbacks.php
+++ b/plugins/faustwp/includes/settings/callbacks.php
@@ -449,7 +449,7 @@ function display_enable_disable_fields() {
 			<input type="checkbox" id="enable_telemetry" name="faustwp_settings[enable_telemetry]" value="1" <?php checked( $enable_telemetry ); ?> />
 			<?php esc_html_e( 'Enable anonymous telemetry', 'faustwp' ); ?>
 		</label>
-		<input type="hidden" id="telemetry_client_id" name="faustwp_settings[telemetry_client_id]" value="<?php echo get_telemetry_client_id(); ?>" />
+		<input type="hidden" id="telemetry_client_id" name="faustwp_settings[telemetry_client_id]" value="<?php echo esc_attr( get_telemetry_client_id() ); ?>" />
 	</fieldset>
 	<?php
 }

--- a/plugins/faustwp/includes/settings/callbacks.php
+++ b/plugins/faustwp/includes/settings/callbacks.php
@@ -239,6 +239,14 @@ function sanitize_faustwp_settings( $settings, $option ) {
 				}
 				break;
 
+			case 'telemetry_client_id':
+				if ( $value ) {
+					$settings[ $name ] = sanitize_text_field( $value );
+				} else {
+					unset( $settings[ $name ] );
+				}
+				break;
+
 			default:
 				// Remove any settings we don't expect.
 				unset( $settings[ $name ] );

--- a/plugins/faustwp/includes/settings/callbacks.php
+++ b/plugins/faustwp/includes/settings/callbacks.php
@@ -7,6 +7,7 @@
 
 namespace WPE\FaustWP\Settings;
 
+use function WPE\FaustWP\Telemetry\get_telemetry_client_id;
 use function WPE\FaustWP\Utilities\{
 	plugin_version,
 };
@@ -242,8 +243,6 @@ function sanitize_faustwp_settings( $settings, $option ) {
 			case 'telemetry_client_id':
 				if ( $value ) {
 					$settings[ $name ] = sanitize_text_field( $value );
-				} else {
-					unset( $settings[ $name ] );
 				}
 				break;
 
@@ -450,6 +449,7 @@ function display_enable_disable_fields() {
 			<input type="checkbox" id="enable_telemetry" name="faustwp_settings[enable_telemetry]" value="1" <?php checked( $enable_telemetry ); ?> />
 			<?php esc_html_e( 'Enable anonymous telemetry', 'faustwp' ); ?>
 		</label>
+		<input type="hidden" id="telemetry_client_id" name="faustwp_settings[telemetry_client_id]" value="<?php echo get_telemetry_client_id(); ?>" />
 	</fieldset>
 	<?php
 }

--- a/plugins/faustwp/includes/settings/functions.php
+++ b/plugins/faustwp/includes/settings/functions.php
@@ -7,6 +7,9 @@
 
 namespace WPE\FaustWP\Settings;
 
+use function WPE\FaustWP\Telemetry\generate_telemetry_client_id;
+use function WPE\FaustWP\Telemetry\get_telemetry_client_id;
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
@@ -148,8 +151,9 @@ function faustwp_get_settings() {
  * @return void
  */
 function maybe_set_default_settings() {
-	$secret_key = get_secret_key();
-	$settings   = faustwp_get_settings();
+	$secret_key          = get_secret_key();
+	$settings            = faustwp_get_settings();
+	$telemetry_client_id = get_telemetry_client_id();
 
 	if ( empty( $settings ) ) {
 		faustwp_update_setting( 'disable_theme', '0' );
@@ -165,6 +169,10 @@ function maybe_set_default_settings() {
 
 	if ( ! $secret_key ) {
 		faustwp_update_setting( 'secret_key', wp_generate_uuid4() );
+	}
+
+	if ( ! $telemetry_client_id ) {
+		generate_telemetry_client_id();
 	}
 }
 

--- a/plugins/faustwp/includes/telemetry/functions.php
+++ b/plugins/faustwp/includes/telemetry/functions.php
@@ -112,7 +112,12 @@ function get_wpgraphql_content_blocks_plugin_version() {
  */
 function get_telemetry_client_id(): string {
 	// Use the default fallback param to generate and save the uuid if not already saved.
-	return faustwp_get_setting( 'telemetry_uuid', generate_telemetry_client_id() );
+	$id = faustwp_get_setting( 'telemetry_client_id', false );
+	if ( empty( $id ) ) {
+		$id = generate_telemetry_client_id();
+	}
+
+	return $id;
 }
 
 /**

--- a/plugins/faustwp/includes/telemetry/functions.php
+++ b/plugins/faustwp/includes/telemetry/functions.php
@@ -13,6 +13,7 @@ use function WPE\FaustWP\Settings\{
 	is_themes_disabled,
 	is_image_source_replacement_enabled,
 	faustwp_get_setting,
+	faustwp_update_setting,
 };
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -107,18 +108,20 @@ function get_wpgraphql_content_blocks_plugin_version() {
 /**
  * Returns the anonymous client id for this site that has opted in for telemetry.
  *
- * @return string|null
+ * @return string
  */
-function get_telemetry_client_id(): string|null {
-	/**
-	 * Upon saving the site's telemetry decision, if they accept, we'll
-	 * also need to generate a unique, anonymous client ID for them to be sent
-	 * with GA requests.
-	 *
-	 * If a string is returned, telemetry is enabled and a client id has been generated.
-	 * If this function returns null, either telemetry is off, or a client ID is not created.
-	 *
-	 * @TODO
-	 */
-	return null;
+function get_telemetry_client_id(): string {
+	// Use the default fallback param to generate and save the uuid if not already saved.
+	return faustwp_get_setting( 'telemetry_uuid', generate_telemetry_client_id() );
+}
+
+/**
+ * Generates a random uuidv4 and saves it for use with telemetry collection.
+ *
+ * @return string
+ */
+function generate_telemetry_client_id(): string {
+	$id = wp_generate_uuid4();
+	faustwp_update_setting( 'telemetry_client_id', $id );
+	return $id;
 }

--- a/plugins/faustwp/tests/integration/ProcessTelemetryRouteTests.php
+++ b/plugins/faustwp/tests/integration/ProcessTelemetryRouteTests.php
@@ -5,7 +5,7 @@ namespace WPE\FaustWP\Tests\Integration;
 use \WP_UnitTestCase;
 use function WPE\FaustWP\Settings\get_secret_key;
 
-class ProcessTelemetryRouteTest extends WP_UnitTestCase
+class ProcessTelemetryRouteTests extends WP_UnitTestCase
 {
   private $request;
   private $route_name;

--- a/plugins/faustwp/tests/integration/TelemetryCallbacksTests.php
+++ b/plugins/faustwp/tests/integration/TelemetryCallbacksTests.php
@@ -5,7 +5,7 @@
  * @package FaustWP
  */
 
-namespace WPE\FaustWP\Tests\Unit;
+namespace WPE\FaustWP\Tests\Integration;
 
 use \WP_UnitTestCase;
 use function \wp_set_current_user;

--- a/plugins/faustwp/tests/integration/TelemetryFunctionsTests.php
+++ b/plugins/faustwp/tests/integration/TelemetryFunctionsTests.php
@@ -40,6 +40,8 @@ class TelemetryFunctionsTests extends WP_UnitTestCase {
 		self::assertNotEmpty( generate_telemetry_client_id() );
 		$id = get_telemetry_client_id();
 		self::assertTrue( wp_is_uuid( $id ) );
+		$options = get_option( 'faustwp_settings' );
+		self::assertSame( $options['telemetry_client_id'], $id );
 	}
 
 }

--- a/plugins/faustwp/tests/integration/TelemetryFunctionsTests.php
+++ b/plugins/faustwp/tests/integration/TelemetryFunctionsTests.php
@@ -13,6 +13,8 @@ use function WPE\FaustWP\Settings\{
 };
 use function WPE\FaustWP\Telemetry\{
 	has_frontend_uri,
+	generate_telemetry_client_id,
+    get_telemetry_client_id,
 };
 
 class TelemetryFunctionsTests extends WP_UnitTestCase {
@@ -31,6 +33,13 @@ class TelemetryFunctionsTests extends WP_UnitTestCase {
 	public function test_has_frontend_uri_returns_true_if_frontend_uri_setting_has_valid_url() {
 		faustwp_update_setting( 'frontend_uri', 'https://example.org' );
 		$this->assertTrue( has_frontend_uri() );
+	}
+
+	public function test_generate_telemetry_client_id_generates_and_saves_a_valid_id_when_one_is_not_present(): void {
+		delete_option( 'faustwp_settings' );
+		self::assertNotEmpty( generate_telemetry_client_id() );
+		$id = get_telemetry_client_id();
+		self::assertTrue( wp_is_uuid( $id ) );
 	}
 
 }

--- a/plugins/faustwp/tests/integration/TelemetryFunctionsTests.php
+++ b/plugins/faustwp/tests/integration/TelemetryFunctionsTests.php
@@ -37,11 +37,10 @@ class TelemetryFunctionsTests extends WP_UnitTestCase {
 
 	public function test_generate_telemetry_client_id_generates_and_saves_a_valid_id_when_one_is_not_present(): void {
 		delete_option( 'faustwp_settings' );
-		self::assertNotEmpty( generate_telemetry_client_id() );
-		$id = get_telemetry_client_id();
+		$id = generate_telemetry_client_id();
+		self::assertNotEmpty( $id );
 		self::assertTrue( wp_is_uuid( $id ) );
-		$options = get_option( 'faustwp_settings' );
-		self::assertSame( $options['telemetry_client_id'], $id );
+		self::assertSame( $id, get_telemetry_client_id() );
 	}
 
 }


### PR DESCRIPTION
## Tasks

- [x] If a code change, I have written testing instructions that the whole team & outside contributors can understand.

## Description

Generates and saves a uuid for use with anonymous opt-in telemetry requests.

## Testing

Check out this branch and do one or both of these:
- run `get_telemetry_client_id()` and notice it returns a uuid.
- make a mock telemetry call to the REST route

Note there is a uuid stored in `wp_options.faustwp_settings`.
