### PR TITLE
Load plugin textdomain

### DIFF
--- a/.changeset/nine-timers-eat.md
+++ b/.changeset/nine-timers-eat.md
@@ -1,0 +1,5 @@
+---
+'@faustwp/wordpress-plugin': patch
+---
+
+Ensure's any related translations will properly load by calling `load_text_domain`

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ process.yml
 build/
 examples/next/getting-started/package-lock.json
 faustjs.code-workspace
+
+# Ignore the WordPress source where used by various development environments
+wordpress/

--- a/plugins/faustwp/includes/utilities/callbacks.php
+++ b/plugins/faustwp/includes/utilities/callbacks.php
@@ -92,3 +92,15 @@ function handle_new_site_creation( $new_site ) {
 	maybe_set_default_settings();
 	restore_current_blog();
 }
+
+add_action( 'init', __NAMESPACE__ . '\\load_faustwp_textdomain' );
+/**
+ * Load the plugin text domain for translation.
+ *
+ * @link https://developer.wordpress.org/reference/hooks/init/
+ *
+ * @return void
+ */
+function load_faustwp_textdomain() {
+	load_plugin_textdomain( 'faustwp', false, FAUSTWP_DIR . '/languages' );
+}


### PR DESCRIPTION
## Tasks

- [x] I have signed a [Contributor License Agreement (CLA)](https://github.com/wpengine/faustjs#contributor-license-agreement) with WP Engine.
- [x] If a code change, I have written testing instructions that the whole team & outside contributors can understand.
- [x] I have written and included a comprehensive [changeset](https://github.com/wpengine/faustjs/blob/canary/DEVELOPMENT.md#deployment) to properly document the changes I've made.

## Description

Loads the plugin's text domain to allow for proper loading of translations.

Also adds the wordpress source dir to .gitignore for development environments that use it.

## Related Issue(s):

#1711
