### PR TITLE
Feature: Error when NEXT_PUBLIC_WORDPRESS_URL same as headless site URL

### DIFF
--- a/.changeset/modern-tools-collect.md
+++ b/.changeset/modern-tools-collect.md
@@ -1,0 +1,6 @@
+---
+'@faustwp/cli': patch
+'@faustwp/wordpress-plugin': patch
+---
+
+Faust now errors if the NEXT_PUBLIC_WORDPRESS_URL matches the Headless URL in Faust Plugin settings.

--- a/package-lock.json
+++ b/package-lock.json
@@ -15141,6 +15141,30 @@
         }
       }
     },
+    "node_modules/fetch-mock-jest": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/fetch-mock-jest/-/fetch-mock-jest-1.5.1.tgz",
+      "integrity": "sha512-+utwzP8C+Pax1GSka3nFXILWMY3Er2L+s090FOgqVNrNCPp0fDqgXnAHAJf12PLHi0z4PhcTaZNTz8e7K3fjqQ==",
+      "dev": true,
+      "dependencies": {
+        "fetch-mock": "^9.11.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      },
+      "funding": {
+        "type": "charity",
+        "url": "https://www.justgiving.com/refugee-support-europe"
+      },
+      "peerDependencies": {
+        "node-fetch": "*"
+      },
+      "peerDependenciesMeta": {
+        "node-fetch": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
       "dev": true,
@@ -31629,6 +31653,7 @@
         "@types/jest": "^29.5.5",
         "@types/node": "^18.15.11",
         "@types/prompt": "1.1.2",
+        "fetch-mock-jest": "^1.5.1",
         "jest-environment-jsdom": "29.6.4",
         "rimraf": "5.0.5",
         "ts-jest": "^29.1.1",

--- a/packages/faustwp-cli/package.json
+++ b/packages/faustwp-cli/package.json
@@ -20,7 +20,8 @@
     "jest-environment-jsdom": "29.6.4",
     "rimraf": "5.0.5",
     "ts-jest": "^29.1.1",
-    "typescript": "^4.9.5"
+    "typescript": "^4.9.5",
+    "fetch-mock-jest": "^1.5.1"
   },
   "dependencies": {
     "archiver": "^6.0.1",

--- a/packages/faustwp-cli/src/healthCheck/validateFaustEnvVars.ts
+++ b/packages/faustwp-cli/src/healthCheck/validateFaustEnvVars.ts
@@ -64,10 +64,9 @@ export const validateFaustEnvVars = async () => {
         );
         process.exit(1);
       }
+      await validateNextWordPressUrl();
     } catch (error) {
       console.log('error', error);
     }
   }
-
-  await validateNextWordPressUrl();
 };

--- a/packages/faustwp-cli/src/healthCheck/validateFaustEnvVars.ts
+++ b/packages/faustwp-cli/src/healthCheck/validateFaustEnvVars.ts
@@ -1,5 +1,6 @@
 import { getWpSecret, getWpUrl } from '../utils/index.js';
 import { errorLog, infoLog, warnLog } from '../stdout/index.js';
+import { validateNextWordPressUrl } from './validateNextWordPressUrl.js';
 
 export function isWPEngineComSubdomain(url: string) {
   const regex = /\b\w+\.wpengine\.com\b/;
@@ -67,4 +68,6 @@ export const validateFaustEnvVars = async () => {
       console.log('error', error);
     }
   }
+
+  await validateNextWordPressUrl();
 };

--- a/packages/faustwp-cli/src/healthCheck/validateNextWordPressUrl.ts
+++ b/packages/faustwp-cli/src/healthCheck/validateNextWordPressUrl.ts
@@ -1,0 +1,34 @@
+import { getWpSecret, getWpUrl } from '../utils/index.js';
+import { errorLog } from '../stdout/index.js';
+
+/**
+ * Validates the NEXT_PUBLIC_WORDPRESS_URL environment variable by sending a POST request to the Faust Plugin API.
+ * If the URL matches the Faust Plugin Headless URL, the validation fails, and an error is logged.
+ */
+export async function validateNextWordPressUrl(): Promise<void> {
+  const apiUrl = `${getWpUrl()}/wp-json/faustwp/v1/validate_public_wordpress_url`;
+  const headers = {
+    'Content-Type': 'application/json',
+    'x-faustwp-secret': getWpSecret() || '',
+  };
+
+  const postData = {
+    public_wordpress_url: getWpUrl(),
+  };
+  try {
+    const response = await fetch(apiUrl, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(postData),
+    });
+
+    if (!response.ok) {
+      errorLog(
+        'Validation Failed: Ensure your NEXT_PUBLIC_WORDPRESS_URL does not match with Headless URL in the Faust WordPress plugin settings',
+      );
+      process.exit(1);
+    }
+  } catch (error) {
+    console.log('error', error);
+  }
+}

--- a/packages/faustwp-cli/src/healthCheck/validateNextWordPressUrl.ts
+++ b/packages/faustwp-cli/src/healthCheck/validateNextWordPressUrl.ts
@@ -1,5 +1,5 @@
 import { getWpSecret, getWpUrl } from '../utils/index.js';
-import { errorLog } from '../stdout/index.js';
+import { errorLog, warnLog } from '../stdout/index.js';
 
 /**
  * Validates the NEXT_PUBLIC_WORDPRESS_URL environment variable by sending a POST request to the Faust Plugin API.
@@ -23,10 +23,17 @@ export async function validateNextWordPressUrl(): Promise<void> {
     });
 
     if (!response.ok) {
-      errorLog(
-        'Validation Failed: Your NEXT_PUBLIC_WORDPRESS_URL value is misconfigured. It should match your WordPress site URL and not your Faust front-end site URL.',
-      );
-      process.exit(1);
+      if (response.status === 404) {
+        // Handle the case when the route does not exist
+        warnLog(
+          'Route not found: Please update your FaustWP plugin to the latest version.',
+        );
+      } else {
+        errorLog(
+          'Validation Failed: Your NEXT_PUBLIC_WORDPRESS_URL value is misconfigured. It should match your WordPress site URL and not your Faust front-end site URL.',
+        );
+        process.exit(1);
+      }
     }
   } catch (error) {
     console.log('error', error);

--- a/packages/faustwp-cli/src/healthCheck/validateNextWordPressUrl.ts
+++ b/packages/faustwp-cli/src/healthCheck/validateNextWordPressUrl.ts
@@ -30,7 +30,7 @@ export async function validateNextWordPressUrl(): Promise<void> {
         );
       } else {
         errorLog(
-          'Validation Failed: Your NEXT_PUBLIC_WORDPRESS_URL value is misconfigured. It should match your WordPress site URL and not your Faust front-end site URL.',
+          'Validation Failed: Your Faust front-end site URL value is misconfigured. It should NOT match the `NEXT_PUBLIC_WORDPRESS_URL.`',
         );
         process.exit(1);
       }

--- a/packages/faustwp-cli/src/healthCheck/validateNextWordPressUrl.ts
+++ b/packages/faustwp-cli/src/healthCheck/validateNextWordPressUrl.ts
@@ -24,7 +24,7 @@ export async function validateNextWordPressUrl(): Promise<void> {
 
     if (!response.ok) {
       errorLog(
-        'Validation Failed: Ensure your NEXT_PUBLIC_WORDPRESS_URL does not match with Headless URL in the Faust WordPress plugin settings',
+        'Validation Failed: Your NEXT_PUBLIC_WORDPRESS_URL value is misconfigured. It should match your WordPress site URL and not your Faust front-end site URL.',
       );
       process.exit(1);
     }

--- a/packages/faustwp-cli/tests/healthCheck/validateFaustEnvVars.test.ts
+++ b/packages/faustwp-cli/tests/healthCheck/validateFaustEnvVars.test.ts
@@ -2,8 +2,7 @@ import {
   isWPEngineComSubdomain,
   validateFaustEnvVars,
 } from '../../src/healthCheck/validateFaustEnvVars';
-import fetchMock from 'fetch-mock';
-
+import fetchMock from 'fetch-mock-jest';
 /**
  * @jest-environment jsdom
  */
@@ -56,19 +55,22 @@ describe('healthCheck/validateFaustEnvVars', () => {
   });
 
   it('logs an error when the secret key validation fails', async () => {
-
     process.env.NEXT_PUBLIC_WORDPRESS_URL = 'https://headless.local';
     process.env.FAUST_SECRET_KEY = 'invalid-secret-key';
 
-    fetchMock.post('https://headless.local/wp-json/faustwp/v1/validate_secret_key', {
-      status: 401,
-    });
-    
+    fetchMock.post(
+      'https://headless.local/wp-json/faustwp/v1/validate_secret_key',
+      {
+        status: 401,
+      },
+    );
+
     await validateFaustEnvVars();
 
-    return expect(Promise.resolve(validateFaustEnvVars())).toMatchSnapshot(`Ensure your FAUST_SECRET_KEY environment variable matches your Secret Key in the Faust WordPress plugin settings`);
+    return expect(Promise.resolve(validateFaustEnvVars())).toMatchSnapshot(
+      `Ensure your FAUST_SECRET_KEY environment variable matches your Secret Key in the Faust WordPress plugin settings`,
+    );
   });
-
 });
 
 describe('isWPEngineComTLD', () => {

--- a/packages/faustwp-cli/tests/healthCheck/validateNextWordPressUrl.test.ts
+++ b/packages/faustwp-cli/tests/healthCheck/validateNextWordPressUrl.test.ts
@@ -49,7 +49,7 @@ describe('healthCheck/validateNextWordPressUrl', () => {
     await validateNextWordPressUrl();
     expect(consoleLogSpy).toHaveBeenCalledWith(
       expect.stringContaining(
-        'Validation Failed: Your NEXT_PUBLIC_WORDPRESS_URL value is misconfigured. It should match your WordPress site URL and not your Faust front-end site URL.',
+        'Validation Failed: Your Faust front-end site URL value is misconfigured. It should NOT match the `NEXT_PUBLIC_WORDPRESS_URL.',
       ),
     );
     expect(mockExit).toHaveBeenCalledWith(1);

--- a/packages/faustwp-cli/tests/healthCheck/validateNextWordPressUrl.test.ts
+++ b/packages/faustwp-cli/tests/healthCheck/validateNextWordPressUrl.test.ts
@@ -1,0 +1,58 @@
+import fetchMock from 'fetch-mock-jest';
+import { validateNextWordPressUrl } from '../../src/healthCheck/validateNextWordPressUrl';
+/**
+ * @jest-environment jsdom
+ */
+describe('healthCheck/validateNextWordPressUrl', () => {
+  const envBackup = process.env;
+
+  beforeEach(() => {
+    process.env = { ...envBackup };
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterAll(() => {
+    process.env = envBackup;
+  });
+
+  it('exits with a 1 exit code when the WordPress URL matches the Headless URL', async () => {
+    // @ts-ignore
+    const mockExit = jest.spyOn(process, 'exit').mockImplementation((code) => {
+      if (code && code !== 0) {
+        throw new Error(`Exit code: ${code}`);
+      }
+    });
+    const consoleLogSpy = jest.spyOn(console, 'log').mockImplementation();
+
+    process.env.NEXT_PUBLIC_WORDPRESS_URL = 'https://headless.local';
+    process.env.FAUST_SECRET_KEY = 'invalid-secret-key';
+
+    const headers = {
+      'Content-Type': 'application/json',
+      'x-faustwp-secret': process.env.FAUST_SECRET_KEY,
+    };
+
+    fetchMock.post(
+      'https://headless.local/wp-json/faustwp/v1/validate_public_wordpress_url',
+      {
+        headers,
+	      body: JSON.stringify({ public_wordpress_url: process.env.NEXT_PUBLIC_WORDPRESS_URL }),
+        status: 400,
+      },
+    );
+
+    await validateNextWordPressUrl();
+    expect(consoleLogSpy).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'Validation Failed: Ensure your NEXT_PUBLIC_WORDPRESS_URL does not match with Headless URL in the Faust WordPress plugin settings',
+      ),
+    );
+    expect(mockExit).toHaveBeenCalledWith(1);
+    expect(fetchMock).toHaveFetched('https://headless.local/wp-json/faustwp/v1/validate_public_wordpress_url');
+
+    consoleLogSpy.mockClear();
+  });
+});

--- a/packages/faustwp-cli/tests/healthCheck/validateNextWordPressUrl.test.ts
+++ b/packages/faustwp-cli/tests/healthCheck/validateNextWordPressUrl.test.ts
@@ -47,7 +47,7 @@ describe('healthCheck/validateNextWordPressUrl', () => {
     await validateNextWordPressUrl();
     expect(consoleLogSpy).toHaveBeenCalledWith(
       expect.stringContaining(
-        'Validation Failed: Ensure your NEXT_PUBLIC_WORDPRESS_URL does not match with Headless URL in the Faust WordPress plugin settings',
+        'Validation Failed: Your NEXT_PUBLIC_WORDPRESS_URL value is misconfigured. It should match your WordPress site URL and not your Faust front-end site URL.',
       ),
     );
     expect(mockExit).toHaveBeenCalledWith(1);

--- a/packages/faustwp-cli/tests/healthCheck/verifyGraphQLEndpoint.test.ts
+++ b/packages/faustwp-cli/tests/healthCheck/verifyGraphQLEndpoint.test.ts
@@ -2,7 +2,7 @@
  * @jest-environment jsdom
  */
 import 'isomorphic-fetch';
-import fetchMock from 'fetch-mock';
+import fetchMock from 'fetch-mock-jest';
 import { verifyGraphQLEndpoint } from '../../src/healthCheck/verifyGraphQLEndpoint.js';
 import { getGraphqlEndpoint } from '../../src/utils/index.js';
 

--- a/plugins/faustwp/includes/rest/callbacks.php
+++ b/plugins/faustwp/includes/rest/callbacks.php
@@ -565,11 +565,11 @@ function handle_rest_validate_public_wordpress_url_callback( \WP_REST_Request $r
 			$response = new \WP_REST_Response( 'OK', 200 );
 		} else {
 			// Return 400 Bad Request if the URLs match.
-			$response = new \WP_REST_Response( 'Bad Request: Provided URL matches the frontend URI setting.', 400 );
+			$response = new \WP_REST_Response( 'Bad Request', 400 );
 		}
 	} else {
 		// Return 400 Bad Request if the public_wordpress_url parameter is missing.
-		$response = new \WP_REST_Response( 'Bad Request: public_wordpress_url parameter is missing.', 400 );
+		$response = new \WP_REST_Response( 'Bad Request', 400 );
 	}
 
 	return $response;

--- a/plugins/faustwp/includes/rest/callbacks.php
+++ b/plugins/faustwp/includes/rest/callbacks.php
@@ -26,6 +26,7 @@ use function WPE\FaustWP\Blocks\handle_uploaded_blockset;
 use function WPE\FaustWP\Settings\faustwp_get_setting;
 use function WPE\FaustWP\Settings\faustwp_update_setting;
 use function WPE\FaustWP\Settings\is_telemetry_enabled;
+use function WPE\FaustWP\Utilities\domains_match;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -136,6 +137,16 @@ function register_rest_routes() {
 			'methods'             => 'POST',
 			'callback'            => __NAMESPACE__ . '\\handle_rest_validate_secret_key_callback',
 			'permission_callback' => __NAMESPACE__ . '\\rest_validate_secret_key_permission_callback',
+		)
+	);
+
+	register_rest_route(
+		'faustwp/v1',
+		'/validate_public_wordpress_url',
+		array(
+			'methods'             => 'POST',
+			'callback'            => __NAMESPACE__ . '\\handle_rest_validate_public_wordpress_url_callback',
+			'permission_callback' => __NAMESPACE__ . '\\rest_authorize_permission_callback',
 		)
 	);
 
@@ -522,4 +533,44 @@ function handle_rest_validate_secret_key_callback( \WP_REST_Request $request ) {
  */
 function rest_validate_secret_key_permission_callback( \WP_REST_Request $request ) {
 	return rest_authorize_permission_callback( $request );
+}
+
+/**
+ * Callback for WordPress register_rest_route() 'callback' parameter.
+ *
+ * Handle POST /faustwp/v1/validate_public_wordpress_url response.
+ *
+ * @link https://developer.wordpress.org/reference/functions/register_rest_route/
+ * @link https://developer.wordpress.org/rest-api/extending-the-rest-api/routes-and-endpoints/#endpoint-callback
+ *
+ * @param \WP_REST_Request $request Current \WP_REST_Request object.
+ *
+ * @return mixed A \WP_REST_Response, or \WP_Error.
+ */
+function handle_rest_validate_public_wordpress_url_callback( \WP_REST_Request $request ) {
+	// Get the frontend URI setting from WordPress
+    $frontendUri = faustwp_get_setting('frontend_uri');
+
+    // Retrieve the parameters from the request
+	$parameters = $request->get_params();
+
+	// Check if the public_wordpress_url parameter is present in the request
+	if (isset($parameters['public_wordpress_url'])) {
+		// Retrieve the value of the public_wordpress_url parameter
+    	$publicWordpressUrl = $parameters['public_wordpress_url'];
+
+        // Check if the provided WordPress URL does not match the frontend URI
+        if ( ! domains_match( $publicWordpressUrl, $frontendUri ) ) {
+            // Return 200 OK if the URLs match
+            $response = new \WP_REST_Response('OK', 200);
+        } else {
+            // Return 400 Bad Request if the URLs match
+            $response = new \WP_REST_Response('Bad Request: Provided URL matches the frontend URI setting.', 400);
+        }
+    } else {
+        // Return 400 Bad Request if the public_wordpress_url parameter is missing
+        $response = new \WP_REST_Response('Bad Request: public_wordpress_url parameter is missing.', 400);
+    }
+
+    return $response;
 }

--- a/plugins/faustwp/includes/rest/callbacks.php
+++ b/plugins/faustwp/includes/rest/callbacks.php
@@ -548,29 +548,29 @@ function rest_validate_secret_key_permission_callback( \WP_REST_Request $request
  * @return mixed A \WP_REST_Response, or \WP_Error.
  */
 function handle_rest_validate_public_wordpress_url_callback( \WP_REST_Request $request ) {
-	// Get the frontend URI setting from WordPress
-    $frontendUri = faustwp_get_setting('frontend_uri');
+	// Get the frontend URI setting from WordPress.
+	$frontend_uri = faustwp_get_setting( 'frontend_uri' );
 
-    // Retrieve the parameters from the request
+	// Retrieve the parameters from the request.
 	$parameters = $request->get_params();
 
-	// Check if the public_wordpress_url parameter is present in the request
-	if (isset($parameters['public_wordpress_url'])) {
-		// Retrieve the value of the public_wordpress_url parameter
-    	$publicWordpressUrl = $parameters['public_wordpress_url'];
+	// Check if the public_wordpress_url parameter is present in the request.
+	if ( isset( $parameters['public_wordpress_url'] ) ) {
+		// Retrieve the value of the public_wordpress_url parameter.
+		$public_wordpress_url = $parameters['public_wordpress_url'];
 
-        // Check if the provided WordPress URL does not match the frontend URI
-        if ( ! domains_match( $publicWordpressUrl, $frontendUri ) ) {
-            // Return 200 OK if the URLs match
-            $response = new \WP_REST_Response('OK', 200);
-        } else {
-            // Return 400 Bad Request if the URLs match
-            $response = new \WP_REST_Response('Bad Request: Provided URL matches the frontend URI setting.', 400);
-        }
-    } else {
-        // Return 400 Bad Request if the public_wordpress_url parameter is missing
-        $response = new \WP_REST_Response('Bad Request: public_wordpress_url parameter is missing.', 400);
-    }
+		// Check if the provided WordPress URL does not match the frontend URI.
+		if ( ! domains_match( $public_wordpress_url, $frontend_uri ) ) {
+			// Return 200 OK if the URLs do not match.
+			$response = new \WP_REST_Response( 'OK', 200 );
+		} else {
+			// Return 400 Bad Request if the URLs match.
+			$response = new \WP_REST_Response( 'Bad Request: Provided URL matches the frontend URI setting.', 400 );
+		}
+	} else {
+		// Return 400 Bad Request if the public_wordpress_url parameter is missing.
+		$response = new \WP_REST_Response( 'Bad Request: public_wordpress_url parameter is missing.', 400 );
+	}
 
-    return $response;
+	return $response;
 }

--- a/plugins/faustwp/includes/utilities/functions.php
+++ b/plugins/faustwp/includes/utilities/functions.php
@@ -53,17 +53,17 @@ function plugin_version() {
  */
 function domains_match( $domain1, $domain2 ) {
 	// Extract the domain part
-    $extract_domain = function ( $url ) {
-        $parsed_url = wp_parse_url( $url, PHP_URL_HOST );
-        return $parsed_url ? $parsed_url : null;
-    };
+	$extract_domain = function ( $url ) {
+		$parsed_url = wp_parse_url( $url, PHP_URL_HOST );
+		return $parsed_url ? $parsed_url : null;
+	};
 
-    $domain1 = $extract_domain( $domain1 );
-    $domain2 = $extract_domain( $domain2 );
+	$domain1 = $extract_domain( $domain1 );
+	$domain2 = $extract_domain( $domain2 );
 
 	// Remove "www" prefix from domain if present
-    $domain1 = preg_replace('/^www\./i', '', $domain1);
-    $domain2 = preg_replace('/^www\./i', '', $domain2);
+	$domain1 = preg_replace( '/^www\./i', '', $domain1 );
+	$domain2 = preg_replace( '/^www\./i', '', $domain2 );
 
-    return $domain1 !== null && $domain2 !== null && $domain1 === $domain2;
+	return $domain1 !== null && $domain2 !== null && $domain1 === $domain2;
 }

--- a/plugins/faustwp/includes/utilities/functions.php
+++ b/plugins/faustwp/includes/utilities/functions.php
@@ -52,11 +52,11 @@ function plugin_version() {
  * @return bool True if the domains match, false otherwise.
  */
 function domains_match( $domain1, $domain2 ) {
-	// Remove leading "http://" or "https://" if present
+	// Remove leading "http://" or "https://" if present.
 	$first  = preg_replace( '/^(https?:\/\/)?/', '', $domain1 );
 	$second = preg_replace( '/^(https?:\/\/)?/', '', $domain2 );
 
-	// Extract the domain part (remove path and query parameters)
+	// Extract the domain part (remove path and query parameters).
 	$extract_domain = function ( $url ) {
 		return explode( '/', wp_parse_url( $url, PHP_URL_HOST ) )[0];
 	};

--- a/plugins/faustwp/includes/utilities/functions.php
+++ b/plugins/faustwp/includes/utilities/functions.php
@@ -43,3 +43,23 @@ function plugin_version() {
 
 	return $plugin['Version'];
 }
+
+/**
+ * Checks if two domain strings represent the same domain.
+ *
+ * @param string $domain1 The first domain string.
+ * @param string $domain2 The second domain string.
+ * @return bool True if the domains match, false otherwise.
+ */
+function domains_match( $domain1, $domain2 ) {
+    // Remove leading "http://" or "https://" if present
+    $first = preg_replace('/^(https?:\/\/)?/', '', $domain1);
+    $second = preg_replace('/^(https?:\/\/)?/', '', $domain2);
+
+    // Extract the domain part (remove path and query parameters)
+    $extractDomain = function ($url) {
+        return explode('/', parse_url($url, PHP_URL_HOST))[0];
+    };
+
+    return $extractDomain($first) === $extractDomain($second);
+}

--- a/plugins/faustwp/includes/utilities/functions.php
+++ b/plugins/faustwp/includes/utilities/functions.php
@@ -52,14 +52,18 @@ function plugin_version() {
  * @return bool True if the domains match, false otherwise.
  */
 function domains_match( $domain1, $domain2 ) {
-	// Remove leading "http://" or "https://" if present.
-	$first  = preg_replace( '/^(https?:\/\/)?/', '', $domain1 );
-	$second = preg_replace( '/^(https?:\/\/)?/', '', $domain2 );
+	// Extract the domain part
+    $extract_domain = function ( $url ) {
+        $parsed_url = wp_parse_url( $url, PHP_URL_HOST );
+        return $parsed_url ? $parsed_url : null;
+    };
 
-	// Extract the domain part (remove path and query parameters).
-	$extract_domain = function ( $url ) {
-		return explode( '/', wp_parse_url( $url, PHP_URL_HOST ) )[0];
-	};
+    $domain1 = $extract_domain( $domain1 );
+    $domain2 = $extract_domain( $domain2 );
 
-	return $extract_domain( $first ) === $extract_domain( $second );
+	// Remove "www" prefix from domain if present
+    $domain1 = preg_replace('/^www\./i', '', $domain1);
+    $domain2 = preg_replace('/^www\./i', '', $domain2);
+
+    return $domain1 !== null && $domain2 !== null && $domain1 === $domain2;
 }

--- a/plugins/faustwp/includes/utilities/functions.php
+++ b/plugins/faustwp/includes/utilities/functions.php
@@ -52,14 +52,14 @@ function plugin_version() {
  * @return bool True if the domains match, false otherwise.
  */
 function domains_match( $domain1, $domain2 ) {
-    // Remove leading "http://" or "https://" if present
-    $first = preg_replace('/^(https?:\/\/)?/', '', $domain1);
-    $second = preg_replace('/^(https?:\/\/)?/', '', $domain2);
+	// Remove leading "http://" or "https://" if present
+	$first  = preg_replace( '/^(https?:\/\/)?/', '', $domain1 );
+	$second = preg_replace( '/^(https?:\/\/)?/', '', $domain2 );
 
-    // Extract the domain part (remove path and query parameters)
-    $extractDomain = function ($url) {
-        return explode('/', parse_url($url, PHP_URL_HOST))[0];
-    };
+	// Extract the domain part (remove path and query parameters)
+	$extract_domain = function ( $url ) {
+		return explode( '/', wp_parse_url( $url, PHP_URL_HOST ) )[0];
+	};
 
-    return $extractDomain($first) === $extractDomain($second);
+	return $extract_domain( $first ) === $extract_domain( $second );
 }

--- a/plugins/faustwp/includes/utilities/functions.php
+++ b/plugins/faustwp/includes/utilities/functions.php
@@ -52,7 +52,7 @@ function plugin_version() {
  * @return bool True if the domains match, false otherwise.
  */
 function domains_match( $domain1, $domain2 ) {
-	// Extract the domain part
+	// Extract the domain part.
 	$extract_domain = function ( $url ) {
 		$parsed_url = wp_parse_url( $url, PHP_URL_HOST );
 		return $parsed_url ? $parsed_url : null;
@@ -61,9 +61,9 @@ function domains_match( $domain1, $domain2 ) {
 	$domain1 = $extract_domain( $domain1 );
 	$domain2 = $extract_domain( $domain2 );
 
-	// Remove "www" prefix from domain if present
+	// Remove "www" prefix from domain if present.
 	$domain1 = preg_replace( '/^www\./i', '', $domain1 );
 	$domain2 = preg_replace( '/^www\./i', '', $domain2 );
 
-	return $domain1 !== null && $domain2 !== null && $domain1 === $domain2;
+	return null !== $domain1 && null !== $domain2 && $domain1 === $domain2;
 }

--- a/plugins/faustwp/tests/unit/FunctionsTests.php
+++ b/plugins/faustwp/tests/unit/FunctionsTests.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace WPE\FaustWP\Tests\Unit;
+
+use function WPE\FaustWP\Utilities\{domains_match};
+
+class FunctionsTests extends FaustUnitTest {
+	public function test_domains_match() {
+		// Test case 1: Same domains with different protocols
+		$this->assertTrue(domains_match("http://example.com", "https://example.com"));
+
+		// Test case 2: Same domains with trailing slashes
+		$this->assertTrue(domains_match("http://example.com/", "http://example.com"));
+
+		// Test case 3: Same domains with www prefix
+		$this->assertTrue(domains_match("http://www.example.com", "http://example.com"));
+
+		// Test case 4: Different domains
+		$this->assertFalse(domains_match("http://example1.com", "http://example2.com"));
+
+		// Test case 5: Same domains with different subdomains
+		$this->assertFalse(domains_match("http://1.example.com", "http://2.example.com"));
+	}
+}


### PR DESCRIPTION
## Tasks

- [ ] I have signed a [Contributor License Agreement (CLA)](https://github.com/wpengine/faustjs#contributor-license-agreement) with WP Engine.
- [ ] If a code change, I have written testing instructions that the whole team & outside contributors can understand.
- [ ] I have written and included a comprehensive [changeset](https://github.com/wpengine/faustjs/blob/canary/DEVELOPMENT.md#deployment) to properly document the changes I've made.

## Description

This pull request adds a check in order to alert Faust users if they accidentally set the NEXT_PUBLIC_WORDPRESS_URL to the URL of their headless site. The code now makes a request to the FaustWP endpoint and checks if the response indicates that the URL is pointing to a headless site.


## Related Issue(s):

Closes #1750 

## Testing
To test these changes, follow these steps:

1. In the Faust Plugin Settings, set the Headless URL to match the NEXT_PUBLIC_WORDPRESS_URL.
2. Try to run the dev or build commands in your headless site.
Observe that it should error with the following message:
```
Validation Failed: Ensure your NEXT_PUBLIC_WORDPRESS_URL does not match with Headless URL in the Faust WordPress plugin settings
```

### Testing Instructions (for Older Plugin Versions)
To test these changes on older versions of the Faust Plugin, follow these steps:

1) In the Faust Plugin Settings, set the Headless URL to match the NEXT_PUBLIC_WORDPRESS_URL.
2) Try to run the development or build commands in your headless site.
3) Observe the behavior when the plugin version is outdated:
4) The function should continue silently, logging a message indicating the missing route and prompting the user to update their FaustWP plugin to the latest version.

```
warn - Route not found: Please update your FaustWP plugin to the latest version.
```

## Screenshots

<!--
If this is a visual change include relevant screenshots about the behavior of the application before and after this change.
-->

<img width="1792" alt="Screenshot 2024-02-21 at 13 11 29" src="https://github.com/wpengine/faustjs/assets/328805/91fe93b5-a0b3-49ec-be9f-016da57132b2">

<img width="1253" alt="Screenshot 2024-02-21 at 13 12 00" src="https://github.com/wpengine/faustjs/assets/328805/1509071f-c692-4c55-b62f-95b039ae443d">

## Documentation Changes

<!--
List corresponding changes to the documentation.
-->

## Dependant PRs

<!--
List any dependent PR's that are awaiting review. Use the following syntax:

- #1234
-->
