### PR TITLE
Added multiple queries to interface for FaustTemplate

### DIFF
--- a/.changeset/quiet-avocados-turn.md
+++ b/.changeset/quiet-avocados-turn.md
@@ -2,4 +2,4 @@
 "@faustwp/core": patch
 ---
 
-Added multiple queries to interface for FaustTemplate
+Added `queries` property to FaustTemplate interface. Fixes an error when using multiple queries with TypeScript.

--- a/.changeset/quiet-avocados-turn.md
+++ b/.changeset/quiet-avocados-turn.md
@@ -1,0 +1,5 @@
+---
+"@faustwp/core": patch
+---
+
+Added multiple queries to interface for FaustTemplate

--- a/packages/faustwp-core/src/getWordPressProps.tsx
+++ b/packages/faustwp-core/src/getWordPressProps.tsx
@@ -52,6 +52,12 @@ export type WordPressTemplate = React.FC & {
 export interface FaustTemplate<Data>
   extends React.FC<FaustTemplateProps<Data>> {
   query?: WordPressTemplate['query'];
+  queries?: {
+    query: DocumentNode;
+    variables?: (...args: QueryVariablesArgs) => {
+      [key: string]: any;
+    };
+  }[];
   variables?: WordPressTemplate['variables'];
 }
 


### PR DESCRIPTION
## Tasks

- [x] I have signed a [Contributor License Agreement (CLA)](https://github.com/wpengine/faustjs#contributor-license-agreement) with WP Engine.
- [x] If a code change, I have written testing instructions that the whole team & outside contributors can understand.
- [x] I have written and included a comprehensive [changeset](https://github.com/wpengine/faustjs/blob/canary/DEVELOPMENT.md#deployment) to properly document the changes I've made.

## Description

Faust Templates do not recognize the 'Component.queries` portion when in TypeScript. This change will add multiple queries to the interface for FaustTemplate, which will resolve this issue.

## Related Issue(s):
#1825 

## Testing

### Testing in a preexisting TypeScript Faust app

If you already have a TypeScript Faust app, you can run test the package changes there (note: do not use the `faust-scaffold-ts`, as the React version discrepancy will throw an error). If you do not have a TypeScript Faust app, skip this section and head down to the next section to set up testing from within an example project in the Faust monorepo.

If you already have a TypeScript Faust app, you can run test the package changes there by doing the following:
1.  In this branch,`cd` into the `packages/faustwp-core`.
2.  Run `npm link`
3.  Head over to your test site's repo. from within this repo, run `npm link @faustwp/core`
4. Add a `page.tsx` in your wp-templates, and add the following:

```
// wp-templates/page.tsx

import { gql } from '@apollo/client';
import { FaustTemplate, useFaustQuery } from '@faustwp/core';

const Component: FaustTemplate<{}> = (props) => {
  const data = useFaustQuery(pageQuery);

  // const { title: siteTitle, description: siteDescription } =
  //   data?.generalSettings;
  // const primaryMenu = data?.headerMenuItems?.nodes ?? [];
  // const footerMenu = data?.footerMenuItems?.nodes ?? [];

  console.log(data);

  return (
    <>
      <p>Test</p>
      <p>TEST TEST</p>
    </>
  );
};

const pageQuery = gql`
  query {
    generalSettings {
      title
      description
    }
    headerMenuItems: menuItems(where: { location: PRIMARY }) {
      nodes {
        label
        path
      }
    }
    footerMenuItems: menuItems(where: { location: FOOTER }) {
      nodes {
        label
        path
      }
    }
  }
`;

Component.queries = [
  {
    query: pageQuery,
  },
];

export default Component;
```
5. Note that the `Component.queries` is typed.
6. Run `npm run dev` and go to the page in localhost.
7. Open devtools in the browser and note that queries are still being logged to the console.

### Testing from the `faustwp-getting-started` example project in Faust's monorepo

1. Head to this branch. in Faust's root, run `npm i` and `npm run build`. 
2. In Faust's `faustwp-getting-started` project, create an `env.local` file with your test WordPress site's proper url and secret key.
3. `cd` into the `examples/next/faustwp-getting-started` example project and run `npm run dev`
4. Now you'll need to make two files into `tsx` files in the example project to ensure you see the typing you're testing. Rename `pages/index.js` to `pages/index.tsx`. This will trigger the project to run as TypeScript. Then rename `wp-templates/front-page.js` to `wp-templates/front-page.tsx`
5. In wp-templates/front-page.tsx, empty the file and replace it with:
```
// wp-templates/front-page.tsx

import { gql } from '@apollo/client';
import { FaustTemplate, useFaustQuery } from '@faustwp/core';

const Component: FaustTemplate<{}> = (props) => {
  const data = useFaustQuery(pageQuery);

  // const { title: siteTitle, description: siteDescription } =
  //   data?.generalSettings;
  // const primaryMenu = data?.headerMenuItems?.nodes ?? [];
  // const footerMenu = data?.footerMenuItems?.nodes ?? [];

  console.log(data);

  return (
    <>
      <p>Test</p>
      <p>TEST TEST</p>
    </>
  );
};

const pageQuery = gql`
  query {
    generalSettings {
      title
      description
    }
    headerMenuItems: menuItems(where: { location: PRIMARY }) {
      nodes {
        label
        path
      }
    }
    footerMenuItems: menuItems(where: { location: FOOTER }) {
      nodes {
        label
        path
      }
    }
  }
`;

Component.queries = [
  {
    query: pageQuery,
  },
];

export default Component;
```
6. Note that the `Component.queries` is typed.
7. Run `npm run dev` and go to the page in localhost.
8. Open devtools in the browser and note that queries are still being logged to the console.

## Screenshots

Below is a video of the second testing technique (converting the `faustwp-getting-started` example project to TypeScript):


https://github.com/wpengine/faustjs/assets/50935135/1e8e4835-bb8b-48bb-9d9a-77471220c161
