### PR TITLE
Update @apollo/experimental-nextjs-app-support to v0.8.0-OLD

### DIFF
--- a/.changeset/blue-berries-jam.md
+++ b/.changeset/blue-berries-jam.md
@@ -1,0 +1,5 @@
+---
+'@faustwp/experimental-app-router': minor
+---
+
+Raises min version of @apollo/experimental-nextjs-app-support to v0.8.0

--- a/.github/workflows/e2e-next-example.yml
+++ b/.github/workflows/e2e-next-example.yml
@@ -56,6 +56,7 @@ jobs:
         run: |
           rm -rf e2e-app/node_modules/@faustjs/core
           rm -rf e2e-app/node_modules/@faustjs/next
+          mkdir -p e2e-app/node_modules/@faustjs
           cp -r packages/core e2e-app/node_modules/@faustjs/core
           cp -r packages/next e2e-app/node_modules/@faustjs/next
       - name: copy env

--- a/examples/next/app-router/package.json
+++ b/examples/next/app-router/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@apollo/client": "^3.8.0",
-    "@apollo/experimental-nextjs-app-support": "^0.5.1",
+    "@apollo/experimental-nextjs-app-support": "^0.8.0",
     "@faustwp/cli": "^2.0.0",
     "@faustwp/core": "^2.1.2",
     "@faustwp/experimental-app-router": "^0.2.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,9 +50,9 @@
       "name": "@faustwp/app-router-example",
       "dependencies": {
         "@apollo/client": "^3.8.0",
-        "@apollo/experimental-nextjs-app-support": "^0.5.1",
+        "@apollo/experimental-nextjs-app-support": "^0.8.0",
         "@faustwp/cli": "^2.0.0",
-        "@faustwp/core": "^2.1.1",
+        "@faustwp/core": "^2.1.2",
         "@faustwp/experimental-app-router": "^0.2.2",
         "graphql": "^16.7.1",
         "next": "^14.0.1",
@@ -70,17 +70,59 @@
         "npm": ">=8"
       }
     },
+    "examples/next/app-router/node_modules/@apollo/client": {
+      "version": "3.9.2",
+      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.9.2.tgz",
+      "integrity": "sha512-Zw9WvXjqhpbgkvAvnj52vstOWwM0iedKWtn1hSq1cODQyoe1CF2uFwMYFI7l56BrAY9CzLi6MQA0AhxpgJgvxw==",
+      "dependencies": {
+        "@graphql-typed-document-node/core": "^3.1.1",
+        "@wry/caches": "^1.0.0",
+        "@wry/equality": "^0.5.6",
+        "@wry/trie": "^0.5.0",
+        "graphql-tag": "^2.12.6",
+        "hoist-non-react-statics": "^3.3.2",
+        "optimism": "^0.18.0",
+        "prop-types": "^15.7.2",
+        "rehackt": "0.0.3",
+        "response-iterator": "^0.2.6",
+        "symbol-observable": "^4.0.0",
+        "ts-invariant": "^0.10.3",
+        "tslib": "^2.3.0",
+        "zen-observable-ts": "^1.2.5"
+      },
+      "peerDependencies": {
+        "graphql": "^15.0.0 || ^16.0.0",
+        "graphql-ws": "^5.5.5",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "subscriptions-transport-ws": "^0.9.0 || ^0.11.0"
+      },
+      "peerDependenciesMeta": {
+        "graphql-ws": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "subscriptions-transport-ws": {
+          "optional": true
+        }
+      }
+    },
     "examples/next/app-router/node_modules/@apollo/experimental-nextjs-app-support": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@apollo/experimental-nextjs-app-support/-/experimental-nextjs-app-support-0.5.1.tgz",
-      "integrity": "sha512-gQiFY/zntVAhPTTFfFFOogp4TKVMpbPsydv3gyMR5E0IK6WgtITTcl/uuWlnfL92+enk5mfrtoQ+0p+t2a9u2A==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@apollo/experimental-nextjs-app-support/-/experimental-nextjs-app-support-0.8.0.tgz",
+      "integrity": "sha512-uyNIkOkew0T6ukC8ycbWBeTu8gtDSD5i+NVGEHU0DIEQaToFHObYcvIxaQ/8hvWzgvnpNU/KMsApfGXA9Xkpyw==",
       "dependencies": {
         "server-only": "^0.0.1",
-        "superjson": "^1.12.2",
+        "superjson": "^1.12.2 || ^2.0.0",
         "ts-invariant": "^0.10.3"
       },
       "peerDependencies": {
-        "@apollo/client": ">=3.8.0-rc || ^3.8.0 || >=3.9.0-alpha || >=3.9.0-beta || >=3.9.0-rc",
+        "@apollo/client": "^3.9.0",
         "next": "^13.4.1 || ^14.0.0",
         "react": "^18"
       }
@@ -135,6 +177,17 @@
       "dev": true,
       "dependencies": {
         "@types/react": "*"
+      }
+    },
+    "examples/next/app-router/node_modules/@wry/trie": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@wry/trie/-/trie-0.5.0.tgz",
+      "integrity": "sha512-FNoYzHawTMk/6KMQoEG5O4PuioX19UbwdQKF44yw0nLfOypfQdjtfZzo/UIJWAJ23sNIFbD1Ug9lbaDGMwbqQA==",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "examples/next/app-router/node_modules/next": {
@@ -204,6 +257,28 @@
         }
       }
     },
+    "examples/next/app-router/node_modules/optimism": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.18.0.tgz",
+      "integrity": "sha512-tGn8+REwLRNFnb9WmcY5IfpOqeX2kpaYJ1s6Ae3mn12AeydLkR3j+jSCmVQFoXqU8D41PAJ1RG1rCRNWmNZVmQ==",
+      "dependencies": {
+        "@wry/caches": "^1.0.0",
+        "@wry/context": "^0.7.0",
+        "@wry/trie": "^0.4.3",
+        "tslib": "^2.3.0"
+      }
+    },
+    "examples/next/app-router/node_modules/optimism/node_modules/@wry/trie": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@wry/trie/-/trie-0.4.3.tgz",
+      "integrity": "sha512-I6bHwH0fSf6RqQcnnXLJKhkSXG45MFral3GxPaY4uAl0LYDZM+YDVDAiU9bYwjTuysy1S0IeecWtmq1SZA3M1w==",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "examples/next/app-router/node_modules/react": {
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
@@ -254,7 +329,7 @@
         "@apollo/client": "^3.8.8",
         "@faustwp/blocks": "2.0.0",
         "@faustwp/cli": "^2.0.0",
-        "@faustwp/core": "^2.1.1",
+        "@faustwp/core": "^2.1.2",
         "classnames": "^2.3.1",
         "graphql": "^16.8.1",
         "next": "^14.0.3",
@@ -2353,7 +2428,7 @@
       "dependencies": {
         "@apollo/client": "^3.6.6",
         "@faustwp/cli": "^2.0.0",
-        "@faustwp/core": "^2.1.1",
+        "@faustwp/core": "^2.1.2",
         "@wordpress/base-styles": "^4.36.0",
         "@wordpress/block-library": "^7.19.0",
         "classnames": "^2.3.1",
@@ -24196,6 +24271,23 @@
         "jsesc": "bin/jsesc"
       }
     },
+    "node_modules/rehackt": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/rehackt/-/rehackt-0.0.3.tgz",
+      "integrity": "sha512-aBRHudKhOWwsTvCbSoinzq+Lej/7R8e8UoPvLZo5HirZIIBLGAgdG7SL9QpdcBoQ7+3QYPi3lRLknAzXBlhZ7g==",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "*"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/rememo": {
       "version": "4.0.2",
       "license": "MIT"
@@ -30921,7 +31013,7 @@
       "license": "MIT",
       "devDependencies": {
         "@apollo/client": "^3.8.0",
-        "@apollo/experimental-nextjs-app-support": "^0.5.1",
+        "@apollo/experimental-nextjs-app-support": "^0.8.0",
         "@faustwp/cli": "^2.0.0",
         "@faustwp/core": "^2.0.0",
         "@testing-library/jest-dom": "^5.17.0",
@@ -30943,7 +31035,7 @@
       },
       "peerDependencies": {
         "@apollo/client": ">=3.8.0",
-        "@apollo/experimental-nextjs-app-support": ">=0.5.0",
+        "@apollo/experimental-nextjs-app-support": ">=0.8.0",
         "@faustwp/cli": ">=1.1.3",
         "@faustwp/core": ">=1.1.2",
         "next": ">=14.0.0",
@@ -30951,18 +31043,61 @@
         "react-dom": ">=18.0.0"
       }
     },
+    "packages/experimental-app-router/node_modules/@apollo/client": {
+      "version": "3.9.2",
+      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.9.2.tgz",
+      "integrity": "sha512-Zw9WvXjqhpbgkvAvnj52vstOWwM0iedKWtn1hSq1cODQyoe1CF2uFwMYFI7l56BrAY9CzLi6MQA0AhxpgJgvxw==",
+      "dev": true,
+      "dependencies": {
+        "@graphql-typed-document-node/core": "^3.1.1",
+        "@wry/caches": "^1.0.0",
+        "@wry/equality": "^0.5.6",
+        "@wry/trie": "^0.5.0",
+        "graphql-tag": "^2.12.6",
+        "hoist-non-react-statics": "^3.3.2",
+        "optimism": "^0.18.0",
+        "prop-types": "^15.7.2",
+        "rehackt": "0.0.3",
+        "response-iterator": "^0.2.6",
+        "symbol-observable": "^4.0.0",
+        "ts-invariant": "^0.10.3",
+        "tslib": "^2.3.0",
+        "zen-observable-ts": "^1.2.5"
+      },
+      "peerDependencies": {
+        "graphql": "^15.0.0 || ^16.0.0",
+        "graphql-ws": "^5.5.5",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "subscriptions-transport-ws": "^0.9.0 || ^0.11.0"
+      },
+      "peerDependenciesMeta": {
+        "graphql-ws": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "subscriptions-transport-ws": {
+          "optional": true
+        }
+      }
+    },
     "packages/experimental-app-router/node_modules/@apollo/experimental-nextjs-app-support": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@apollo/experimental-nextjs-app-support/-/experimental-nextjs-app-support-0.5.1.tgz",
-      "integrity": "sha512-gQiFY/zntVAhPTTFfFFOogp4TKVMpbPsydv3gyMR5E0IK6WgtITTcl/uuWlnfL92+enk5mfrtoQ+0p+t2a9u2A==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@apollo/experimental-nextjs-app-support/-/experimental-nextjs-app-support-0.8.0.tgz",
+      "integrity": "sha512-uyNIkOkew0T6ukC8ycbWBeTu8gtDSD5i+NVGEHU0DIEQaToFHObYcvIxaQ/8hvWzgvnpNU/KMsApfGXA9Xkpyw==",
       "dev": true,
       "dependencies": {
         "server-only": "^0.0.1",
-        "superjson": "^1.12.2",
+        "superjson": "^1.12.2 || ^2.0.0",
         "ts-invariant": "^0.10.3"
       },
       "peerDependencies": {
-        "@apollo/client": ">=3.8.0-rc || ^3.8.0 || >=3.9.0-alpha || >=3.9.0-beta || >=3.9.0-rc",
+        "@apollo/client": "^3.9.0",
         "next": "^13.4.1 || ^14.0.0",
         "react": "^18"
       }
@@ -31130,6 +31265,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "packages/experimental-app-router/node_modules/@wry/trie": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@wry/trie/-/trie-0.5.0.tgz",
+      "integrity": "sha512-FNoYzHawTMk/6KMQoEG5O4PuioX19UbwdQKF44yw0nLfOypfQdjtfZzo/UIJWAJ23sNIFbD1Ug9lbaDGMwbqQA==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "packages/experimental-app-router/node_modules/ansi-styles": {
       "version": "4.3.0",
       "dev": true,
@@ -31286,6 +31433,30 @@
         "sass": {
           "optional": true
         }
+      }
+    },
+    "packages/experimental-app-router/node_modules/optimism": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.18.0.tgz",
+      "integrity": "sha512-tGn8+REwLRNFnb9WmcY5IfpOqeX2kpaYJ1s6Ae3mn12AeydLkR3j+jSCmVQFoXqU8D41PAJ1RG1rCRNWmNZVmQ==",
+      "dev": true,
+      "dependencies": {
+        "@wry/caches": "^1.0.0",
+        "@wry/context": "^0.7.0",
+        "@wry/trie": "^0.4.3",
+        "tslib": "^2.3.0"
+      }
+    },
+    "packages/experimental-app-router/node_modules/optimism/node_modules/@wry/trie": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@wry/trie/-/trie-0.4.3.tgz",
+      "integrity": "sha512-I6bHwH0fSf6RqQcnnXLJKhkSXG45MFral3GxPaY4uAl0LYDZM+YDVDAiU9bYwjTuysy1S0IeecWtmq1SZA3M1w==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "packages/experimental-app-router/node_modules/react": {
@@ -31576,7 +31747,7 @@
     },
     "packages/faustwp-core": {
       "name": "@faustwp/core",
-      "version": "2.1.1",
+      "version": "2.1.2",
       "license": "MIT",
       "dependencies": {
         "@wordpress/hooks": "^3.14.0",
@@ -35834,7 +36005,7 @@
     },
     "plugins/faustwp": {
       "name": "@faustwp/wordpress-plugin",
-      "version": "1.2.0"
+      "version": "1.2.1"
     }
   }
 }

--- a/packages/experimental-app-router/package.json
+++ b/packages/experimental-app-router/package.json
@@ -48,7 +48,7 @@
   },
   "peerDependencies": {
     "@apollo/client": ">=3.8.0",
-    "@apollo/experimental-nextjs-app-support": ">=0.5.0",
+    "@apollo/experimental-nextjs-app-support": ">=0.8.0",
     "@faustwp/cli": ">=1.1.3",
     "@faustwp/core": ">=1.1.2",
     "next": ">=14.0.0",
@@ -57,7 +57,7 @@
   },
   "devDependencies": {
     "@apollo/client": "^3.8.0",
-    "@apollo/experimental-nextjs-app-support": "^0.5.1",
+    "@apollo/experimental-nextjs-app-support": "^0.8.0",
     "@faustwp/cli": "^2.0.0",
     "@faustwp/core": "^2.0.0",
     "@testing-library/jest-dom": "^5.17.0",


### PR DESCRIPTION
## Tasks

- [ ] I have signed a [Contributor License Agreement (CLA)](https://github.com/wpengine/faustjs#contributor-license-agreement) with WP Engine.
- [ ] If a code change, I have written testing instructions that the whole team & outside contributors can understand.
- [ ] I have written and included a comprehensive [changeset](https://github.com/wpengine/faustjs/blob/canary/DEVELOPMENT.md#deployment) to properly document the changes I've made.

## Description

Updates @apollo/experimental-nextjs-app-support to v0.8.0 in both the package and the example projects

## Related Issue(s):

<!--
Provide the GitHub issue(s) number for issue tracking purposes, use the following syntax:

- #1234
-->

## Testing

1. Cleanup all your node_modules from the `examples/next/app-router`.
2. Run `npm i` and `npm run build`
3. Start the app-router example project. It should works as. expected.

## Screenshots

<!--
If this is a visual change include relevant screenshots about the behavior of the application before and after this change.
-->

## Documentation Changes

<!--
List corresponding changes to the documentation.
-->

## Dependant PRs

<!--
List any dependent PR's that are awaiting review. Use the following syntax:

- #1234
-->
