### PR TITLE
Detect NEXT_PUBLIC_WORDPRESS_URL using wpengine.com TLD and recommend using wpenginepowered.com TLD

### DIFF
--- a/.changeset/neat-foxes-develop.md
+++ b/.changeset/neat-foxes-develop.md
@@ -1,0 +1,5 @@
+---
+'@faustwp/cli': minor
+---
+
+Added: Detect if the `NEXT_PUBLIC_WORDPRESS_URL` is a `wpengine.com` TLD and if so recommend a switch to `wpenginepowered.com`

--- a/package-lock.json
+++ b/package-lock.json
@@ -36006,6 +36006,66 @@
     "plugins/faustwp": {
       "name": "@faustwp/wordpress-plugin",
       "version": "1.2.1"
+    },
+    "packages/experimental-app-router/node_modules/@next/swc-android-arm-eabi": {
+      "version": "12.3.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-12.3.4.tgz",
+      "integrity": "sha512-cM42Cw6V4Bz/2+j/xIzO8nK/Q3Ly+VSlZJTa1vHzsocJRYz8KT6MrreXaci2++SIZCF1rVRCDgAg5PpqRibdIA==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "packages/experimental-app-router/node_modules/@next/swc-android-arm64": {
+      "version": "12.3.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-12.3.4.tgz",
+      "integrity": "sha512-5jf0dTBjL+rabWjGj3eghpLUxCukRhBcEJgwLedewEA/LJk2HyqCvGIwj5rH+iwmq1llCWbOky2dO3pVljrapg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "packages/experimental-app-router/node_modules/@next/swc-freebsd-x64": {
+      "version": "12.3.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-freebsd-x64/-/swc-freebsd-x64-12.3.4.tgz",
+      "integrity": "sha512-KM9JXRXi/U2PUM928z7l4tnfQ9u8bTco/jb939pdFUHqc28V43Ohd31MmZD1QzEK4aFlMRaIBQOWQZh4D/E5lQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "packages/experimental-app-router/node_modules/@next/swc-linux-arm-gnueabihf": {
+      "version": "12.3.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-12.3.4.tgz",
+      "integrity": "sha512-3zqD3pO+z5CZyxtKDTnOJ2XgFFRUBciOox6EWkoZvJfc9zcidNAQxuwonUeNts6Xbm8Wtm5YGIRC0x+12YH7kw==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
     }
   }
 }

--- a/packages/faustwp-cli/src/healthCheck/validateFaustEnvVars.ts
+++ b/packages/faustwp-cli/src/healthCheck/validateFaustEnvVars.ts
@@ -1,5 +1,5 @@
 import { getWpSecret } from '../utils/index.js';
-import { errorLog, warnLog } from '../stdout/index.js';
+import { errorLog, infoLog, warnLog } from '../stdout/index.js';
 
 /**
  * Validates that the appropriate Faust related environment variables are set.
@@ -9,6 +9,13 @@ export const validateFaustEnvVars = () => {
     errorLog('Could not find NEXT_PUBLIC_WORDPRESS_URL environment variable.');
 
     process.exit(1);
+  }
+
+  const regex = /\b\w+\.wpengine\.com\b/;
+  if (regex.test(process.env.NEXT_PUBLIC_WORDPRESS_URL)) {
+    infoLog(
+      'We detected your NEXT_PUBLIC_WORDPRESS_URL is using wpengine.com. It is recommended to use the wpenginepowered.com TLD',
+    );
   }
 
   if (!getWpSecret()) {

--- a/packages/faustwp-cli/src/healthCheck/validateFaustEnvVars.ts
+++ b/packages/faustwp-cli/src/healthCheck/validateFaustEnvVars.ts
@@ -22,8 +22,10 @@ export const validateFaustEnvVars = () => {
   }
 
   if (isWPEngineComSubdomain(process.env.NEXT_PUBLIC_WORDPRESS_URL)) {
+    infoLog(`Found NEXT_PUBLIC_WORDPRESS_URL using wpengine.com TLD.`);
+    infoLog(`It is recommended to use the wpenginepowered.com TLD instead.`);
     infoLog(
-      'We detected your NEXT_PUBLIC_WORDPRESS_URL is using wpengine.com. It is recommended to use the wpenginepowered.com TLD',
+      `Ex: https://example.wpengine.com -> https://example.wpenginepowered.com`,
     );
   }
 

--- a/packages/faustwp-cli/src/healthCheck/validateFaustEnvVars.ts
+++ b/packages/faustwp-cli/src/healthCheck/validateFaustEnvVars.ts
@@ -23,6 +23,9 @@ export const validateFaustEnvVars = () => {
     infoLog(
       `Ex: https://example.wpengine.com -> https://example.wpenginepowered.com`,
     );
+    infoLog(
+      `This will leverage WP Engine's Advanced Network CDN. See: https://wpengine.com/support/network/`,
+    );
   }
 
   if (!getWpSecret()) {

--- a/packages/faustwp-cli/src/healthCheck/validateFaustEnvVars.ts
+++ b/packages/faustwp-cli/src/healthCheck/validateFaustEnvVars.ts
@@ -1,6 +1,16 @@
 import { getWpSecret } from '../utils/index.js';
 import { errorLog, infoLog, warnLog } from '../stdout/index.js';
 
+export function isWPEngineComSubdomain(url: string) {
+  const regex = /\b\w+\.wpengine\.com\b/;
+
+  if (regex.test(url)) {
+    return true;
+  }
+
+  return false;
+}
+
 /**
  * Validates that the appropriate Faust related environment variables are set.
  */
@@ -11,8 +21,7 @@ export const validateFaustEnvVars = () => {
     process.exit(1);
   }
 
-  const regex = /\b\w+\.wpengine\.com\b/;
-  if (regex.test(process.env.NEXT_PUBLIC_WORDPRESS_URL)) {
+  if (isWPEngineComSubdomain(process.env.NEXT_PUBLIC_WORDPRESS_URL)) {
     infoLog(
       'We detected your NEXT_PUBLIC_WORDPRESS_URL is using wpengine.com. It is recommended to use the wpenginepowered.com TLD',
     );

--- a/packages/faustwp-cli/src/healthCheck/validateFaustEnvVars.ts
+++ b/packages/faustwp-cli/src/healthCheck/validateFaustEnvVars.ts
@@ -4,11 +4,7 @@ import { errorLog, infoLog, warnLog } from '../stdout/index.js';
 export function isWPEngineComSubdomain(url: string) {
   const regex = /\b\w+\.wpengine\.com\b/;
 
-  if (regex.test(url)) {
-    return true;
-  }
-
-  return false;
+  return regex.test(url);
 }
 
 /**

--- a/packages/faustwp-cli/tests/healthCheck/validateFaustEnvVars.test.ts
+++ b/packages/faustwp-cli/tests/healthCheck/validateFaustEnvVars.test.ts
@@ -1,4 +1,7 @@
-import { validateFaustEnvVars } from '../../src/healthCheck/validateFaustEnvVars';
+import {
+  isWPEngineComSubdomain,
+  validateFaustEnvVars,
+} from '../../src/healthCheck/validateFaustEnvVars';
 /**
  * @jest-environment jsdom
  */
@@ -48,5 +51,29 @@ describe('healthCheck/validateFaustEnvVars', () => {
     validateFaustEnvVars();
 
     expect(mockExit).toBeCalledTimes(0);
+  });
+});
+
+describe('isWPEngineComTLD', () => {
+  it('matches subdomains on wpengine.com', () => {
+    expect(isWPEngineComSubdomain('https://my-site.wpengine.com')).toBeTruthy();
+    expect(
+      isWPEngineComSubdomain('http://some-site.wpengine.com/graphql'),
+    ).toBeTruthy();
+    expect(isWPEngineComSubdomain('https://example.wpengine.com')).toBeTruthy();
+    expect(
+      isWPEngineComSubdomain('https://some-long-weird-subdomain.wpengine.com'),
+    );
+  });
+
+  it('does not match urls that are not subdomains of wpengine.com', () => {
+    expect(isWPEngineComSubdomain('https://example.com')).toBeFalsy();
+    expect(isWPEngineComSubdomain('https://wpengine.com')).toBeFalsy();
+    expect(isWPEngineComSubdomain('https://wpengine.com/plans')).toBeFalsy();
+    expect(isWPEngineComSubdomain('https://my-site.wpengine.co')).toBeFalsy();
+    expect(
+      isWPEngineComSubdomain('https://my-site.wpenginepowered.com'),
+    ).toBeFalsy();
+    expect(isWPEngineComSubdomain('https://my-site.wpengine.co'));
   });
 });

--- a/packages/faustwp-cli/tests/healthCheck/validateFaustEnvVars.test.ts
+++ b/packages/faustwp-cli/tests/healthCheck/validateFaustEnvVars.test.ts
@@ -74,6 +74,5 @@ describe('isWPEngineComTLD', () => {
     expect(
       isWPEngineComSubdomain('https://my-site.wpenginepowered.com'),
     ).toBeFalsy();
-    expect(isWPEngineComSubdomain('https://my-site.wpengine.co'));
   });
 });


### PR DESCRIPTION
## Tasks

- [x] I have signed a [Contributor License Agreement (CLA)](https://github.com/wpengine/faustjs#contributor-license-agreement) with WP Engine.
- [x] If a code change, I have written testing instructions that the whole team & outside contributors can understand.
- [x] I have written and included a comprehensive [changeset](https://github.com/wpengine/faustjs/blob/canary/DEVELOPMENT.md#deployment) to properly document the changes I've made.

## Description

This PR recommends the user update their NEXT_PUBLIC_WORDPRESS_URL to use the `wpenginepowered.com` TLD if they are using the `wpengine.com` TLD.

<!--
Include a summary of the change and some contextual information.
-->

## Related Issue(s):

<!--
Provide the GitHub issue(s) number for issue tracking purposes, use the following syntax:

- #1234
-->

## Testing

Unit tests have been provided. However, you can manually test this PR by:

1. Checking out this branch
2. `npm install`
3. `npm run build`
4. Set the `NEXT_PUBLIC_WORDPRESS_URL` in `examples/next/faustwp-getting-started/.env.local` to a `https://xxxxx.wpengine.com` URL.
5. Run the example project `npm run dev -w @faustwp/getting-started-example`
6. Notice the info text in the terminal
    ![Screenshot 2024-02-14 at 11 52 49 AM](https://github.com/wpengine/faustjs/assets/5946219/da7e5702-d261-4860-b067-a6b350287fcd)



<!--
Describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Also list any relevant details for your test configuration such as how to test the changes locally or in staging.
-->

## Screenshots

<!--
If this is a visual change include relevant screenshots about the behavior of the application before and after this change.
-->

## Documentation Changes

<!--
List corresponding changes to the documentation.
-->

## Dependant PRs

<!--
List any dependent PR's that are awaiting review. Use the following syntax:

- #1234
-->
