### PR TITLE
Toolbar should respect show avatars setting in wp

### DIFF
--- a/.changeset/smooth-dogs-cough.md
+++ b/.changeset/smooth-dogs-cough.md
@@ -2,4 +2,4 @@
 "@faustwp/core": patch
 ---
 
-Toolbar should respect show avatars setting in wp
+Faust Toolbar will now respect the Show Avatars setting in WordPress.

--- a/.changeset/smooth-dogs-cough.md
+++ b/.changeset/smooth-dogs-cough.md
@@ -2,4 +2,4 @@
 "@faustwp/core": patch
 ---
 
-Faust Toolbar will now respect the Show Avatars setting in WordPress.
+Faust Toolbar will now respect the Show Avatars setting in WordPress. Requires WPGraphQL version 1.22.1 or higher.

--- a/packages/faustwp-core/src/components/Toolbar/nodes/MyAccount.tsx
+++ b/packages/faustwp-core/src/components/Toolbar/nodes/MyAccount.tsx
@@ -58,26 +58,28 @@ export function AuthenticatedAccount() {
     <>
       <ToolbarItem aria-haspopup="true">
         Howdy, <span className="display-name">{data?.viewer?.name}</span>
-        <img
-          alt=""
-          src={data?.viewer?.avatar26.url}
-          srcSet={`${data?.viewer?.avatar52.url as string} 2x`}
-          className="avatar avatar-26 photo"
-          height="26"
-          width="26"
-          loading="lazy"
-          decoding="async"
-        />
+        {data?.viewer?.avatar64?.url ? (
+          <img
+            alt=""
+            src={data?.viewer?.avatar26?.url}
+            srcSet={`${data?.viewer?.avatar52?.url as string} 2x`}
+            className="avatar avatar-26 photo"
+            height="26"
+            width="26"
+            loading="lazy"
+            decoding="async"
+          />
+        ) : null}
       </ToolbarItem>
       <ToolbarSubmenuWrapper>
         <ToolbarSubmenu id="wp-admin-bar-user-actions">
           <li id="wp-admin-bar-user-info">
             <ToolbarItem tabIndex={-1} href={getAdminUrl('profile.php')}>
-              {data?.viewer?.avatar64.url ? (
+              {data?.viewer?.avatar64?.url ? (
                 <img
                   alt=""
-                  src={data?.viewer?.avatar64.url}
-                  srcSet={`${data?.viewer?.avatar128.url as string} 2x`}
+                  src={data?.viewer?.avatar64?.url}
+                  srcSet={`${data?.viewer?.avatar128?.url as string} 2x`}
                   className="avatar avatar-64 photo"
                   height="64"
                   width="64"

--- a/packages/faustwp-core/src/components/Toolbar/nodes/MyAccount.tsx
+++ b/packages/faustwp-core/src/components/Toolbar/nodes/MyAccount.tsx
@@ -73,16 +73,18 @@ export function AuthenticatedAccount() {
         <ToolbarSubmenu id="wp-admin-bar-user-actions">
           <li id="wp-admin-bar-user-info">
             <ToolbarItem tabIndex={-1} href={getAdminUrl('profile.php')}>
-              <img
-                alt=""
-                src={data?.viewer?.avatar64.url}
-                srcSet={`${data?.viewer?.avatar128.url as string} 2x`}
-                className="avatar avatar-64 photo"
-                height="64"
-                width="64"
-                loading="lazy"
-                decoding="async"
-              />
+              {data?.viewer?.avatar64.url ? (
+                <img
+                  alt=""
+                  src={data?.viewer?.avatar64.url}
+                  srcSet={`${data?.viewer?.avatar128.url as string} 2x`}
+                  className="avatar avatar-64 photo"
+                  height="64"
+                  width="64"
+                  loading="lazy"
+                  decoding="async"
+                />
+              ) : null}
               <span className="display-name">{data?.viewer?.name}</span>
               <span className="username">{data?.viewer?.username}</span>
             </ToolbarItem>

--- a/packages/faustwp-core/src/hooks/useAuth.tsx
+++ b/packages/faustwp-core/src/hooks/useAuth.tsx
@@ -40,7 +40,7 @@ type ViewerType = {
   url?: string;
   userId?: number;
   avatar?: {
-    url: string;
+    url?: string;
   };
 };
 
@@ -177,8 +177,6 @@ export function useAuth(_config?: UseAuthConfig) {
               url
               userId
               avatar {
-                forceDefault
-                isRestricted
                 url
               }
             }

--- a/packages/faustwp-core/src/hooks/useAuth.tsx
+++ b/packages/faustwp-core/src/hooks/useAuth.tsx
@@ -39,6 +39,9 @@ type ViewerType = {
   uri?: string;
   url?: string;
   userId?: number;
+  avatar?: {
+    url: string;
+  };
 };
 
 export type UseAuthConfig = RedirectStrategyConfig | LocalStrategyConfig;
@@ -173,6 +176,11 @@ export function useAuth(_config?: UseAuthConfig) {
               uri
               url
               userId
+              avatar {
+                forceDefault
+                isRestricted
+                url
+              }
             }
           }
         `,

--- a/packages/faustwp-core/tests/hooks/useAuth.test.ts
+++ b/packages/faustwp-core/tests/hooks/useAuth.test.ts
@@ -47,7 +47,7 @@ describe('useAuth hook', () => {
       status: 200,
       body: JSON.stringify({ accessToken: 'at', refreshToken: 'rt' }),
     });
-    fetchMock.get(`http://headless.local/index.php?graphql&query=query%20GetFaustViewer%20%7B%0A%20%20viewer%20%7B%0A%20%20%20%20name%0A%20%20%20%20username%0A%20%20%20%20capabilities%0A%20%20%20%20databaseId%0A%20%20%20%20description%0A%20%20%20%20email%0A%20%20%20%20firstName%0A%20%20%20%20id%0A%20%20%20%20lastName%0A%20%20%20%20nickname%0A%20%20%20%20locale%0A%20%20%20%20registeredDate%0A%20%20%20%20slug%0A%20%20%20%20templates%0A%20%20%20%20uri%0A%20%20%20%20url%0A%20%20%20%20userId%0A%20%20%20%20__typename%0A%20%20%7D%0A%7D&operationName=GetFaustViewer&variables=%7B%7D`, {
+    fetchMock.get(`http://headless.local/index.php?graphql&query=query%20GetFaustViewer%20%7B%0A%20%20viewer%20%7B%0A%20%20%20%20name%0A%20%20%20%20username%0A%20%20%20%20capabilities%0A%20%20%20%20databaseId%0A%20%20%20%20description%0A%20%20%20%20email%0A%20%20%20%20firstName%0A%20%20%20%20id%0A%20%20%20%20lastName%0A%20%20%20%20nickname%0A%20%20%20%20locale%0A%20%20%20%20registeredDate%0A%20%20%20%20slug%0A%20%20%20%20templates%0A%20%20%20%20uri%0A%20%20%20%20url%0A%20%20%20%20userId%0A%20%20%20%20avatar%20%7B%0A%20%20%20%20%20%20url%0A%20%20%20%20%20%20__typename%0A%20%20%20%20%7D%0A%20%20%20%20__typename%0A%20%20%7D%0A%7D&operationName=GetFaustViewer&variables=%7B%7D`, {
       status: 200,
       body: JSON.stringify({
         data: {

--- a/packages/faustwp-core/tests/hooks/useAuth.test.ts
+++ b/packages/faustwp-core/tests/hooks/useAuth.test.ts
@@ -126,7 +126,7 @@ describe('useAuth hook', () => {
         refreshToken: 'rt',
       }),
     });
-    fetchMock.get(`http://headless.local/index.php?graphql&query=query%20GetFaustViewer%20%7B%0A%20%20viewer%20%7B%0A%20%20%20%20name%0A%20%20%20%20username%0A%20%20%20%20capabilities%0A%20%20%20%20databaseId%0A%20%20%20%20description%0A%20%20%20%20email%0A%20%20%20%20firstName%0A%20%20%20%20id%0A%20%20%20%20lastName%0A%20%20%20%20nickname%0A%20%20%20%20locale%0A%20%20%20%20registeredDate%0A%20%20%20%20slug%0A%20%20%20%20templates%0A%20%20%20%20uri%0A%20%20%20%20url%0A%20%20%20%20userId%0A%20%20%20%20__typename%0A%20%20%7D%0A%7D&operationName=GetFaustViewer&variables=%7B%7D`, {
+    fetchMock.get(`http://headless.local/index.php?graphql&query=query%20GetFaustViewer%20%7B%0A%20%20viewer%20%7B%0A%20%20%20%20name%0A%20%20%20%20username%0A%20%20%20%20capabilities%0A%20%20%20%20databaseId%0A%20%20%20%20description%0A%20%20%20%20email%0A%20%20%20%20firstName%0A%20%20%20%20id%0A%20%20%20%20lastName%0A%20%20%20%20nickname%0A%20%20%20%20locale%0A%20%20%20%20registeredDate%0A%20%20%20%20slug%0A%20%20%20%20templates%0A%20%20%20%20uri%0A%20%20%20%20url%0A%20%20%20%20userId%0A%20%20%20%20avatar%20%7B%0A%20%20%20%20%20%20url%0A%20%20%20%20%20%20__typename%0A%20%20%20%20%7D%0A%20%20%20%20__typename%0A%20%20%7D%0A%7D&operationName=GetFaustViewer&variables=%7B%7D`, {
       status: 200,
       body: JSON.stringify({
         data: {


### PR DESCRIPTION
## Tasks

- [x] I have signed a [Contributor License Agreement (CLA)](https://github.com/wpengine/faustjs#contributor-license-agreement) with WP Engine.
- [x] If a code change, I have written testing instructions that the whole team & outside contributors can understand.
- [x] I have written and included a comprehensive [changeset](https://github.com/wpengine/faustjs/blob/canary/DEVELOPMENT.md#deployment) to properly document the changes I've made.

## Description

Currently when avatars are disabled in WP, the Faust Toolbar loads them anyway. It should respect the Avatar Display option in WP. This PR works with the most recent change to avatar settings in WPGraphQL to ensure the avatar renders conditionally in the Faust Toolbar.

## Related Issue(s):

#1817 

## Testing

**Note:** if WPGraphQL has not had a release containing [changes to the avatar setting](https://github.com/wp-graphql/wp-graphql/pull/3067) by the time you review this PR, then you will need to ensure your test site is using a symlinked WPGraphQL plugin that is set to the `develop` branch. If there has been a recent release containing this change, you can skip to the next set of testing instructions below.

### Set up your symlink to WPGraphQL plugin for testing this PR
1. Clone down the [WPGraphQL plugin](https://github.com/wp-graphql/wp-graphql).
2. In its repo, run `composer i` and then `composer build-plugin`
3. Note the location of its file, and the location of the file that contains all the plugins of your test site (`/app/public/wp-content/plugins`).
4. Symlink your file locations. You can do so by running ln -s \ {the location of your WPGraphQL plugin} {the location of plugin file of your test site}. For example,
```
ln -s \
 ~/Desktop/wp-graphql \
~/Local\ Sites/armadillo/app/public/wp-content/plugins
```

### After ensuring WPGraphQL plugin is set to `develop` in your symlinked plugin folder (or that [this change to avatar settings](https://github.com/wp-graphql/wp-graphql/pull/3067) is now in master):

1. Enable the WPGraphQL plugin in WP for your test site.
2. Disable avatars in WP under Settings > Discussion
![image](https://github.com/wpengine/faustjs/assets/1254870/f5fe1434-5abd-40be-8336-4d33cab50093)
3. Switch to this branch and run `npm install` and `npm run build` at the root of the monorepo
4. Ensure the Toolbar is enabled in Faust under the `custom-toolbar` example project (or any example project is fine):
<img width="480" alt="image" src="https://github.com/wpengine/faustjs/assets/50935135/02ac4d61-fc57-4149-9f8a-8f7add2bd9b3">

5. After you cd into the example project, run `npm run dev`
6. Load the Faust front end by going to `localhost:3000`. 
7. Look for the avatar at the top right of the window in the toolbar.
8. Ensure you do not see the avatar. 

## Screenshots

https://github.com/wpengine/faustjs/assets/50935135/0493e29a-8aef-41c0-8109-d6dfffb2425f
