### PR TITLE
Update plugin unit testing with more WordPress versions and Nightly WordPress builds

### DIFF
--- a/.github/workflows/e2e-next-example.yml
+++ b/.github/workflows/e2e-next-example.yml
@@ -1,4 +1,4 @@
-name: E2E Test
+name: E2E Test Packages (Legacy)
 
 on:
   pull_request:

--- a/.github/workflows/e2e-next-faustwp-example.yml
+++ b/.github/workflows/e2e-next-faustwp-example.yml
@@ -1,4 +1,4 @@
-name: E2E Test
+name: E2E Test Packages
 
 on:
   pull_request:
@@ -6,7 +6,7 @@ on:
       - '**/*.md'
 
 jobs:
-  e2e-test-next-getting-started-example:
+  e2e-test-faustwp-getting-started-example:
     name: (faustwp) Next Getting Started Example on Node ${{ matrix.node }}
     runs-on: ubuntu-22.04
     env:

--- a/.github/workflows/e2e-nightly-build.yml
+++ b/.github/workflows/e2e-nightly-build.yml
@@ -1,4 +1,4 @@
-name: E2E Nightly Test
+name: E2E Test Packages (Nightly)
 
 on:
   workflow_run:

--- a/.github/workflows/e2e-test-plugin.yml
+++ b/.github/workflows/e2e-test-plugin.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   e2e_test_plugin:
+    name: WordPress ${{ matrix.wordpress }}
     timeout-minutes: 10
     runs-on: ubuntu-22.04
     strategy:

--- a/.github/workflows/e2e-test-plugin.yml
+++ b/.github/workflows/e2e-test-plugin.yml
@@ -7,81 +7,59 @@ on:
 
 jobs:
   e2e_test_plugin:
-    name: WordPress ${{ matrix.wordpress }}
     timeout-minutes: 10
     runs-on: ubuntu-22.04
-    strategy:
-      fail-fast: false
-      matrix:
-        wordpress: [ '6.1', '6.2', '6.3', '6.4', '6.5' ]
-
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
           node-version: '18'
-
       - name: Install NPM Deps
         run: |
           npm ci
           npm run build
-
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.1'
+          coverage: pcov
+          ini-values: pcov.directory=includes
       - name: Setup Frontend
         run: |
           NEXT_PUBLIC_WORDPRESS_URL=http://localhost:8080 FAUSTWP_SECRET_KEY=00000000-0000-4000-8000-000000000001 npm run dev:next:getting-started &
-
+      - name: Composer install
+        working-directory: plugins/faustwp
+        run: composer install --prefer-dist --no-progress --no-interaction --no-suggest
       - name: Setup Containers
         working-directory: plugins/faustwp
-        env:
-          WP_VERSION: ${{ matrix.wordpress }}
-        run: |
-          docker-compose build \
-            --build-arg WP_VERSION=${{ matrix.wordpress }}
-          docker-compose up -d
-
-      - name: Wait for db
-        run: |
-          while ! mysqladmin ping --host=127.0.0.1 --port=33066 --password=$MYSQL_ROOT_PASSWORD --silent; do
-            sleep 1
-          done
-
+        run: docker-compose up -d
+      - name: Sleep 15 seconds
+        run: sleep 15
       - name: Maybe upgrade WP DB
-        working-directory: ./plugins/faustwp
-        run: docker exec -e COVERAGE=1 -w /var/www/html/wp-content/plugins/faustwp $(docker-compose ps -q wordpress) wp core update-db --allow-root
-
+        working-directory: plugins/faustwp
+        run: docker exec --workdir=/var/www/html/wp-content/plugins/faustwp $(docker-compose ps -q wordpress) wp core update-db --allow-root
       - name: Init Testing Environment
-        working-directory: ./plugins/faustwp
+        working-directory: plugins/faustwp
         run: docker exec --workdir=/var/www/html/wp-content/plugins/faustwp $(docker-compose ps -q wordpress) init-testing-environment.sh
-
       - name: Install WP GraphQL
-        working-directory: ./plugins/faustwp
+        working-directory: plugins/faustwp
         run: |
           docker exec --workdir=/var/www/html/wp-content/plugins/faustwp $(docker-compose ps -q wordpress) wp plugin install wp-graphql --activate --allow-root
-
-      - name: Install Dependencies
-        working-directory: ./plugins/faustwp
-        run: docker exec -e COVERAGE=1 -w /var/www/html/wp-content/plugins/faustwp $(docker-compose ps -q wordpress) composer install
-
       - name: Setup testing data
-        working-directory: ./plugins/faustwp
+        working-directory: plugins/faustwp
         run: |
           docker exec --workdir=/var/www/html/wp-content/plugins/faustwp $(docker-compose ps -q wordpress) wp db export tests/_data/dump.sql --allow-root
-
       - name: Copy env file
-        working-directory: ./plugins/faustwp
+        working-directory: plugins/faustwp
         run: cp .env.testing.example .env.testing
-
       - name: Run Acceptance tests
-        working-directory: ./plugins/faustwp
+        working-directory: plugins/faustwp
         run: vendor/bin/codecept run acceptance
-
       - name: Run API tests
-        working-directory: ./plugins/faustwp
+        working-directory: plugins/faustwp
         run: vendor/bin/codecept run api
-
       - name: Upload Test Output
         uses: actions/upload-artifact@v4
         if: failure()

--- a/.github/workflows/e2e-test-plugin.yml
+++ b/.github/workflows/e2e-test-plugin.yml
@@ -87,4 +87,4 @@ jobs:
         if: failure()
         with:
           name: failed-test-output
-          path: ${{ github.workspace }}/plugins/faustwp/tests/_output/${{ matrix.wordpress }}
+          path: ${{ github.workspace }}/plugins/faustwp/tests/_output

--- a/.github/workflows/e2e-test-plugin.yml
+++ b/.github/workflows/e2e-test-plugin.yml
@@ -28,20 +28,9 @@ jobs:
           npm ci
           npm run build
 
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: '8.1'
-          coverage: pcov
-          ini-values: pcov.directory=includes
-
       - name: Setup Frontend
         run: |
           NEXT_PUBLIC_WORDPRESS_URL=http://localhost:8080 FAUSTWP_SECRET_KEY=00000000-0000-4000-8000-000000000001 npm run dev:next:getting-started &
-
-      - name: Composer install
-        working-directory: plugins/faustwp
-        run: composer install --prefer-dist --no-progress --no-interaction --no-suggest
 
       - name: Setup Containers
         working-directory: plugins/faustwp
@@ -58,34 +47,34 @@ jobs:
             sleep 1
           done
 
-      - name: Maybe upgrade WP DB
-        working-directory: plugins/faustwp
-        run: docker exec --workdir=/var/www/html/wp-content/plugins/faustwp $(docker-compose ps -q wordpress) wp core update-db --allow-root
-
       - name: Init Testing Environment
-        working-directory: plugins/faustwp
+        working-directory: ./plugins/faustwp
         run: docker exec --workdir=/var/www/html/wp-content/plugins/faustwp $(docker-compose ps -q wordpress) init-testing-environment.sh
 
       - name: Install WP GraphQL
-        working-directory: plugins/faustwp
+        working-directory: ./plugins/faustwp
         run: |
           docker exec --workdir=/var/www/html/wp-content/plugins/faustwp $(docker-compose ps -q wordpress) wp plugin install wp-graphql --activate --allow-root
 
+      - name: Install Dependencies
+        working-directory: ./plugins/faustwp
+        run: docker exec -e COVERAGE=1 -w /var/www/html/wp-content/plugins/faustwp $(docker-compose ps -q wordpress) composer install
+
       - name: Setup testing data
-        working-directory: plugins/faustwp
+        working-directory: ./plugins/faustwp
         run: |
           docker exec --workdir=/var/www/html/wp-content/plugins/faustwp $(docker-compose ps -q wordpress) wp db export tests/_data/dump.sql --allow-root
 
       - name: Copy env file
-        working-directory: plugins/faustwp
+        working-directory: ./plugins/faustwp
         run: cp .env.testing.example .env.testing
 
       - name: Run Acceptance tests
-        working-directory: plugins/faustwp
+        working-directory: ./plugins/faustwp
         run: vendor/bin/codecept run acceptance
 
       - name: Run API tests
-        working-directory: plugins/faustwp
+        working-directory: ./plugins/faustwp
         run: vendor/bin/codecept run api
 
       - name: Upload Test Output

--- a/.github/workflows/e2e-test-plugin.yml
+++ b/.github/workflows/e2e-test-plugin.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        wordpress: [ '6.5', '6.4', '6.3', '6.2', '6.1' ]
+        wordpress: [ '6.1', '6.2', '6.3', '6.4', '6.5' ]
 
     steps:
       - name: Checkout

--- a/.github/workflows/e2e-test-plugin.yml
+++ b/.github/workflows/e2e-test-plugin.yml
@@ -48,6 +48,10 @@ jobs:
             sleep 1
           done
 
+      - name: Maybe upgrade WP DB
+        working-directory: ./plugins/faustwp
+        run: docker exec -e COVERAGE=1 -w /var/www/html/wp-content/plugins/faustwp $(docker-compose ps -q wordpress) wp core update-db --allow-root
+
       - name: Init Testing Environment
         working-directory: ./plugins/faustwp
         run: docker exec --workdir=/var/www/html/wp-content/plugins/faustwp $(docker-compose ps -q wordpress) init-testing-environment.sh

--- a/.github/workflows/e2e-test-plugin.yml
+++ b/.github/workflows/e2e-test-plugin.yml
@@ -87,4 +87,4 @@ jobs:
         if: failure()
         with:
           name: failed-test-output
-          path: ${{ github.workspace }}/plugins/faustwp/tests/_output
+          path: ${{ github.workspace }}/plugins/faustwp/tests/_output/${{ matrix.wordpress }}

--- a/.github/workflows/e2e-test-plugin.yml
+++ b/.github/workflows/e2e-test-plugin.yml
@@ -30,7 +30,7 @@ jobs:
         working-directory: plugins/faustwp
         run: |
           docker-compose build \
-            --build-arg WP_VERSION=6.5
+            --build-arg WP_VERSION=6.4
           docker-compose up -d
       - name: Sleep 15 seconds
         run: sleep 15

--- a/.github/workflows/e2e-test-plugin.yml
+++ b/.github/workflows/e2e-test-plugin.yml
@@ -1,4 +1,4 @@
-name: E2E Test Plugin
+name: E2E Test Plugin (Legacy)
 
 on:
   pull_request:
@@ -6,7 +6,7 @@ on:
       - '**/*.md'
 
 jobs:
-  e2e_test_plugin:
+  e2e_test_plugin_legacy:
     timeout-minutes: 10
     runs-on: ubuntu-22.04
     steps:

--- a/.github/workflows/e2e-test-plugin.yml
+++ b/.github/workflows/e2e-test-plugin.yml
@@ -9,57 +9,84 @@ jobs:
   e2e_test_plugin:
     timeout-minutes: 10
     runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        wordpress: [ '6.5', '6.4', '6.3', '6.2', '6.1' ]
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
           node-version: '18'
+
       - name: Install NPM Deps
         run: |
           npm ci
           npm run build
+
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
           php-version: '8.1'
           coverage: pcov
           ini-values: pcov.directory=includes
+
       - name: Setup Frontend
         run: |
           NEXT_PUBLIC_WORDPRESS_URL=http://localhost:8080 FAUSTWP_SECRET_KEY=00000000-0000-4000-8000-000000000001 npm run dev:next:getting-started &
+
       - name: Composer install
         working-directory: plugins/faustwp
         run: composer install --prefer-dist --no-progress --no-interaction --no-suggest
+
       - name: Setup Containers
         working-directory: plugins/faustwp
-        run: docker-compose up -d
-      - name: Sleep 15 seconds
-        run: sleep 15
+        env:
+          WP_VERSION: ${{ matrix.wordpress }}
+        run: |
+          docker-compose build \
+            --build-arg WP_VERSION=${{ matrix.wordpress }}
+          docker-compose up -d
+
+      - name: Wait for db
+        run: |
+          while ! mysqladmin ping --host=127.0.0.1 --port=33066 --password=$MYSQL_ROOT_PASSWORD --silent; do
+            sleep 1
+          done
+
       - name: Maybe upgrade WP DB
         working-directory: plugins/faustwp
         run: docker exec --workdir=/var/www/html/wp-content/plugins/faustwp $(docker-compose ps -q wordpress) wp core update-db --allow-root
+
       - name: Init Testing Environment
         working-directory: plugins/faustwp
         run: docker exec --workdir=/var/www/html/wp-content/plugins/faustwp $(docker-compose ps -q wordpress) init-testing-environment.sh
+
       - name: Install WP GraphQL
         working-directory: plugins/faustwp
         run: |
           docker exec --workdir=/var/www/html/wp-content/plugins/faustwp $(docker-compose ps -q wordpress) wp plugin install wp-graphql --activate --allow-root
+
       - name: Setup testing data
         working-directory: plugins/faustwp
         run: |
           docker exec --workdir=/var/www/html/wp-content/plugins/faustwp $(docker-compose ps -q wordpress) wp db export tests/_data/dump.sql --allow-root
+
       - name: Copy env file
         working-directory: plugins/faustwp
         run: cp .env.testing.example .env.testing
+
       - name: Run Acceptance tests
         working-directory: plugins/faustwp
         run: vendor/bin/codecept run acceptance
+
       - name: Run API tests
         working-directory: plugins/faustwp
         run: vendor/bin/codecept run api
+
       - name: Upload Test Output
         uses: actions/upload-artifact@v4
         if: failure()

--- a/.github/workflows/e2e-test-plugin.yml
+++ b/.github/workflows/e2e-test-plugin.yml
@@ -11,6 +11,7 @@ jobs:
     timeout-minutes: 10
     runs-on: ubuntu-22.04
     strategy:
+      fail-fast: false
       matrix:
         wordpress: [ '6.1', '6.2', '6.3', '6.4', '6.5' ]
 

--- a/.github/workflows/e2e-test-plugin.yml
+++ b/.github/workflows/e2e-test-plugin.yml
@@ -28,9 +28,10 @@ jobs:
         run: composer install --prefer-dist --no-progress --no-interaction --no-suggest
       - name: Setup Containers
         working-directory: plugins/faustwp
-        env:
-          WP_VERSION: '6.5'
-        run: docker-compose up -d
+        run: |
+          docker-compose build \
+            --build-arg WP_VERSION=6.5
+          docker-compose up -d
       - name: Sleep 15 seconds
         run: sleep 15
       - name: Maybe upgrade WP DB

--- a/.github/workflows/e2e-test-plugin.yml
+++ b/.github/workflows/e2e-test-plugin.yml
@@ -20,12 +20,6 @@ jobs:
         run: |
           npm ci
           npm run build
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: '8.1'
-          coverage: pcov
-          ini-values: pcov.directory=includes
       - name: Setup Frontend
         run: |
           NEXT_PUBLIC_WORDPRESS_URL=http://localhost:8080 FAUSTWP_SECRET_KEY=00000000-0000-4000-8000-000000000001 npm run dev:next:getting-started &
@@ -34,6 +28,8 @@ jobs:
         run: composer install --prefer-dist --no-progress --no-interaction --no-suggest
       - name: Setup Containers
         working-directory: plugins/faustwp
+        env:
+          WP_VERSION: '6.5'
         run: docker-compose up -d
       - name: Sleep 15 seconds
         run: sleep 15

--- a/.github/workflows/test-plugin-nightly.yml
+++ b/.github/workflows/test-plugin-nightly.yml
@@ -1,4 +1,4 @@
-name: Test Plugin / WordPress Nightly, PHP 8.2
+name: Test Plugin / WordPress Nightly
 
 on:
   pull_request:

--- a/.github/workflows/test-plugin-nightly.yml
+++ b/.github/workflows/test-plugin-nightly.yml
@@ -1,0 +1,50 @@
+name: Test Plugin / WordPress Nightly, PHP 8.2
+
+on:
+  pull_request:
+    paths-ignore:
+      - '**/*.md'
+
+jobs:
+  test_plugin:
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Create Docker Containers
+        working-directory: ./plugins/faustwp
+        run: |
+          docker-compose build \
+            --build-arg WP_VERSION=6.5
+          docker-compose up -d
+
+      - name: Wait for db
+        run: |
+          while ! mysqladmin ping --host=127.0.0.1 --port=33066 --password=$MYSQL_ROOT_PASSWORD --silent; do
+            sleep 1
+          done
+
+      - name: Setup testing framework
+        working-directory: ./plugins/faustwp
+        run: docker exec -e COVERAGE=1 $(docker-compose ps -q wordpress) init-testing-environment.sh
+
+      - name: Ensure Correct WordPress version
+        working-directory: ./plugins/faustwp
+        run: |
+            docker exec -w /var/www/html/wp-content/plugins/faustwp $(docker-compose ps -q wordpress) wp core version --allow-root
+            docker exec -w /var/www/html/wp-content/plugins/faustwp $(docker-compose ps -q wordpress) wp core upgrade --version=nightly --force --allow-root
+            docker exec -w /var/www/html/wp-content/plugins/faustwp $(docker-compose ps -q wordpress) wp core version --allow-root
+
+      - name: Install and activate WP GraphQL
+        working-directory: ./plugins/faustwp
+        run: docker exec -e COVERAGE=1 -w /var/www/html/wp-content/plugins/faustwp $(docker-compose ps -q wordpress) wp plugin install wp-graphql --activate --allow-root
+
+      - name: Install Dependencies
+        working-directory: ./plugins/faustwp
+        run: docker exec -e COVERAGE=1 -w /var/www/html/wp-content/plugins/faustwp $(docker-compose ps -q wordpress) composer install
+
+      - name: Run unit tests
+        working-directory: ./plugins/faustwp
+        run: docker exec -e COVERAGE=1 -w /var/www/html/wp-content/plugins/faustwp $(docker-compose ps -q wordpress) composer test

--- a/.github/workflows/test-plugin.yml
+++ b/.github/workflows/test-plugin.yml
@@ -7,36 +7,22 @@ on:
 
 jobs:
   test_plugin:
-    name: WordPress ${{ matrix.wordpress }}, PHP ${{ matrix.php }}
+    name: WordPress ${{ matrix.wordpress }}
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        php: [ '8.2', '7.4' ]
         wordpress: [ '6.5', '6.4', '6.3', '6.2', '6.1' ]
-        exclude:
-        - php: 8.2
-          wordpress: 6.1
-        - php: 7.4
-          wordpress: 6.2
-        - php: 7.4
-          wordpress: 6.3
-        - php: 7.4
-          wordpress: 6.4
-        - php: 7.4
-          wordpress: 6.5
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
       - name: Create Docker Containers
         env:
-          PHP_VERSION: ${{ matrix.php }}
           WP_VERSION: ${{ matrix.wordpress }}
         working-directory: ./plugins/faustwp
         run: |
           docker-compose build \
             --build-arg WP_VERSION=${{ matrix.wordpress }} \
-            --build-arg PHP_VERSION=${{ matrix.php }}
           docker-compose up -d
 
       - name: Wait for db

--- a/.github/workflows/test-plugin.yml
+++ b/.github/workflows/test-plugin.yml
@@ -51,7 +51,7 @@ jobs:
 
       - name: Install and activate WP GraphQL
         working-directory: ./plugins/faustwp
-        run: docker exec --workdir=/var/www/html/wp-content/pluginsfaustwp $(docker-compose ps -q wordpress) wp plugin install wp-graphql --activate --allow-root
+        run: docker exec -e COVERAGE=1 -w /var/www/html/wp-content/plugins/faustwp $(docker-compose ps -q wordpress) wp plugin install wp-graphql --activate --allow-root
 
       - name: Install Dependencies
         working-directory: ./plugins/faustwp

--- a/.github/workflows/test-plugin.yml
+++ b/.github/workflows/test-plugin.yml
@@ -51,7 +51,7 @@ jobs:
 
       - name: Install and activate WP GraphQL
         working-directory: ./plugins/faustwp
-        run: docker exec --workdir=/var/www/html/wp-content/plugins/wp-graphql-content-blocks $(docker-compose ps -q wordpress) wp plugin install wp-graphql --activate --allow-root
+        run: docker exec --workdir=/var/www/html/wp-content/pluginsfaustwp $(docker-compose ps -q wordpress) wp plugin install wp-graphql --activate --allow-root
 
       - name: Install Dependencies
         working-directory: ./plugins/faustwp

--- a/.github/workflows/test-plugin.yml
+++ b/.github/workflows/test-plugin.yml
@@ -31,10 +31,6 @@ jobs:
             sleep 1
           done
 
-      - name: Maybe upgrade WP DB
-        working-directory: ./plugins/faustwp
-        run: docker exec -e COVERAGE=1 -w /var/www/html/wp-content/plugins/faustwp $(docker-compose ps -q wordpress) wp core update-db --allow-root
-
       - name: Setup testing framework
         working-directory: ./plugins/faustwp
         run: docker exec -e COVERAGE=1 $(docker-compose ps -q wordpress) init-testing-environment.sh

--- a/.github/workflows/test-plugin.yml
+++ b/.github/workflows/test-plugin.yml
@@ -31,6 +31,10 @@ jobs:
             sleep 1
           done
 
+      - name: Maybe upgrade WP DB
+        working-directory: ./plugins/faustwp
+        run: docker exec -e COVERAGE=1 -w /var/www/html/wp-content/plugins/faustwp $(docker-compose ps -q wordpress) wp core update-db --allow-root
+
       - name: Setup testing framework
         working-directory: ./plugins/faustwp
         run: docker exec -e COVERAGE=1 $(docker-compose ps -q wordpress) init-testing-environment.sh

--- a/.github/workflows/test-plugin.yml
+++ b/.github/workflows/test-plugin.yml
@@ -7,28 +7,56 @@ on:
 
 jobs:
   test_plugin:
-    name: WordPress ${{ matrix.wordpress }}
+    name: WordPress ${{ matrix.wordpress }}, PHP ${{ matrix.php }}
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        wordpress: ['6.3', '6.4', '6.5']
+        php: [ '8.2', '7.4' ]
+        wordpress: [ '6.5', '6.4', '6.3', '6.2', '6.1' ]
+        exclude:
+        - php: 8.2
+          wordpress: 6.1
+        - php: 7.4
+          wordpress: 6.2
+        - php: 7.4
+          wordpress: 6.3
+        - php: 7.4
+          wordpress: 6.4
+        - php: 7.4
+          wordpress: 6.5
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
       - name: Create Docker Containers
+        env:
+          PHP_VERSION: ${{ matrix.php }}
+          WP_VERSION: ${{ matrix.wordpress }}
         working-directory: ./plugins/faustwp
-        run: docker-compose up -d
-      - name: Sleep 15 seconds
-        run: sleep 15
+        run: |
+          docker-compose build \
+            --build-arg WP_VERSION=${{ matrix.wordpress }} \
+            --build-arg PHP_VERSION=${{ matrix.php }}
+          docker-compose up -d
+
+      - name: Wait for db
+        run: |
+          while ! mysqladmin ping --host=127.0.0.1 --port=33066 --password=$MYSQL_ROOT_PASSWORD --silent; do
+            sleep 1
+          done
+
       - name: Setup testing framework
         working-directory: ./plugins/faustwp
-        run: docker exec -e COVERAGE=1 -e WP_VERSION=${{ matrix.wordpress}} $(docker-compose ps -q wordpress) init-testing-environment.sh
+        run: docker exec -e COVERAGE=1 $(docker-compose ps -q wordpress) init-testing-environment.sh
+
       - name: Install and activate WP GraphQL
         working-directory: ./plugins/faustwp
-        run: docker exec --workdir=/var/www/html/wp-content/plugins/faustwp $(docker-compose ps -q wordpress) wp plugin install wp-graphql --activate --allow-root
+        run: docker exec --workdir=/var/www/html/wp-content/plugins/wp-graphql-content-blocks $(docker-compose ps -q wordpress) wp plugin install wp-graphql --activate --allow-root
+
       - name: Install Dependencies
         working-directory: ./plugins/faustwp
-        run: docker exec -e COVERAGE=1 -e WP_VERSION=${{ matrix.wordpress}} -w /var/www/html/wp-content/plugins/faustwp $(docker-compose ps -q wordpress) composer install
+        run: docker exec -e COVERAGE=1 -w /var/www/html/wp-content/plugins/faustwp $(docker-compose ps -q wordpress) composer install
+
       - name: Run unit tests
         working-directory: ./plugins/faustwp
-        run: docker exec -e COVERAGE=1 -e WP_VERSION=${{ matrix.wordpress}} -w /var/www/html/wp-content/plugins/faustwp $(docker-compose ps -q wordpress) composer test
+        run: docker exec -e COVERAGE=1 -w /var/www/html/wp-content/plugins/faustwp $(docker-compose ps -q wordpress) composer test

--- a/.github/workflows/test-plugin.yml
+++ b/.github/workflows/test-plugin.yml
@@ -22,7 +22,7 @@ jobs:
         working-directory: ./plugins/faustwp
         run: |
           docker-compose build \
-            --build-arg WP_VERSION=${{ matrix.wordpress }} \
+            --build-arg WP_VERSION=${{ matrix.wordpress }}
           docker-compose up -d
 
       - name: Wait for db

--- a/.github/workflows/unit-test-packages.yml
+++ b/.github/workflows/unit-test-packages.yml
@@ -6,7 +6,7 @@ on:
       - '**/*.md'
 
 jobs:
-  test_packages:
+  unit-test_packages:
     name: "Test packages on Node.js ${{ matrix.node }} ${{ matrix.os }}"
     strategy:
       matrix:

--- a/.github/workflows/unit-test-plugin-nightly.yml
+++ b/.github/workflows/unit-test-plugin-nightly.yml
@@ -1,4 +1,4 @@
-name: Test Plugin / WordPress Nightly
+name: Unit Test Plugin / WordPress Nightly
 
 on:
   pull_request:
@@ -6,7 +6,7 @@ on:
       - '**/*.md'
 
 jobs:
-  test_plugin:
+  unit_test_plugin:
     runs-on: ubuntu-22.04
 
     steps:

--- a/.github/workflows/unit-test-plugin.yml
+++ b/.github/workflows/unit-test-plugin.yml
@@ -1,4 +1,4 @@
-name: Test Plugin
+name: Unit Test Plugin
 
 on:
   pull_request:
@@ -6,7 +6,7 @@ on:
       - '**/*.md'
 
 jobs:
-  test_plugin:
+  unit_test_plugin:
     name: WordPress ${{ matrix.wordpress }}
     runs-on: ubuntu-22.04
     strategy:

--- a/plugins/faustwp/.docker/Dockerfile
+++ b/plugins/faustwp/.docker/Dockerfile
@@ -1,12 +1,11 @@
-ARG WP_VERSION=6.4
-
-FROM wordpress:${WP_VERSION}
-
-# Needed to specify the build args again after the FROM command.
 ARG WP_VERSION
+ARG PHP_VERSION
+
+FROM wordpress:${WP_VERSION}-php${PHP_VERSION}
 
 # Save the build args for use by the runtime environment
 ENV WP_VERSION=${WP_VERSION}
+ENV PHP_VERSION=${PHP_VERSION}
 
 # Needed for Codeception WPDB test integration.
 RUN docker-php-ext-install pdo pdo_mysql

--- a/plugins/faustwp/.docker/Dockerfile
+++ b/plugins/faustwp/.docker/Dockerfile
@@ -1,9 +1,9 @@
 ARG WP_VERSION
 
-FROM wordpress:${WP_VERSION}
+FROM wordpress:${WP_VERSION}-php8.2
 
 # Save the build args for use by the runtime environment
-ENV WP_VERSION=${WP_VERSION}-php8.2
+ENV WP_VERSION=${WP_VERSION}
 
 # Needed for Codeception WPDB test integration.
 RUN docker-php-ext-install pdo pdo_mysql

--- a/plugins/faustwp/.docker/Dockerfile
+++ b/plugins/faustwp/.docker/Dockerfile
@@ -1,11 +1,9 @@
 ARG WP_VERSION
-ARG PHP_VERSION
-
-FROM wordpress:${WP_VERSION}-php${PHP_VERSION}
 
 # Save the build args for use by the runtime environment
 ENV WP_VERSION=${WP_VERSION}
-ENV PHP_VERSION=${PHP_VERSION}
+
+FROM wordpress:${WP_VERSION}
 
 # Needed for Codeception WPDB test integration.
 RUN docker-php-ext-install pdo pdo_mysql

--- a/plugins/faustwp/.docker/Dockerfile
+++ b/plugins/faustwp/.docker/Dockerfile
@@ -3,7 +3,7 @@ ARG WP_VERSION
 FROM wordpress:${WP_VERSION}
 
 # Save the build args for use by the runtime environment
-ENV WP_VERSION=${WP_VERSION}
+ENV WP_VERSION=${WP_VERSION}-php8.2
 
 # Needed for Codeception WPDB test integration.
 RUN docker-php-ext-install pdo pdo_mysql

--- a/plugins/faustwp/.docker/Dockerfile
+++ b/plugins/faustwp/.docker/Dockerfile
@@ -1,9 +1,9 @@
 ARG WP_VERSION
 
+FROM wordpress:${WP_VERSION}
+
 # Save the build args for use by the runtime environment
 ENV WP_VERSION=${WP_VERSION}
-
-FROM wordpress:${WP_VERSION}
 
 # Needed for Codeception WPDB test integration.
 RUN docker-php-ext-install pdo pdo_mysql

--- a/plugins/faustwp/docker-compose.yml
+++ b/plugins/faustwp/docker-compose.yml
@@ -11,6 +11,7 @@ services:
     links:
       - db
     environment:
+      WP_VERSION: ${WP_VERSION:-6.2}
       WORDPRESS_DB_HOST: db
       WORDPRESS_DB_NAME: wordpress
       WORDPRESS_DB_USER: root

--- a/plugins/faustwp/docker-compose.yml
+++ b/plugins/faustwp/docker-compose.yml
@@ -11,7 +11,7 @@ services:
     links:
       - db
     environment:
-      WP_VERSION: ${WP_VERSION:-6.2}
+      WP_VERSION: ${WP_VERSION:-6.5}
       WORDPRESS_DB_HOST: db
       WORDPRESS_DB_NAME: wordpress
       WORDPRESS_DB_USER: root


### PR DESCRIPTION
## Tasks

- [x] I have signed a [Contributor License Agreement (CLA)](https://github.com/wpengine/faustjs#contributor-license-agreement) with WP Engine.
- [x] If a code change, I have written testing instructions that the whole team & outside contributors can understand.
- [x] I have written and included a comprehensive [changeset](https://github.com/wpengine/faustjs/blob/canary/DEVELOPMENT.md#deployment) to properly document the changes I've made.

## Description

1. Updates the plugin unit tests to include WordPress 6.1, 6.2, 6.5 and WordPress Nightly. This better matches our testing strategy with the content blocks plugin.
2. Ceans up some of it's testing steps
3. Ensures the PHP version in Dockerfile can be set by specifying it in the parent image
4. Updates existing E2E tests for the plugin to work with the updated Dockerfile
5. Ensures plugin E2E tests no longer overwrite the PHP version provided by the image
6. Normalizes workflow naming for better identification of workflows and their results 
