### PR TITLE
update @experimental-app-router for handle trailing slash config

### DIFF
--- a/.changeset/cool-stingrays-hammer.md
+++ b/.changeset/cool-stingrays-hammer.md
@@ -1,5 +1,5 @@
 ---
-'@faustwp/experimental-app-router': minor
+'@faustwp/experimental-app-router': patch
 ---
 
-handle trailing slash into routehandler to retieve wp token
+Fixed issue where Faust's router handler failed to retrieve a token when trailingSlash is set to true in next.config.js.

--- a/.changeset/cool-stingrays-hammer.md
+++ b/.changeset/cool-stingrays-hammer.md
@@ -2,4 +2,4 @@
 '@faustwp/experimental-app-router': patch
 ---
 
-Fixed issue where Faust's router handler failed to retrieve a token when trailingSlash is set to true in next.config.js.
+Fixed issue where Faust's route handler failed to retrieve a token when trailingSlash is set to true in next.config.js.

--- a/.changeset/cool-stingrays-hammer.md
+++ b/.changeset/cool-stingrays-hammer.md
@@ -1,0 +1,5 @@
+---
+'@faustwp/experimental-app-router': minor
+---
+
+handle trailing slash into routehandler to retieve wp token

--- a/packages/experimental-app-router/src/server/routeHandler/index.ts
+++ b/packages/experimental-app-router/src/server/routeHandler/index.ts
@@ -5,6 +5,7 @@ export async function GetFn(req: Request) {
   const { pathname } = new URL(req.url);
 
   switch (pathname) {
+    case '/api/faust/token/':
     case '/api/faust/token': {
       return tokenHandler(req);
     }


### PR DESCRIPTION
## Tasks

- [x] I have signed a [Contributor License Agreement (CLA)](https://github.com/wpengine/faustjs#contributor-license-agreement) with WP Engine.
- [x] If a code change, I have written testing instructions that the whole team & outside contributors can understand.
- [x] I have written and included a comprehensive [changeset](https://github.com/wpengine/faustjs/blob/canary/DEVELOPMENT.md#deployment) to properly document the changes I've made.

## Description

When `trailingSlash` is set to `true` in `next.config.js` ([Reference](https://nextjs.org/docs/app/api-reference/next-config-js/trailingSlash)), the route handler doesn't handle the `pathname` with a trailing slash and returns a 404 ([Reference](https://github.com/wpengine/faustjs/blob/4724719eaa36295733955d47ad98c43e06ebc1f7/packages/experimental-app-router/src/server/routeHandler/index.ts#L8)). In the console you'll see `There was an error fetching the access token Error: Invalid response from token endpoint`.

