### PR TITLE
Add next-secure-headers in example projects

### DIFF
--- a/examples/next/app-router/next.config.js
+++ b/examples/next/app-router/next.config.js
@@ -4,6 +4,8 @@ import { createSecureHeaders } from 'next-secure-headers';
 /** @type {import('next').NextConfig} */
 export default withFaust({
   async headers() {
-    return [{ source: '/:path*', headers: createSecureHeaders() }];
+    return [{ source: '/:path*', headers: createSecureHeaders({
+      xssProtection: false
+    }) }];
   },
 });

--- a/examples/next/app-router/next.config.js
+++ b/examples/next/app-router/next.config.js
@@ -1,4 +1,9 @@
 import { withFaust } from '@faustwp/core';
+import { createSecureHeaders } from 'next-secure-headers';
 
 /** @type {import('next').NextConfig} */
-export default withFaust();
+export default withFaust({
+  async headers() {
+    return [{ source: '/(.*)', headers: createSecureHeaders() }];
+  },
+});

--- a/examples/next/app-router/next.config.js
+++ b/examples/next/app-router/next.config.js
@@ -4,6 +4,6 @@ import { createSecureHeaders } from 'next-secure-headers';
 /** @type {import('next').NextConfig} */
 export default withFaust({
   async headers() {
-    return [{ source: '/(.*)', headers: createSecureHeaders() }];
+    return [{ source: '/:path*', headers: createSecureHeaders() }];
   },
 });

--- a/examples/next/app-router/package.json
+++ b/examples/next/app-router/package.json
@@ -28,6 +28,7 @@
     "@types/node": "^20.6.3",
     "@types/react": "^18.2.36",
     "@types/react-dom": "^18.2.14",
-    "typescript": "^5.2.2"
+    "typescript": "^5.2.2",
+    "next-secure-headers": "^2.2.0"
   }
 }

--- a/examples/next/block-support/next.config.js
+++ b/examples/next/block-support/next.config.js
@@ -1,4 +1,5 @@
 const { withFaust, getWpHostname } = require('@faustwp/core');
+const { createSecureHeaders } = require('next-secure-headers');
 
 /**
  * @type {import('next').NextConfig}
@@ -14,5 +15,8 @@ module.exports = withFaust({
   i18n: {
     locales: ['en'],
     defaultLocale: 'en',
+  },
+  async headers() {
+    return [{ source: '/(.*)', headers: createSecureHeaders() }];
   },
 });

--- a/examples/next/block-support/next.config.js
+++ b/examples/next/block-support/next.config.js
@@ -17,6 +17,6 @@ module.exports = withFaust({
     defaultLocale: 'en',
   },
   async headers() {
-    return [{ source: '/(.*)', headers: createSecureHeaders() }];
+    return [{ source: '/:path*', headers: createSecureHeaders() }];
   },
 });

--- a/examples/next/block-support/next.config.js
+++ b/examples/next/block-support/next.config.js
@@ -17,6 +17,8 @@ module.exports = withFaust({
     defaultLocale: 'en',
   },
   async headers() {
-    return [{ source: '/:path*', headers: createSecureHeaders() }];
+    return [{ source: '/:path*', headers: createSecureHeaders({
+      xssProtection: false
+    }) }];
   },
 });

--- a/examples/next/block-support/package.json
+++ b/examples/next/block-support/package.json
@@ -26,7 +26,8 @@
     "@wordpress/scripts": "26.18.0",
     "@faustwp/block-editor-utils": "0.1.0",
     "@wordpress/base-styles": "^4.41.0",
-    "@wordpress/block-library": "^8.27.0"
+    "@wordpress/block-library": "^8.27.0",
+    "next-secure-headers": "^2.2.0"
   },
   "engines": {
     "node": ">=18",

--- a/examples/next/faustwp-getting-started/next.config.js
+++ b/examples/next/faustwp-getting-started/next.config.js
@@ -1,4 +1,5 @@
 const { withFaust, getWpHostname } = require('@faustwp/core');
+const { createSecureHeaders } = require('next-secure-headers');
 
 /**
  * @type {import('next').NextConfig}
@@ -14,5 +15,8 @@ module.exports = withFaust({
   i18n: {
     locales: ['en'],
     defaultLocale: 'en',
+  },
+  async headers() {
+    return [{ source: '/(.*)', headers: createSecureHeaders() }];
   },
 });

--- a/examples/next/faustwp-getting-started/next.config.js
+++ b/examples/next/faustwp-getting-started/next.config.js
@@ -17,6 +17,6 @@ module.exports = withFaust({
     defaultLocale: 'en',
   },
   async headers() {
-    return [{ source: '/(.*)', headers: createSecureHeaders() }];
+    return [{ source: '/:path*', headers: createSecureHeaders() }];
   },
 });

--- a/examples/next/faustwp-getting-started/next.config.js
+++ b/examples/next/faustwp-getting-started/next.config.js
@@ -17,6 +17,8 @@ module.exports = withFaust({
     defaultLocale: 'en',
   },
   async headers() {
-    return [{ source: '/:path*', headers: createSecureHeaders() }];
+    return [{ source: '/:path*', headers: createSecureHeaders({
+      xssProtection: false
+    }) }];
   },
 });

--- a/examples/next/faustwp-getting-started/package.json
+++ b/examples/next/faustwp-getting-started/package.json
@@ -22,6 +22,9 @@
     "react-dom": "^17.0.2",
     "sass": "^1.54.9"
   },
+  "devDependencies": {
+    "next-secure-headers": "^2.2.0"
+  },
   "engines": {
     "node": ">=18",
     "npm": ">=8"

--- a/package-lock.json
+++ b/package-lock.json
@@ -35999,6 +35999,66 @@
     "plugins/faustwp": {
       "name": "@faustwp/wordpress-plugin",
       "version": "1.2.1"
+    },
+    "packages/experimental-app-router/node_modules/@next/swc-android-arm-eabi": {
+      "version": "12.3.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-12.3.4.tgz",
+      "integrity": "sha512-cM42Cw6V4Bz/2+j/xIzO8nK/Q3Ly+VSlZJTa1vHzsocJRYz8KT6MrreXaci2++SIZCF1rVRCDgAg5PpqRibdIA==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "packages/experimental-app-router/node_modules/@next/swc-android-arm64": {
+      "version": "12.3.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-12.3.4.tgz",
+      "integrity": "sha512-5jf0dTBjL+rabWjGj3eghpLUxCukRhBcEJgwLedewEA/LJk2HyqCvGIwj5rH+iwmq1llCWbOky2dO3pVljrapg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "packages/experimental-app-router/node_modules/@next/swc-freebsd-x64": {
+      "version": "12.3.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-freebsd-x64/-/swc-freebsd-x64-12.3.4.tgz",
+      "integrity": "sha512-KM9JXRXi/U2PUM928z7l4tnfQ9u8bTco/jb939pdFUHqc28V43Ohd31MmZD1QzEK4aFlMRaIBQOWQZh4D/E5lQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "packages/experimental-app-router/node_modules/@next/swc-linux-arm-gnueabihf": {
+      "version": "12.3.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-12.3.4.tgz",
+      "integrity": "sha512-3zqD3pO+z5CZyxtKDTnOJ2XgFFRUBciOox6EWkoZvJfc9zcidNAQxuwonUeNts6Xbm8Wtm5YGIRC0x+12YH7kw==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -63,6 +63,7 @@
         "@types/node": "^20.6.3",
         "@types/react": "^18.2.36",
         "@types/react-dom": "^18.2.14",
+        "next-secure-headers": "^2.2.0",
         "typescript": "^5.2.2"
       },
       "engines": {
@@ -341,7 +342,8 @@
         "@faustwp/block-editor-utils": "0.1.0",
         "@wordpress/base-styles": "^4.41.0",
         "@wordpress/block-library": "^8.27.0",
-        "@wordpress/scripts": "26.18.0"
+        "@wordpress/scripts": "26.18.0",
+        "next-secure-headers": "^2.2.0"
       },
       "engines": {
         "node": ">=18",
@@ -2437,6 +2439,9 @@
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
         "sass": "^1.54.9"
+      },
+      "devDependencies": {
+        "next-secure-headers": "^2.2.0"
       },
       "engines": {
         "node": ">=18",
@@ -6587,22 +6592,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@playwright/test": {
-      "version": "1.40.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.40.1.tgz",
-      "integrity": "sha512-EaaawMTOeEItCRvfmkI9v6rBkF1svM8wjl/YPRrg2N2Wmp+4qJYkWtJsbew1szfKKDm6fPLy4YAanBhIlf9dWw==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "playwright": "1.40.1"
-      },
-      "bin": {
-        "playwright": "cli.js"
-      },
-      "engines": {
-        "node": ">=16"
       }
     },
     "node_modules/@pmmmwh/react-refresh-webpack-plugin": {
@@ -16640,10 +16629,23 @@
         "loose-envify": "^1.0.0"
       }
     },
-    "node_modules/ip": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.9.tgz",
-      "integrity": "sha512-cyRxvOEpNHNtchU3Ln9KC/auJgup87llfQpQ+t5ghoC/UhL16SWzbueiCsdTnWmqAWl7LadfuwhlqmtOaqMHdQ==",
+    "node_modules/ip-address": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
+      "integrity": "sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==",
+      "dev": true,
+      "dependencies": {
+        "jsbn": "1.1.0",
+        "sprintf-js": "^1.1.3"
+      },
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ip-address/node_modules/sprintf-js": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
       "dev": true
     },
     "node_modules/ipaddr.js": {
@@ -19876,6 +19878,12 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/jsbn": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
+      "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==",
+      "dev": true
+    },
     "node_modules/jsdoc-type-pratt-parser": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-4.0.0.tgz",
@@ -21461,6 +21469,15 @@
         }
       }
     },
+    "node_modules/next-secure-headers": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/next-secure-headers/-/next-secure-headers-2.2.0.tgz",
+      "integrity": "sha512-C7OfZ9JdSJyYMz2ZBMI/WwNbt0qNjlFWX9afUp8nEUzbz6ez3JbeopdyxSZJZJAzVLIAfyk6n73rFpd4e22jRg==",
+      "dev": true,
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/next/node_modules/@next/swc-darwin-arm64": {
       "version": "12.3.4",
       "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-12.3.4.tgz",
@@ -22405,13 +22422,12 @@
       }
     },
     "node_modules/pac-resolver": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-7.0.0.tgz",
-      "integrity": "sha512-Fd9lT9vJbHYRACT8OhCbZBbxr6KRSawSovFpy8nDGshaK99S/EBhVIHp9+crhxrsZOuvLpgL1n23iyPg6Rl2hg==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-7.0.1.tgz",
+      "integrity": "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==",
       "dev": true,
       "dependencies": {
         "degenerator": "^5.0.0",
-        "ip": "^1.1.8",
         "netmask": "^2.0.2"
       },
       "engines": {
@@ -22634,58 +22650,11 @@
         "node": ">=8"
       }
     },
-    "node_modules/playwright": {
-      "version": "1.40.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.40.1.tgz",
-      "integrity": "sha512-2eHI7IioIpQ0bS1Ovg/HszsN/XKNwEG1kbzSDDmADpclKc7CyqkHw7Mg2JCz/bbCxg25QUPcjksoMW7JcIFQmw==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "playwright-core": "1.40.1"
-      },
-      "bin": {
-        "playwright": "cli.js"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "optionalDependencies": {
-        "fsevents": "2.3.2"
-      }
-    },
     "node_modules/playwright-core": {
       "version": "1.39.0",
       "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.39.0.tgz",
       "integrity": "sha512-+k4pdZgs1qiM+OUkSjx96YiKsXsmb59evFoqv8SKO067qBA+Z2s/dCzJij/ZhdQcs2zlTAgRKfeiiLm8PQ2qvw==",
       "dev": true,
-      "bin": {
-        "playwright-core": "cli.js"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/playwright/node_modules/fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
-      "hasInstallScript": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "peer": true,
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
-    },
-    "node_modules/playwright/node_modules/playwright-core": {
-      "version": "1.40.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.40.1.tgz",
-      "integrity": "sha512-+hkOycxPiV534c4HhpfX6yrlawqVUzITRKwHAmYfmsVreltEl6fAZJ3DPfLMOODw0H3s1Itd6MDCWmP1fl/QvQ==",
-      "dev": true,
-      "peer": true,
       "bin": {
         "playwright-core": "cli.js"
       },
@@ -23904,16 +23873,6 @@
     "node_modules/react-is": {
       "version": "16.13.1",
       "license": "MIT"
-    },
-    "node_modules/react-refresh": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.10.0.tgz",
-      "integrity": "sha512-PgidR3wST3dDYKr6b4pJoqQFpPGNKDSCDx4cZoshjXipw3LzO7mG1My2pwEzz2JVkF+inx3xRpDeQLFQGH/hsQ==",
-      "dev": true,
-      "peer": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/react-remove-scroll": {
       "version": "2.5.5",
@@ -25503,16 +25462,16 @@
       }
     },
     "node_modules/socks": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/socks/-/socks-2.7.1.tgz",
-      "integrity": "sha512-7maUZy1N7uo6+WVEX6psASxtNlKaNVMlGQKkG/63nEDdLOWNbiUMoLK7X4uYoLhQstau72mLgfEWcXcwsaHbYQ==",
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.7.3.tgz",
+      "integrity": "sha512-vfuYK48HXCTFD03G/1/zkIls3Ebr2YNa4qU9gHDZdblHLiqhJrJGkY3+0Nx0JpN9qBhJbVObc1CNciT1bIZJxw==",
       "dev": true,
       "dependencies": {
-        "ip": "^2.0.0",
+        "ip-address": "^9.0.5",
         "smart-buffer": "^4.2.0"
       },
       "engines": {
-        "node": ">= 10.13.0",
+        "node": ">= 10.0.0",
         "npm": ">= 3.0.0"
       }
     },
@@ -25541,12 +25500,6 @@
       "engines": {
         "node": ">= 14"
       }
-    },
-    "node_modules/socks/node_modules/ip": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.1.tgz",
-      "integrity": "sha512-lJUL9imLTNi1ZfXT+DU6rBBdbiKGBuay9B6xGSPVjUeQwaH1RIGqef8RZkUtHioLmSNpPR5M4HVKJGm1j8FWVQ==",
-      "dev": true
     },
     "node_modules/source-map": {
       "version": "0.6.1",


### PR DESCRIPTION
## Tasks

- [ ] I have signed a [Contributor License Agreement (CLA)](https://github.com/wpengine/faustjs#contributor-license-agreement) with WP Engine.
- [ ] If a code change, I have written testing instructions that the whole team & outside contributors can understand.
- [ ] I have written and included a comprehensive [changeset](https://github.com/wpengine/faustjs/blob/canary/DEVELOPMENT.md#deployment) to properly document the changes I've made.

## Description

Adds `next-secure-headers` in all example projects, providing secure default header configuration across the site.

## Related Issue(s):

<!--
Provide the GitHub issue(s) number for issue tracking purposes, use the following syntax:

- https://github.com/wpengine/faustjs/issues/1756
-->

## Testing

-Build and run one of the example projects
-Inspect the response headers of each page. It should have the following headers as defined in the [package doc](https://github.com/jagaapple/next-secure-headers?tab=readme-ov-file#next-secure-headers-vs-helmet)



|                                   | next-secure-headers     | Helmet                  | Comment                                                                                           |
|-----------------------------------|-------------------------|-------------------------|---------------------------------------------------------------------------------------------------|
| Strict-Transport-Security         | `forceHTTPSRedirect`    | `hsts`                  |                                                                                                   |
| X-Frame-Options                   | `frameGuard`            | `frameguard`            |                                                                                                   |
| X-Download-Options                | `noopen`                | `ieNoOpen`              |                                                                                                   |
| X-Content-Type-Options            | `nosniff`               | `noSniff`               |                                                                                                   |
| X-XSS-Protection                  | `0`         | `xssFilter`             |                                                                                                   |
| Content-Security-Policy           | `contentSecurityPolicy` | `contentSecurityPolicy` |                                                                                                   |
| Expect-CT                         | `expectCT`              | `expectCt`              |                                                                                                   |
| Referrer-Policy                   | `referrerPolicy`        | `referrerPolicy`        |                                                                                                   |
| X-DNS-Prefetch-Control            | -                       | `dnsPrefetchControl`    | This has privacy implications but this improves performance.                                      |
| Feature-Policy                    | -                       | `featurePolicy`         | Feature Policy improves security but it is working draft yet.                                     |
| X-Powered-By                      | -                       | `hidePoweredBy`         | [Next.js supports to remove this header in `next.config.js`](#how-to-remove-x-powered-by-header). |
| Related to cache                  | -                       | `nocache`               | As Helmet said, caching has lots of benefits.                                                     |
| X-Permitted-Cross-Domain-Policies | -                       | `crossdomain`           | Adobe Flash is one of old web technologies.                                                       |


## Screenshots

<!--
If this is a visual change include relevant screenshots about the behavior of the application before and after this change.
-->

## Documentation Changes

<!--
List corresponding changes to the documentation.
-->

## Dependant PRs

<!--
List any dependent PR's that are awaiting review. Use the following syntax:

- #1234
-->
