### PR TITLE
Fix anonymous opt-in 

### DIFF
--- a/packages/faustwp-cli/src/index.ts
+++ b/packages/faustwp-cli/src/index.ts
@@ -75,10 +75,9 @@ import { marshallTelemetryData, sendTelemetryData } from './telemetry/index.js';
   if (getWpSecret()) {
     try {
       const telemetryData = marshallTelemetryData(arg1);
-      void sendTelemetryData(telemetryData);
+      await sendTelemetryData(telemetryData);
     } catch (err) {
-      // console.log(err);
-      // Fail silently
+      console.log(err);
     }
   }
 

--- a/packages/faustwp-cli/src/index.ts
+++ b/packages/faustwp-cli/src/index.ts
@@ -77,7 +77,10 @@ import { marshallTelemetryData, sendTelemetryData } from './telemetry/index.js';
       const telemetryData = marshallTelemetryData(arg1);
       await sendTelemetryData(telemetryData);
     } catch (err) {
-      console.log(err);
+      debugLog(
+      `Telemetry event failed: `,
+      err,
+    );
     }
   }
 

--- a/packages/faustwp-cli/src/index.ts
+++ b/packages/faustwp-cli/src/index.ts
@@ -77,10 +77,7 @@ import { marshallTelemetryData, sendTelemetryData } from './telemetry/index.js';
       const telemetryData = marshallTelemetryData(arg1);
       await sendTelemetryData(telemetryData);
     } catch (err) {
-      debugLog(
-      `Telemetry event failed: `,
-      err,
-    );
+      debugLog(`Telemetry event failed: `, err);
     }
   }
 

--- a/plugins/faustwp/includes/rest/callbacks.php
+++ b/plugins/faustwp/includes/rest/callbacks.php
@@ -258,7 +258,12 @@ function handle_rest_process_telemetry_callback( \WP_REST_Request $request ) {
 		'multisite'                                    => is_multisite(),
 		'php_version'                                  => PHP_VERSION,
 		'wp_version'                                   => get_wp_version(),
+		'engagement_time_msec'                         => 100,
+		'session_id'                                   => md5( get_telemetry_client_id() ),
 	);
+
+	// Remove null values since GA rejects them.
+	$telemetry_data = array_filter( $telemetry_data );
 
 	$ga_telemetry_url = add_query_arg(
 		array(

--- a/plugins/faustwp/includes/rest/callbacks.php
+++ b/plugins/faustwp/includes/rest/callbacks.php
@@ -278,18 +278,13 @@ function handle_rest_process_telemetry_callback( \WP_REST_Request $request ) {
 		),
 	);
 
-	/**
-	 * This code should be uncommented once we can accept/decline the
-	 * telemetry option and an appropriate clientID is generated for the site.
-	 *
-	 * @TODO
-	 */
-
-	// @codingStandardsIgnoreStart
-	wp_remote_post( $ga_telemetry_url, [
-		'body' => $telemetry_body,
-	] );
-  // @codingStandardsIgnoreEnd
+	wp_remote_post(
+		$ga_telemetry_url,
+		array(
+			'body'     => wp_json_encode( $telemetry_body ),
+			'blocking' => false,
+		)
+	);
 
 	return new \WP_REST_Response( array( $telemetry_body, $ga_telemetry_url ), 201 );
 }

--- a/plugins/faustwp/includes/rest/callbacks.php
+++ b/plugins/faustwp/includes/rest/callbacks.php
@@ -286,9 +286,9 @@ function handle_rest_process_telemetry_callback( \WP_REST_Request $request ) {
 	 */
 
 	// @codingStandardsIgnoreStart
-	// wp_remote_post($ga_telemetry_url, [
-	// 'body' => $telemetry_body,
-	// ]);
+	wp_remote_post( $ga_telemetry_url, [
+		'body' => $telemetry_body,
+	] );
   // @codingStandardsIgnoreEnd
 
 	return new \WP_REST_Response( array( $telemetry_body, $ga_telemetry_url ), 201 );


### PR DESCRIPTION
## Description

Unblocks the `wp_remote_post()` call for anonymous opt-in telemetry.

Fixes a couple other small issues.

## Testing
If you are opted in under Faust > Settings, any of the npm scripts (`dev`, `build`, `generate`, etc.) should result in an event showing up in GA, with associated telemetry data.

## Screenshots

<!--
If this is a visual change include relevant screenshots about the behavior of the application before and after this change.
-->

## Documentation Changes

<!--
List corresponding changes to the documentation.
-->

## Dependant PRs

<!--
List any dependent PR's that are awaiting review. Use the following syntax:

- #1234
-->
