### PR TITLE
[FaustWP] Ignore robots in plugin redirects

### DIFF
--- a/.changeset/brave-horses-laugh.md
+++ b/.changeset/brave-horses-laugh.md
@@ -1,0 +1,5 @@
+---
+'@faustwp/wordpress-plugin': minor
+---
+
+Allow robots.txt on be accessible on the WP site and is not redirected.

--- a/.changeset/brave-horses-laugh.md
+++ b/.changeset/brave-horses-laugh.md
@@ -2,4 +2,4 @@
 '@faustwp/wordpress-plugin': minor
 ---
 
-Allow robots.txt on be accessible on the WP site and is not redirected.
+Requests to robots.txt on the WordPress site are now accessible and are no longer redirected to the front-end site.

--- a/plugins/faustwp/includes/deny-public-access/callbacks.php
+++ b/plugins/faustwp/includes/deny-public-access/callbacks.php
@@ -28,6 +28,7 @@ function deny_public_access() {
 		is_customize_preview() ||
 		doing_file_editor_save() ||
 		is_feed() ||
+		is_robots() ||
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		isset( $_GET['_wp-find-template'] ) // Allow loading full site editor.
 	) {

--- a/plugins/faustwp/tests/acceptance/DenyPublicAccessCest.php
+++ b/plugins/faustwp/tests/acceptance/DenyPublicAccessCest.php
@@ -1,0 +1,19 @@
+<?php
+
+class DenyPublicAccessCest
+{
+	/**
+	 * Ensure robots.txt is accessible on the WP site and is not redirected when
+	 */
+	public function i_can_view_robots_txt_when_redirects_are_enabled(AcceptanceTester $I)
+	{
+		$robots = 'robots.txt';
+		$robots_first_line = 'User-agent: *';
+		$robots_second_line = 'Disallow: /wp-admin/';
+		$I->haveFaustWPSetting('enable_redirects', 1);
+		$I->loginAsAdmin();
+		$I->amOnPage($robots);
+		$I->see($robots_first_line);
+		$I->see($robots_second_line);
+	}
+}


### PR DESCRIPTION
## Tasks

- [ ] I have signed a [Contributor License Agreement (CLA)](https://github.com/wpengine/faustjs#contributor-license-agreement) with WP Engine.
- [ ] If a code change, I have written testing instructions that the whole team & outside contributors can understand.
- [ ] I have written and included a comprehensive [changeset](https://github.com/wpengine/faustjs/blob/canary/DEVELOPMENT.md#deployment) to properly document the changes I've made.

## Description

Fixes: https://github.com/wpengine/faustjs/issues/1699

## Related Issue(s):

<!--
Provide the GitHub issue(s) number for issue tracking purposes, use the following syntax:

- #1234
-->

## Testing

<!--
Describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Also list any relevant details for your test configuration such as how to test the changes locally or in staging.
-->
1. Ensure Public Route Redirects is checked
2. Visit the robots.txt file from the WP instance. It should be accessible



## Screenshots

<!--
If this is a visual change include relevant screenshots about the behavior of the application before and after this change.
-->

## Documentation Changes

<!--
List corresponding changes to the documentation.
-->

## Dependant PRs

<!--
List any dependent PR's that are awaiting review. Use the following syntax:

- #1234
-->
