### PR TITLE
feat: Set `enable_image_source` to on by default

### DIFF
--- a/.changeset/red-dots-juggle.md
+++ b/.changeset/red-dots-juggle.md
@@ -1,0 +1,5 @@
+---
+'@faustwp/wordpress-plugin': minor
+---
+
+The default settings for `enable_image_source` has been changed to "on" for new installs.

--- a/plugins/faustwp/includes/settings/functions.php
+++ b/plugins/faustwp/includes/settings/functions.php
@@ -159,6 +159,7 @@ function maybe_set_default_settings() {
 		faustwp_update_setting( 'disable_theme', '0' );
 		faustwp_update_setting( 'enable_rewrites', '1' );
 		faustwp_update_setting( 'enable_redirects', '1' );
+		faustwp_update_setting( 'enable_image_source', '1' );
 
 		// Force WP to regenerate rewrite rules without calling flush_rewrite_rules which breaks
 		// things when used inside of `switch_to_blog()`.
@@ -191,4 +192,3 @@ function get_icon( $icon ) {
 
 	return '';
 }
-

--- a/plugins/faustwp/tests/acceptance/SettingsCest.php
+++ b/plugins/faustwp/tests/acceptance/SettingsCest.php
@@ -37,7 +37,7 @@ class SettingsCest
         $I->dontSeeCheckboxIsChecked('#disable_theme');
         $I->seeCheckboxIsChecked('#enable_rewrites');
         $I->seeCheckboxIsChecked('#enable_redirects');
-        $I->dontSeeCheckboxIsChecked('#enable_image_source');
+        $I->seeCheckboxIsChecked('#enable_image_source');
     }
 
     /**


### PR DESCRIPTION
## Tasks

- [x] I have signed a [Contributor License Agreement (CLA)](https://github.com/wpengine/faustjs#contributor-license-agreement) with WP Engine.
- [x] If a code change, I have written testing instructions that the whole team & outside contributors can understand.
- [x] I have written and included a comprehensive [changeset](https://github.com/wpengine/faustjs/blob/canary/DEVELOPMENT.md#deployment) to properly document the changes I've made.

## Description

Sets the default for `enable_image_source` to true without affecting existing settings.

## Related Issue(s):

#1849 

## Testing

As this is a toggle of a default, no further testing has been added

## Screenshots

N/A

## Documentation Changes

N/A

## Dependant PRs

N/A
