### PR TITLE
TOOLBAR LOGOUT LOOP: init commit and test

### DIFF
--- a/packages/faustwp-core/src/hooks/useLogout.tsx
+++ b/packages/faustwp-core/src/hooks/useLogout.tsx
@@ -25,11 +25,20 @@ export function useLogout() {
       return;
     }
 
+    const isPreview = window.location.search.includes('preview=true');
+
     if (redirectUrl) {
       window.location.assign(redirectUrl);
-    } else {
-      window.location.reload();
     }
+
+    if (isPreview) {
+      const publicUrlPath = process.env.NEXT_PUBLIC_URL;
+      if (publicUrlPath) {
+        window.location.assign(publicUrlPath);
+      }
+    }
+
+    window.location.reload();
 
     setLoading(false);
   }

--- a/packages/faustwp-core/tests/hooks/useLogout.test.ts
+++ b/packages/faustwp-core/tests/hooks/useLogout.test.ts
@@ -60,6 +60,24 @@ describe('useLogout hook', () => {
     fetchMock.restore();
   });
 
+  it('calls window.location.assign if there is a preview url and public path', async () => {
+    fetchMock.post(`/api/faust/auth/logout`, {
+      status: 205,
+    });
+
+    global.window.location.search = 'preview=true';
+
+    process.env.NEXT_PUBLIC_URL = 'test';
+
+    const { result } = renderHook(() => useLogout());
+
+    await act(() => result.current.logout());
+
+    expect(window.location.assign).toBeCalledWith('test');
+
+    fetchMock.restore();
+  });
+
   it('calls window.location.assign if there is a redirect url', async () => {
     fetchMock.post(`/api/faust/auth/logout`, {
       status: 205,


### PR DESCRIPTION
## Description
If on a preview page, if you logged out, it would do a reload of the page and log you right back in. This redirects you back to your base wordpress public url.

## Testing
1. Pull this PR's feature branch
2. Build and `npm run dev` to start the getting started project
3. Once it's running go to WordPress and preview a page or post to authenticate
4. Once authenticated, refresh the page to see the toolbar
5. Click logout
6. You should logout and redirect to the base url for the public site
7. If you logout on non preview pages you should logout and remain on the same page
8. If you logout with a redirectUrl defined, you should logout and be taken to that url