### PR TITLE
chore: Test WP versions 6.3 and 6.4. Drop 6.2.

### DIFF
--- a/.github/workflows/test-plugin.yml
+++ b/.github/workflows/test-plugin.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        wordpress: ['6.2', '6.3']
+        wordpress: ['6.3', '6.4']
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
## Description
Updates GitHub Actions to test WP 6.4 and drops 6.2.

## Testing
Automated test-plugin tests should continue to pass.

