### PR TITLE
Changed 'tested up to' in readme.txt to 6.5

### DIFF
--- a/plugins/faustwp/readme.txt
+++ b/plugins/faustwp/readme.txt
@@ -2,7 +2,7 @@
 Contributors: antpb, apmatthe, blakewpe, chriswiegman, claygriffiths, jasonkonen, joefusco, markkelnar, matthewguywright, mindctrl, modernnerd, rfmeier, TeresaGobble, thdespou, wpengine
 Tags: faustjs, faust, headless, decoupled, composable-architecture
 Requires at least: 5.7
-Tested up to: 6.4
+Tested up to: 6.5
 Stable tag: 1.2.2
 Requires PHP: 7.2
 License: GPLv2 or later


### PR DESCRIPTION
## Tasks

- [x] I have signed a [Contributor License Agreement (CLA)](https://github.com/wpengine/faustjs#contributor-license-agreement) with WP Engine.
- [x] If a code change, I have written testing instructions that the whole team & outside contributors can understand.
- [x] I have written and included a comprehensive [changeset](https://github.com/wpengine/faustjs/blob/canary/DEVELOPMENT.md#deployment) to properly document the changes I've made.

## Description

<!--
Include a summary of the change and some contextual information.
-->

## Related Issue(s):

[Internal logistics tracking](https://github.com/orgs/wpengine/projects/13/views/1?pane=issue&itemId=56809132) 

## Testing

I tested our wp-graphql-content-blocks plugin with the [WordPress Beta Tester](https://wordpress.org/extend/plugins/wordpress-beta-tester/) plugin. After uploading this testing plugin, I changed the settings of the plugin to the following to enable v6.5 testing: 

<img width="1159" alt="image" src="https://github.com/wpengine/wp-graphql-content-blocks/assets/50935135/30347501-13c9-4f4d-9747-367079bd3e2c">
I then updated WordPress to version 6.5-RC3:

<img width="683" alt="image" src="https://github.com/wpengine/faustjs/assets/50935135/847f2639-d669-4a45-b7ff-1a4d4d5d3868">

I then made a post with various media types, including gallery blocks, and ensured they are still appearing as expected (see screenshots section for a quick video). Note: during testing, be sure to set the media urls to the below in Faust: 

<img width="656" alt="image" src="https://github.com/wpengine/faustjs/assets/50935135/b5083809-8668-4eb0-bbc6-e3c55d9c5aad">

There does not appear to be any breaking changes upon the update.

## Screenshots


https://github.com/wpengine/faustjs/assets/50935135/c92068ec-b5e2-4673-817e-d83055d01f15