### PR TITLE
Add `continue-on-error` for next bundle workflow for outside contributors

### DIFF
--- a/.github/workflows/nextjs-bundle-analysis.yml
+++ b/.github/workflows/nextjs-bundle-analysis.yml
@@ -7,6 +7,8 @@ name: 'Next.js Bundle Analysis'
 
 on:
   pull_request:
+    branches-ignore:
+      - 'main'
   push:
     branches:
       - 'canary'

--- a/.github/workflows/nextjs-bundle-analysis.yml
+++ b/.github/workflows/nextjs-bundle-analysis.yml
@@ -124,6 +124,7 @@ jobs:
 
       - name: Create Comment
         uses: peter-evans/create-or-update-comment@v2
+        continue-on-error: true
         if: success() && github.event.number && steps.fc.outputs.comment-id == 0
         with:
           issue-number: ${{ github.event.number }}
@@ -131,6 +132,7 @@ jobs:
 
       - name: Update Comment
         uses: peter-evans/create-or-update-comment@v2
+        continue-on-error: true
         if: success() && github.event.number && steps.fc.outputs.comment-id != 0
         with:
           issue-number: ${{ github.event.number }}


### PR DESCRIPTION
## Tasks

- [x] I have signed a [Contributor License Agreement (CLA)](https://github.com/wpengine/faustjs#contributor-license-agreement) with WP Engine.
- [ ] If a code change, I have written testing instructions that the whole team & outside contributors can understand.
- [ ] I have written and included a comprehensive [changeset](https://github.com/wpengine/faustjs/blob/canary/DEVELOPMENT.md#deployment) to properly document the changes I've made.

## Description

This PR adds a `continue-on-error` for the Next.js bundle workflow during the "comment" steps. The action we use can not write comments when the PR is from an outside contributor:

> Note: In public repositories this action does not work in pull_request workflows when triggered by forks. Any attempt will be met with the error, Resource not accessible by integration.
> https://github.com/peter-evans/create-or-update-comment

So this PR will allow us to continue to use the Next.js bundle workflow, but also will not fail for outside contributors. 

<!--
Include a summary of the change and some contextual information.
-->

## Related Issue(s):

<!--
Provide the GitHub issue(s) number for issue tracking purposes, use the following syntax:

- #1234
-->

## Testing

<!--
Describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Also list any relevant details for your test configuration such as how to test the changes locally or in staging.
-->

## Screenshots

<!--
If this is a visual change include relevant screenshots about the behavior of the application before and after this change.
-->

## Documentation Changes

<!--
List corresponding changes to the documentation.
-->

## Dependant PRs

<!--
List any dependent PR's that are awaiting review. Use the following syntax:

- #1234
-->
