### PR TITLE
Feat: Added Error Logging Apollo Link

### DIFF
--- a/.changeset/soft-swans-chew.md
+++ b/.changeset/soft-swans-chew.md
@@ -1,0 +1,5 @@
+---
+'@faustwp/core': patch
+---
+
+Implemented ErrorLoggingLink class to capture GraphQL errors and server errors, providing enhanced error handling and logging capabilities.

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,9 +51,9 @@
       "dependencies": {
         "@apollo/client": "^3.8.0",
         "@apollo/experimental-nextjs-app-support": "^0.8.0",
-        "@faustwp/cli": "^2.0.0",
-        "@faustwp/core": "^2.1.2",
-        "@faustwp/experimental-app-router": "^0.2.2",
+        "@faustwp/cli": "^3.0.0",
+        "@faustwp/core": "^3.0.0",
+        "@faustwp/experimental-app-router": "^0.3.0",
         "graphql": "^16.7.1",
         "next": "^14.0.1",
         "react": "^18.2.0",
@@ -328,9 +328,9 @@
       "version": "0.2.0",
       "dependencies": {
         "@apollo/client": "^3.8.8",
-        "@faustwp/blocks": "3.0.0",
-        "@faustwp/cli": "^2.0.0",
-        "@faustwp/core": "^2.1.2",
+        "@faustwp/blocks": "4.0.0",
+        "@faustwp/cli": "^3.0.0",
+        "@faustwp/core": "^3.0.0",
         "classnames": "^2.3.1",
         "graphql": "^16.8.1",
         "next": "^14.0.3",
@@ -339,7 +339,7 @@
         "sass": "^1.54.9"
       },
       "devDependencies": {
-        "@faustwp/block-editor-utils": "0.1.0",
+        "@faustwp/block-editor-utils": "0.2.0",
         "@wordpress/base-styles": "^4.41.0",
         "@wordpress/block-library": "^8.27.0",
         "@wordpress/scripts": "26.18.0",
@@ -2429,8 +2429,8 @@
       "version": "0.1.0",
       "dependencies": {
         "@apollo/client": "^3.6.6",
-        "@faustwp/cli": "^2.0.0",
-        "@faustwp/core": "^2.1.2",
+        "@faustwp/cli": "^3.0.0",
+        "@faustwp/core": "^3.0.0",
         "@wordpress/base-styles": "^4.36.0",
         "@wordpress/block-library": "^7.19.0",
         "classnames": "^2.3.1",
@@ -8736,6 +8736,11 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/zen-observable": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/@types/zen-observable/-/zen-observable-0.8.3.tgz",
+      "integrity": "sha512-fbF6oTd4sGGy0xjHPKAt+eS2CrxJ3+6gQ3FGcBoIJR2TLAyCkCyI8JqZNy+FeON0AhVgNJoUumVoZQjBFUqHkw=="
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "5.62.0",
@@ -28649,7 +28654,8 @@
     },
     "node_modules/zen-observable-ts": {
       "version": "1.2.5",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-1.2.5.tgz",
+      "integrity": "sha512-QZWQekv6iB72Naeake9hS1KxHlotfRpe+WGNbNx5/ta+R3DNjVO2bswf63gXlWDcs+EMd7XY8HfVQyP1X6T4Zg==",
       "dependencies": {
         "zen-observable": "0.8.15"
       }
@@ -28668,7 +28674,7 @@
     },
     "packages/block-editor-utils": {
       "name": "@faustwp/block-editor-utils",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "@wordpress/block-editor": "^12.11.1",
@@ -29477,7 +29483,7 @@
     },
     "packages/blocks": {
       "name": "@faustwp/blocks",
-      "version": "3.0.0",
+      "version": "4.0.0",
       "license": "MIT",
       "devDependencies": {
         "@testing-library/jest-dom": "^5.16.5",
@@ -30998,13 +31004,13 @@
     },
     "packages/experimental-app-router": {
       "name": "@faustwp/experimental-app-router",
-      "version": "0.2.2",
+      "version": "0.3.0",
       "license": "MIT",
       "devDependencies": {
         "@apollo/client": "^3.8.0",
         "@apollo/experimental-nextjs-app-support": "^0.8.0",
-        "@faustwp/cli": "^2.0.0",
-        "@faustwp/core": "^2.0.0",
+        "@faustwp/cli": "^3.0.0",
+        "@faustwp/core": "^3.0.0",
         "@testing-library/jest-dom": "^5.17.0",
         "@types/node": "^20.4.6",
         "concurrently": "^8.2.0",
@@ -31571,7 +31577,7 @@
     },
     "packages/faustwp-cli": {
       "name": "@faustwp/cli",
-      "version": "2.0.0",
+      "version": "3.0.0",
       "license": "MIT",
       "dependencies": {
         "archiver": "^6.0.1",
@@ -31736,7 +31742,7 @@
     },
     "packages/faustwp-core": {
       "name": "@faustwp/core",
-      "version": "2.1.2",
+      "version": "3.0.0",
       "license": "MIT",
       "dependencies": {
         "@wordpress/hooks": "^3.14.0",
@@ -31748,7 +31754,8 @@
         "isomorphic-fetch": "^3.0.0",
         "js-cookie": "^3.0.5",
         "js-sha256": "^0.9.0",
-        "lodash": "^4.17.21"
+        "lodash": "^4.17.21",
+        "zen-observable-ts": "^1.1.0"
       },
       "devDependencies": {
         "@apollo/client": "^3.6.6",
@@ -33164,6 +33171,15 @@
       "license": "ISC",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "packages/faustwp-core/node_modules/zen-observable-ts": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-1.1.0.tgz",
+      "integrity": "sha512-1h4zlLSqI2cRLPJUHJFL8bCWHhkpuXkF+dbGkRaWjgDIG26DmzyshUMrdV/rL3UnR+mhaX4fRq8LPouq0MYYIA==",
+      "dependencies": {
+        "@types/zen-observable": "0.8.3",
+        "zen-observable": "0.8.15"
       }
     },
     "packages/next": {
@@ -36014,7 +36030,7 @@
     },
     "plugins/faustwp": {
       "name": "@faustwp/wordpress-plugin",
-      "version": "1.2.1"
+      "version": "1.2.2"
     },
     "packages/experimental-app-router/node_modules/@next/swc-android-arm-eabi": {
       "version": "12.3.4",

--- a/packages/faustwp-core/package.json
+++ b/packages/faustwp-core/package.json
@@ -41,7 +41,8 @@
     "isomorphic-fetch": "^3.0.0",
     "js-cookie": "^3.0.5",
     "js-sha256": "^0.9.0",
-    "lodash": "^4.17.21"
+    "lodash": "^4.17.21",
+    "zen-observable-ts": "^1.1.0"
   },
   "scripts": {
     "dev": "concurrently \"npm:watch-*\" --prefix-colors \"auto\"",

--- a/packages/faustwp-core/src/apollo/errorLoggingLink.ts
+++ b/packages/faustwp-core/src/apollo/errorLoggingLink.ts
@@ -1,0 +1,73 @@
+import {
+  ApolloLink,
+  FetchResult,
+  NextLink,
+  Operation,
+  ServerError,
+} from '@apollo/client';
+import { Observable } from 'zen-observable-ts';
+import { errorLog } from '../utils/log.js';
+
+/**
+ * Checks if the given error is a server error.
+ * @param error The error to check.
+ * @returns A boolean indicating whether the error is a server error.
+ */
+function isServerError(error: unknown): error is ServerError {
+  if (
+    typeof error === 'object' &&
+    error !== null &&
+    'response' in error &&
+    'result' in error &&
+    'statusCode' in error
+  ) {
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Apollo Link that captures GraphQL errors and server errors, and prints them into the console.
+ */
+export class ErrorLoggingLink extends ApolloLink {
+  /**
+   * Intercepts each GraphQL operation request.
+   * @param operation The GraphQL operation being executed.
+   * @param forward The next link in the chain to delegate the operation to.
+   * @returns An Observable with the operation result or error.
+   */
+  // eslint-disable-next-line class-methods-use-this
+  request(
+    operation: Operation,
+    forward: NextLink,
+  ): Observable<FetchResult> | null {
+    return new Observable<FetchResult>((observer) => {
+      const subscription = forward(operation).subscribe({
+        next: (result) => {
+          // Check if there are GraphQL errors in the result
+          if (result.errors && result.errors.length > 0) {
+            errorLog('GraphQL errors:', result.errors);
+          }
+          observer.next(result);
+        },
+        error: (error) => {
+          // Check if the error is a server error
+          if (isServerError(error)) {
+            errorLog('Server error:', error);
+            errorLog('Fetch result:', error.result);
+          } else {
+            errorLog('Network error:', error);
+          }
+          observer.error(error);
+        },
+        complete: () => {
+          observer.complete();
+        },
+      });
+
+      return () => {
+        subscription.unsubscribe();
+      };
+    });
+  }
+}

--- a/packages/faustwp-core/src/apollo/index.ts
+++ b/packages/faustwp-core/src/apollo/index.ts
@@ -1,0 +1,1 @@
+export * from './errorLoggingLink.js';

--- a/packages/faustwp-core/src/client.ts
+++ b/packages/faustwp-core/src/client.ts
@@ -1,6 +1,7 @@
 import {
   ApolloClient,
   ApolloClientOptions,
+  ApolloLink,
   createHttpLink,
   InMemoryCache,
   InMemoryCacheConfig,
@@ -16,6 +17,7 @@ import { createPersistedQueryLink } from '@apollo/client/link/persisted-queries'
 import { sha256 } from 'js-sha256';
 // eslint-disable-next-line import/extensions
 import { AppProps } from 'next/app';
+import { ErrorLoggingLink } from './apollo/errorLoggingLink.js';
 import { getAccessToken } from './auth/index.js';
 import { getConfig } from './config/index.js';
 import { getGraphqlEndpoint } from './lib/getGraphqlEndpoint.js';
@@ -56,15 +58,18 @@ export function createApolloClient(authenticated = false) {
     {},
   ) as InMemoryCacheConfig;
 
-  let linkChain = createHttpLink({
-    uri: getGraphqlEndpoint(),
-    /**
-     * Only add this option if usePersistedQueries is not set/false.
-     * When persisted queries is enabled and this flag and useGETForHashedQueries
-     * are both set, there is a conflict and persisted queries does not work.
-     */
-    useGETForQueries: useGETForQueries && !usePersistedQueries,
-  });
+  let linkChain = ApolloLink.from([
+    new ErrorLoggingLink(),
+    createHttpLink({
+      uri: getGraphqlEndpoint(),
+      /**
+       * Only add this option if usePersistedQueries is not set/false.
+       * When persisted queries is enabled and this flag and useGETForHashedQueries
+       * are both set, there is a conflict and persisted queries does not work.
+       */
+      useGETForQueries: useGETForQueries && !usePersistedQueries,
+    }),
+  ]);
 
   // If the user requested to use persisted queries, apply the link.
   if (usePersistedQueries) {

--- a/packages/faustwp-core/tests/apollo/errorLoggingLink.test.ts
+++ b/packages/faustwp-core/tests/apollo/errorLoggingLink.test.ts
@@ -2,9 +2,6 @@ import { ApolloError } from '@apollo/client/core';
 import { Observable } from 'zen-observable-ts';
 import { ErrorLoggingLink } from '../../src/apollo/errorLoggingLink';
 
-// Mock console.error to prevent actual logging during tests
-jest.spyOn(console, 'error').mockImplementation(() => {});
-
 describe('ErrorLoggingLink', () => {
   let link: ErrorLoggingLink;
   let mockNextLink: jest.Mock;

--- a/packages/faustwp-core/tests/apollo/errorLoggingLink.test.ts
+++ b/packages/faustwp-core/tests/apollo/errorLoggingLink.test.ts
@@ -15,7 +15,7 @@ describe('ErrorLoggingLink', () => {
     jest.clearAllMocks();
   });
 
-  it('should log GraphQL errors', (done) => {
+  it('logs GraphQL errors', (done) => {
     const mockErrors = [
       new ApolloError({ errorMessage: 'Test GraphQL error' }),
     ];

--- a/packages/faustwp-core/tests/apollo/errorLoggingLink.test.ts
+++ b/packages/faustwp-core/tests/apollo/errorLoggingLink.test.ts
@@ -1,0 +1,119 @@
+import { ApolloError } from '@apollo/client/core';
+import { Observable } from 'zen-observable-ts';
+import { ErrorLoggingLink } from '../../src/apollo/errorLoggingLink';
+
+// Mock console.error to prevent actual logging during tests
+jest.spyOn(console, 'error').mockImplementation(() => {});
+
+describe('ErrorLoggingLink', () => {
+  let link: ErrorLoggingLink;
+  let mockNextLink: jest.Mock;
+
+  beforeEach(() => {
+    link = new ErrorLoggingLink();
+    mockNextLink = jest.fn();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should log GraphQL errors', (done) => {
+    const mockErrors = [
+      new ApolloError({ errorMessage: 'Test GraphQL error' }),
+    ];
+    const mockResult = { errors: mockErrors };
+    const mockOperation = { query: {} };
+
+    mockNextLink.mockReturnValueOnce(
+      new Observable((observer) => {
+        observer.next(mockResult);
+        observer.complete();
+      }),
+    );
+
+    const consoleLogSpy = jest.spyOn(console, 'log').mockImplementation();
+
+    link.request(mockOperation as any, mockNextLink as any).subscribe({
+      next: (result) => {
+        // Check if there are GraphQL errors in the result
+        if (result.errors && result.errors.length > 0) {
+          expect(consoleLogSpy).toHaveBeenCalled();
+          expect(consoleLogSpy.mock.calls[0][0]).toContain('GraphQL errors');
+          expect(consoleLogSpy.mock.calls[0][1]).toEqual(mockErrors);
+        } else {
+          // We shouldn't reach here for an error-free result
+          expect(true).toBe(false);
+        }
+        consoleLogSpy.mockRestore();
+        done();
+      },
+      error: () => {
+        // We shouldn't reach here for an error
+        expect(true).toBe(false);
+        done();
+      },
+    });
+  }, 1000);
+
+  it('logs server errors along with fetch result', (done) => {
+    const mockServerError = new ApolloError({
+      errorMessage: 'Test server error',
+      graphQLErrors: [],
+      networkError: null, // Ensure networkError is null to simulate a server error
+    });
+    const mockOperation = { query: {} };
+
+    mockNextLink.mockReturnValueOnce(
+      new Observable((observer) => {
+        observer.error(mockServerError);
+      }),
+    );
+
+    const consoleLogSpy = jest.spyOn(console, 'log').mockImplementation();
+
+    link.request(mockOperation as any, mockNextLink as any).subscribe({
+      next: () => {
+        // We shouldn't reach here for an error
+        expect(true).toBe(false);
+        done();
+      },
+      error: () => {
+        expect(consoleLogSpy).toHaveBeenCalled();
+        consoleLogSpy.mockRestore();
+        done();
+      },
+    });
+  }, 1000);
+
+  it('logs network errors', (done) => {
+    const mockNetworkError = {
+      response: {},
+      result: {},
+      statusCode: 500,
+    };
+    const mockOperation = { query: {} };
+
+    mockNextLink.mockReturnValueOnce(
+      new Observable((observer) => {
+        observer.error(mockNetworkError); // Emit a network error instead of a server error
+      })
+    );
+
+    const consoleLogSpy = jest.spyOn(console, 'log').mockImplementation();
+
+    link.request(mockOperation as any, mockNextLink as any).subscribe({
+      next: () => {
+        // We shouldn't reach here for an error
+        expect(true).toBe(false);
+        done();
+      },
+      error: (error) => {
+        expect(consoleLogSpy).toHaveBeenCalled();
+        expect(consoleLogSpy.mock.calls[0][0]).toContain('Server error');
+        expect(error).toEqual(mockNetworkError);
+        done();
+      },
+    });
+  }, 1000);
+});

--- a/packages/faustwp-core/tests/apollo/errorLoggingLink.test.ts
+++ b/packages/faustwp-core/tests/apollo/errorLoggingLink.test.ts
@@ -46,7 +46,7 @@ describe('ErrorLoggingLink', () => {
         done();
       },
       error: () => {
-        // We shouldn't reach here for an error
+        // We shouldn't reach here
         expect(true).toBe(false);
         done();
       },
@@ -71,7 +71,7 @@ describe('ErrorLoggingLink', () => {
 
     link.request(mockOperation as any, mockNextLink as any).subscribe({
       next: () => {
-        // We shouldn't reach here for an error
+        // We shouldn't reach here
         expect(true).toBe(false);
         done();
       },
@@ -101,7 +101,7 @@ describe('ErrorLoggingLink', () => {
 
     link.request(mockOperation as any, mockNextLink as any).subscribe({
       next: () => {
-        // We shouldn't reach here for an error
+        // We shouldn't reach here
         expect(true).toBe(false);
         done();
       },


### PR DESCRIPTION
## Tasks

- [ ] I have signed a [Contributor License Agreement (CLA)](https://github.com/wpengine/faustjs#contributor-license-agreement) with WP Engine.
- [ ] If a code change, I have written testing instructions that the whole team & outside contributors can understand.
- [ ] I have written and included a comprehensive [changeset](https://github.com/wpengine/faustjs/blob/canary/DEVELOPMENT.md#deployment) to properly document the changes I've made.

## Description

Implemented `ErrorLoggingLink` class to capture GraphQL errors and server errors, providing enhanced error handling and logging capabilities. 
This class intercepts GraphQL operation requests and logs any encountered errors, including GraphQL errors and server errors, to the console.

## Related Issue(s):
#1732 

<!--
Provide the GitHub issue(s) number for issue tracking purposes, use the following syntax:

- #1234
-->

## Testing

<!--
Describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Also list any relevant details for your test configuration such as how to test the changes locally or in staging.
-->

1. In the example project, try to add a graphQL field that does not exist. For example, in front-page template;

```
Component.query = gql`
  ${BlogInfoFragment}
  ${NavigationMenu.fragments.entry}
  query GetPageData(
    $headerLocation: MenuLocationEnum
    $footerLocation: MenuLocationEnum
  ) {
    generalSettings {
      ...BlogInfoFragment
    }
    nonExistingField
...
```

Now try to build the example project. It should fail while printing the graphQL error message into the console:

```
error - GraphQL errors: [
  {
    message: 'Cannot query field "nonExistingField" on type "RootQuery".',
    extensions: { category: 'graphql' },
    locations: [ [Object] ]
  }
]

Error occurred prerendering page "/en". Read more: https://nextjs.org/docs/messages/prerender-error
ApolloError: Cannot query field "nonExistingField" on type "RootQuery".
```


## Screenshots

<!--
If this is a visual change include relevant screenshots about the behavior of the application before and after this change.
-->

## Documentation Changes

<!--
List corresponding changes to the documentation.
-->

## Dependant PRs

<!--
List any dependent PR's that are awaiting review. Use the following syntax:

- #1234
-->
