### PR TITLE
 Improve domain_match Function and add test cases

### DIFF
--- a/.changeset/fair-rocks-promise.md
+++ b/.changeset/fair-rocks-promise.md
@@ -1,0 +1,5 @@
+---
+'@faustwp/wordpress-plugin': patch
+---
+
+Improve domain_match function to handle port checks and Add Comprehensive Test Cases

--- a/plugins/faustwp/includes/rest/callbacks.php
+++ b/plugins/faustwp/includes/rest/callbacks.php
@@ -84,8 +84,8 @@ function register_rest_routes() {
 		'faustwp/v1',
 		'/blockset',
 		array(
-			'methods' => 'POST',
-			'callback' => __NAMESPACE__ . '\\handle_blockset_callback',
+			'methods'             => 'POST',
+			'callback'            => __NAMESPACE__ . '\\handle_blockset_callback',
 			'permission_callback' => __NAMESPACE__ . '\\rest_blockset_permission_callback',
 		)
 	);
@@ -94,8 +94,8 @@ function register_rest_routes() {
 		'faustwp/v1',
 		'/telemetry/decision',
 		array(
-			'methods' => 'POST',
-			'callback' => __NAMESPACE__ . '\\handle_rest_telemetry_decision_callback',
+			'methods'             => 'POST',
+			'callback'            => __NAMESPACE__ . '\\handle_rest_telemetry_decision_callback',
 			'permission_callback' => __NAMESPACE__ . '\\rest_telemetry_decision_permission_callback',
 		)
 	);
@@ -104,8 +104,8 @@ function register_rest_routes() {
 		'faustwp/v1',
 		'/telemetry',
 		array(
-			'methods' => 'POST',
-			'callback' => __NAMESPACE__ . '\\handle_rest_telemetry_callback',
+			'methods'             => 'POST',
+			'callback'            => __NAMESPACE__ . '\\handle_rest_telemetry_callback',
 			'permission_callback' => __NAMESPACE__ . '\\rest_telemetry_permission_callback',
 		)
 	);
@@ -114,8 +114,8 @@ function register_rest_routes() {
 		'faustwp/v1',
 		'/authorize',
 		array(
-			'methods' => 'POST',
-			'callback' => __NAMESPACE__ . '\\handle_rest_authorize_callback',
+			'methods'             => 'POST',
+			'callback'            => __NAMESPACE__ . '\\handle_rest_authorize_callback',
 			'permission_callback' => __NAMESPACE__ . '\\rest_authorize_permission_callback',
 		)
 	);
@@ -124,8 +124,8 @@ function register_rest_routes() {
 		'faustwp/v1',
 		'/process_telemetry',
 		array(
-			'methods' => 'POST',
-			'callback' => __NAMESPACE__ . '\\handle_rest_process_telemetry_callback',
+			'methods'             => 'POST',
+			'callback'            => __NAMESPACE__ . '\\handle_rest_process_telemetry_callback',
 			'permission_callback' => __NAMESPACE__ . '\\rest_process_telemetry_permission_callback',
 		)
 	);
@@ -134,8 +134,8 @@ function register_rest_routes() {
 		'faustwp/v1',
 		'/validate_secret_key',
 		array(
-			'methods' => 'POST',
-			'callback' => __NAMESPACE__ . '\\handle_rest_validate_secret_key_callback',
+			'methods'             => 'POST',
+			'callback'            => __NAMESPACE__ . '\\handle_rest_validate_secret_key_callback',
 			'permission_callback' => __NAMESPACE__ . '\\rest_validate_secret_key_permission_callback',
 		)
 	);
@@ -144,8 +144,8 @@ function register_rest_routes() {
 		'faustwp/v1',
 		'/validate_public_wordpress_url',
 		array(
-			'methods' => 'POST',
-			'callback' => __NAMESPACE__ . '\\handle_rest_validate_public_wordpress_url_callback',
+			'methods'             => 'POST',
+			'callback'            => __NAMESPACE__ . '\\handle_rest_validate_public_wordpress_url_callback',
 			'permission_callback' => __NAMESPACE__ . '\\rest_authorize_permission_callback',
 		)
 	);
@@ -159,8 +159,8 @@ function register_rest_routes() {
 		'wpac/v1',
 		'/authorize',
 		array(
-			'methods' => 'POST',
-			'callback' => __NAMESPACE__ . '\\handle_rest_authorize_callback',
+			'methods'             => 'POST',
+			'callback'            => __NAMESPACE__ . '\\handle_rest_authorize_callback',
 			'permission_callback' => __NAMESPACE__ . '\\wpac_authorize_permission_callback',
 		)
 	);
@@ -217,12 +217,12 @@ function handle_blockset_callback( \WP_REST_Request $request ) {
  */
 function handle_rest_telemetry_callback( \WP_REST_Request $request ) {
 	$data = array(
-		'faustwp' => get_anonymous_faustwp_data(),
+		'faustwp'                  => get_anonymous_faustwp_data(),
 		'wpgraphql_content_blocks' => get_anonymous_wpgraphql_content_blocks_data(),
-		'is_wpe' => is_wpe(),
-		'multisite' => is_multisite(),
-		'php_version' => PHP_VERSION,
-		'wp_version' => get_wp_version(),
+		'is_wpe'                   => is_wpe(),
+		'multisite'                => is_multisite(),
+		'php_version'              => PHP_VERSION,
+		'wp_version'               => get_wp_version(),
 	);
 
 	return new \WP_REST_Response( $data );
@@ -247,40 +247,40 @@ function handle_rest_process_telemetry_callback( \WP_REST_Request $request ) {
 
 	$body = $request->get_json_params();
 
-	$faust_plugin_data = get_anonymous_faustwp_data();
+	$faust_plugin_data          = get_anonymous_faustwp_data();
 	$content_blocks_plugin_data = get_anonymous_wpgraphql_content_blocks_data();
 
 	$ga_tracking_endpoint = 'https://www.google-analytics.com/mp/collect';
-	$ga_tracking_id = 'G-KPVSTHK1G4';
-	$ga_key = '-SLuZb8JTbWkWcT5BD032w';
+	$ga_tracking_id       = 'G-KPVSTHK1G4';
+	$ga_key               = '-SLuZb8JTbWkWcT5BD032w';
 
 	$telemetry_data = array(
-		'node_faustwp_core_version' => $body['node_faustwp_core_version'] ?? null,
-		'node_faustwp_cli_version' => $body['node_faustwp_cli_version'] ?? null,
-		'node_faustwp_blocks_version' => $body['node_faustwp_blocks_version'] ?? null,
-		'node_apollo_client_version' => $body['node_apollo_client_version'] ?? null,
-		'node_faustwp_block_editor_utils_version' => $body['node_faustwp_block_editor_utils_version'] ?? null,
+		'node_faustwp_core_version'                    => $body['node_faustwp_core_version'] ?? null,
+		'node_faustwp_cli_version'                     => $body['node_faustwp_cli_version'] ?? null,
+		'node_faustwp_blocks_version'                  => $body['node_faustwp_blocks_version'] ?? null,
+		'node_apollo_client_version'                   => $body['node_apollo_client_version'] ?? null,
+		'node_faustwp_block_editor_utils_version'      => $body['node_faustwp_block_editor_utils_version'] ?? null,
 		'node_faustwp_experimental_app_router_version' => $body['node_faustwp_experimental_app_router_version'] ?? null,
-		'node_version' => $body['node_version'] ?? null,
-		'node_next_version' => $body['node_next_version'] ?? null,
-		'node_is_development' => $body['node_is_development'] ?? null,
-		'command' => $body['command'] ?? null,
+		'node_version'                                 => $body['node_version'] ?? null,
+		'node_next_version'                            => $body['node_next_version'] ?? null,
+		'node_is_development'                          => $body['node_is_development'] ?? null,
+		'command'                                      => $body['command'] ?? null,
 
-		'setting_has_frontend_uri' => $faust_plugin_data['has_frontend_uri'],
-		'setting_redirects_enabled' => $faust_plugin_data['redirects_enabled'],
-		'setting_rewrites_enabled' => $faust_plugin_data['rewrites_enabled'],
-		'setting_themes_disabled' => $faust_plugin_data['themes_disabled'],
-		'setting_img_src_replacement_enabled' => $faust_plugin_data['image_source_replacement_enabled'],
-		'faustwp_version' => $faust_plugin_data['version'],
+		'setting_has_frontend_uri'                     => $faust_plugin_data['has_frontend_uri'],
+		'setting_redirects_enabled'                    => $faust_plugin_data['redirects_enabled'],
+		'setting_rewrites_enabled'                     => $faust_plugin_data['rewrites_enabled'],
+		'setting_themes_disabled'                      => $faust_plugin_data['themes_disabled'],
+		'setting_img_src_replacement_enabled'          => $faust_plugin_data['image_source_replacement_enabled'],
+		'faustwp_version'                              => $faust_plugin_data['version'],
 
-		'wpgraphql_content_blocks_version' => $content_blocks_plugin_data['version'],
+		'wpgraphql_content_blocks_version'             => $content_blocks_plugin_data['version'],
 
-		'is_wpe' => is_wpe(),
-		'multisite' => is_multisite(),
-		'php_version' => PHP_VERSION,
-		'wp_version' => get_wp_version(),
-		'engagement_time_msec' => 100,
-		'session_id' => md5( get_telemetry_client_id() ),
+		'is_wpe'                                       => is_wpe(),
+		'multisite'                                    => is_multisite(),
+		'php_version'                                  => PHP_VERSION,
+		'wp_version'                                   => get_wp_version(),
+		'engagement_time_msec'                         => 100,
+		'session_id'                                   => md5( get_telemetry_client_id() ),
 	);
 
 	// Remove null values since GA rejects them.
@@ -289,16 +289,16 @@ function handle_rest_process_telemetry_callback( \WP_REST_Request $request ) {
 	$ga_telemetry_url = add_query_arg(
 		array(
 			'measurement_id' => $ga_tracking_id,
-			'api_secret' => $ga_key,
+			'api_secret'     => $ga_key,
 		),
 		$ga_tracking_endpoint
 	);
 
 	$telemetry_body = array(
 		'client_id' => get_telemetry_client_id(),
-		'events' => array(
+		'events'    => array(
 			array(
-				'name' => 'telemetry_event',
+				'name'   => 'telemetry_event',
 				'params' => $telemetry_data,
 			),
 		),
@@ -307,7 +307,7 @@ function handle_rest_process_telemetry_callback( \WP_REST_Request $request ) {
 	wp_remote_post(
 		$ga_telemetry_url,
 		array(
-			'body' => wp_json_encode( $telemetry_body ),
+			'body'     => wp_json_encode( $telemetry_body ),
 			'blocking' => false,
 		)
 	);
@@ -371,7 +371,7 @@ function rest_process_telemetry_permission_callback( \WP_REST_Request $request )
  * @return mixed A \WP_REST_Response, array, or \WP_Error.
  */
 function handle_rest_authorize_callback( \WP_REST_Request $request ) {
-	$code = trim( $request->get_param( 'code' ) );
+	$code          = trim( $request->get_param( 'code' ) );
 	$refresh_token = trim( $request->get_param( 'refreshToken' ) );
 
 	if ( ! $code && ! $refresh_token ) {
@@ -389,15 +389,15 @@ function handle_rest_authorize_callback( \WP_REST_Request $request ) {
 	}
 
 	$refresh_token_expiration = WEEK_IN_SECONDS * 2;
-	$access_token_expiration = MINUTE_IN_SECONDS * 5;
+	$access_token_expiration  = MINUTE_IN_SECONDS * 5;
 
-	$access_token = generate_access_token( $user, $access_token_expiration );
+	$access_token  = generate_access_token( $user, $access_token_expiration );
 	$refresh_token = generate_refresh_token( $user, $refresh_token_expiration );
 
 	return array(
-		'accessToken' => $access_token,
-		'accessTokenExpiration' => ( time() + $access_token_expiration ),
-		'refreshToken' => $refresh_token,
+		'accessToken'            => $access_token,
+		'accessTokenExpiration'  => ( time() + $access_token_expiration ),
+		'refreshToken'           => $refresh_token,
 		'refreshTokenExpiration' => ( time() + $refresh_token_expiration ),
 	);
 }
@@ -467,7 +467,7 @@ function rest_telemetry_decision_permission_callback( \WP_REST_Request $request 
  * @return \WP_REST_Response|\WP_Error
  */
 function handle_rest_telemetry_decision_callback( \WP_REST_Request $request ) {
-	$body = json_decode( $request->get_body(), true );
+	$body     = json_decode( $request->get_body(), true );
 	$decision = $body['decision'] ?? 'remind';
 	if ( ! in_array( $decision, array( 'yes', 'no', 'remind' ), true ) ) {
 		$decision = 'remind';
@@ -492,10 +492,10 @@ function handle_rest_telemetry_decision_callback( \WP_REST_Request $request ) {
 	$response = array(
 		'decision' => $decision,
 		'settings' => array(
-			'enabled' => faustwp_get_setting( 'enable_telemetry' ),
+			'enabled'  => faustwp_get_setting( 'enable_telemetry' ),
 			'reminder' => faustwp_get_setting( 'telemetry_reminder' ),
 		),
-		'success' => true,
+		'success'  => true,
 	);
 	return rest_ensure_response( $response );
 }

--- a/plugins/faustwp/includes/rest/callbacks.php
+++ b/plugins/faustwp/includes/rest/callbacks.php
@@ -26,7 +26,7 @@ use function WPE\FaustWP\Blocks\handle_uploaded_blockset;
 use function WPE\FaustWP\Settings\faustwp_get_setting;
 use function WPE\FaustWP\Settings\faustwp_update_setting;
 use function WPE\FaustWP\Settings\is_telemetry_enabled;
-use function WPE\FaustWP\Utilities\domains_match;
+use function WPE\FaustWP\Utilities\strict_domain_match;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -84,8 +84,8 @@ function register_rest_routes() {
 		'faustwp/v1',
 		'/blockset',
 		array(
-			'methods'             => 'POST',
-			'callback'            => __NAMESPACE__ . '\\handle_blockset_callback',
+			'methods' => 'POST',
+			'callback' => __NAMESPACE__ . '\\handle_blockset_callback',
 			'permission_callback' => __NAMESPACE__ . '\\rest_blockset_permission_callback',
 		)
 	);
@@ -94,8 +94,8 @@ function register_rest_routes() {
 		'faustwp/v1',
 		'/telemetry/decision',
 		array(
-			'methods'             => 'POST',
-			'callback'            => __NAMESPACE__ . '\\handle_rest_telemetry_decision_callback',
+			'methods' => 'POST',
+			'callback' => __NAMESPACE__ . '\\handle_rest_telemetry_decision_callback',
 			'permission_callback' => __NAMESPACE__ . '\\rest_telemetry_decision_permission_callback',
 		)
 	);
@@ -104,8 +104,8 @@ function register_rest_routes() {
 		'faustwp/v1',
 		'/telemetry',
 		array(
-			'methods'             => 'POST',
-			'callback'            => __NAMESPACE__ . '\\handle_rest_telemetry_callback',
+			'methods' => 'POST',
+			'callback' => __NAMESPACE__ . '\\handle_rest_telemetry_callback',
 			'permission_callback' => __NAMESPACE__ . '\\rest_telemetry_permission_callback',
 		)
 	);
@@ -114,8 +114,8 @@ function register_rest_routes() {
 		'faustwp/v1',
 		'/authorize',
 		array(
-			'methods'             => 'POST',
-			'callback'            => __NAMESPACE__ . '\\handle_rest_authorize_callback',
+			'methods' => 'POST',
+			'callback' => __NAMESPACE__ . '\\handle_rest_authorize_callback',
 			'permission_callback' => __NAMESPACE__ . '\\rest_authorize_permission_callback',
 		)
 	);
@@ -124,8 +124,8 @@ function register_rest_routes() {
 		'faustwp/v1',
 		'/process_telemetry',
 		array(
-			'methods'             => 'POST',
-			'callback'            => __NAMESPACE__ . '\\handle_rest_process_telemetry_callback',
+			'methods' => 'POST',
+			'callback' => __NAMESPACE__ . '\\handle_rest_process_telemetry_callback',
 			'permission_callback' => __NAMESPACE__ . '\\rest_process_telemetry_permission_callback',
 		)
 	);
@@ -134,8 +134,8 @@ function register_rest_routes() {
 		'faustwp/v1',
 		'/validate_secret_key',
 		array(
-			'methods'             => 'POST',
-			'callback'            => __NAMESPACE__ . '\\handle_rest_validate_secret_key_callback',
+			'methods' => 'POST',
+			'callback' => __NAMESPACE__ . '\\handle_rest_validate_secret_key_callback',
 			'permission_callback' => __NAMESPACE__ . '\\rest_validate_secret_key_permission_callback',
 		)
 	);
@@ -144,8 +144,8 @@ function register_rest_routes() {
 		'faustwp/v1',
 		'/validate_public_wordpress_url',
 		array(
-			'methods'             => 'POST',
-			'callback'            => __NAMESPACE__ . '\\handle_rest_validate_public_wordpress_url_callback',
+			'methods' => 'POST',
+			'callback' => __NAMESPACE__ . '\\handle_rest_validate_public_wordpress_url_callback',
 			'permission_callback' => __NAMESPACE__ . '\\rest_authorize_permission_callback',
 		)
 	);
@@ -159,8 +159,8 @@ function register_rest_routes() {
 		'wpac/v1',
 		'/authorize',
 		array(
-			'methods'             => 'POST',
-			'callback'            => __NAMESPACE__ . '\\handle_rest_authorize_callback',
+			'methods' => 'POST',
+			'callback' => __NAMESPACE__ . '\\handle_rest_authorize_callback',
 			'permission_callback' => __NAMESPACE__ . '\\wpac_authorize_permission_callback',
 		)
 	);
@@ -217,12 +217,12 @@ function handle_blockset_callback( \WP_REST_Request $request ) {
  */
 function handle_rest_telemetry_callback( \WP_REST_Request $request ) {
 	$data = array(
-		'faustwp'                  => get_anonymous_faustwp_data(),
+		'faustwp' => get_anonymous_faustwp_data(),
 		'wpgraphql_content_blocks' => get_anonymous_wpgraphql_content_blocks_data(),
-		'is_wpe'                   => is_wpe(),
-		'multisite'                => is_multisite(),
-		'php_version'              => PHP_VERSION,
-		'wp_version'               => get_wp_version(),
+		'is_wpe' => is_wpe(),
+		'multisite' => is_multisite(),
+		'php_version' => PHP_VERSION,
+		'wp_version' => get_wp_version(),
 	);
 
 	return new \WP_REST_Response( $data );
@@ -247,40 +247,40 @@ function handle_rest_process_telemetry_callback( \WP_REST_Request $request ) {
 
 	$body = $request->get_json_params();
 
-	$faust_plugin_data          = get_anonymous_faustwp_data();
+	$faust_plugin_data = get_anonymous_faustwp_data();
 	$content_blocks_plugin_data = get_anonymous_wpgraphql_content_blocks_data();
 
 	$ga_tracking_endpoint = 'https://www.google-analytics.com/mp/collect';
-	$ga_tracking_id       = 'G-KPVSTHK1G4';
-	$ga_key               = '-SLuZb8JTbWkWcT5BD032w';
+	$ga_tracking_id = 'G-KPVSTHK1G4';
+	$ga_key = '-SLuZb8JTbWkWcT5BD032w';
 
 	$telemetry_data = array(
-		'node_faustwp_core_version'                    => $body['node_faustwp_core_version'] ?? null,
-		'node_faustwp_cli_version'                     => $body['node_faustwp_cli_version'] ?? null,
-		'node_faustwp_blocks_version'                  => $body['node_faustwp_blocks_version'] ?? null,
-		'node_apollo_client_version'                   => $body['node_apollo_client_version'] ?? null,
-		'node_faustwp_block_editor_utils_version'      => $body['node_faustwp_block_editor_utils_version'] ?? null,
+		'node_faustwp_core_version' => $body['node_faustwp_core_version'] ?? null,
+		'node_faustwp_cli_version' => $body['node_faustwp_cli_version'] ?? null,
+		'node_faustwp_blocks_version' => $body['node_faustwp_blocks_version'] ?? null,
+		'node_apollo_client_version' => $body['node_apollo_client_version'] ?? null,
+		'node_faustwp_block_editor_utils_version' => $body['node_faustwp_block_editor_utils_version'] ?? null,
 		'node_faustwp_experimental_app_router_version' => $body['node_faustwp_experimental_app_router_version'] ?? null,
-		'node_version'                                 => $body['node_version'] ?? null,
-		'node_next_version'                            => $body['node_next_version'] ?? null,
-		'node_is_development'                          => $body['node_is_development'] ?? null,
-		'command'                                      => $body['command'] ?? null,
+		'node_version' => $body['node_version'] ?? null,
+		'node_next_version' => $body['node_next_version'] ?? null,
+		'node_is_development' => $body['node_is_development'] ?? null,
+		'command' => $body['command'] ?? null,
 
-		'setting_has_frontend_uri'                     => $faust_plugin_data['has_frontend_uri'],
-		'setting_redirects_enabled'                    => $faust_plugin_data['redirects_enabled'],
-		'setting_rewrites_enabled'                     => $faust_plugin_data['rewrites_enabled'],
-		'setting_themes_disabled'                      => $faust_plugin_data['themes_disabled'],
-		'setting_img_src_replacement_enabled'          => $faust_plugin_data['image_source_replacement_enabled'],
-		'faustwp_version'                              => $faust_plugin_data['version'],
+		'setting_has_frontend_uri' => $faust_plugin_data['has_frontend_uri'],
+		'setting_redirects_enabled' => $faust_plugin_data['redirects_enabled'],
+		'setting_rewrites_enabled' => $faust_plugin_data['rewrites_enabled'],
+		'setting_themes_disabled' => $faust_plugin_data['themes_disabled'],
+		'setting_img_src_replacement_enabled' => $faust_plugin_data['image_source_replacement_enabled'],
+		'faustwp_version' => $faust_plugin_data['version'],
 
-		'wpgraphql_content_blocks_version'             => $content_blocks_plugin_data['version'],
+		'wpgraphql_content_blocks_version' => $content_blocks_plugin_data['version'],
 
-		'is_wpe'                                       => is_wpe(),
-		'multisite'                                    => is_multisite(),
-		'php_version'                                  => PHP_VERSION,
-		'wp_version'                                   => get_wp_version(),
-		'engagement_time_msec'                         => 100,
-		'session_id'                                   => md5( get_telemetry_client_id() ),
+		'is_wpe' => is_wpe(),
+		'multisite' => is_multisite(),
+		'php_version' => PHP_VERSION,
+		'wp_version' => get_wp_version(),
+		'engagement_time_msec' => 100,
+		'session_id' => md5( get_telemetry_client_id() ),
 	);
 
 	// Remove null values since GA rejects them.
@@ -289,16 +289,16 @@ function handle_rest_process_telemetry_callback( \WP_REST_Request $request ) {
 	$ga_telemetry_url = add_query_arg(
 		array(
 			'measurement_id' => $ga_tracking_id,
-			'api_secret'     => $ga_key,
+			'api_secret' => $ga_key,
 		),
 		$ga_tracking_endpoint
 	);
 
 	$telemetry_body = array(
 		'client_id' => get_telemetry_client_id(),
-		'events'    => array(
+		'events' => array(
 			array(
-				'name'   => 'telemetry_event',
+				'name' => 'telemetry_event',
 				'params' => $telemetry_data,
 			),
 		),
@@ -307,7 +307,7 @@ function handle_rest_process_telemetry_callback( \WP_REST_Request $request ) {
 	wp_remote_post(
 		$ga_telemetry_url,
 		array(
-			'body'     => wp_json_encode( $telemetry_body ),
+			'body' => wp_json_encode( $telemetry_body ),
 			'blocking' => false,
 		)
 	);
@@ -371,7 +371,7 @@ function rest_process_telemetry_permission_callback( \WP_REST_Request $request )
  * @return mixed A \WP_REST_Response, array, or \WP_Error.
  */
 function handle_rest_authorize_callback( \WP_REST_Request $request ) {
-	$code          = trim( $request->get_param( 'code' ) );
+	$code = trim( $request->get_param( 'code' ) );
 	$refresh_token = trim( $request->get_param( 'refreshToken' ) );
 
 	if ( ! $code && ! $refresh_token ) {
@@ -389,15 +389,15 @@ function handle_rest_authorize_callback( \WP_REST_Request $request ) {
 	}
 
 	$refresh_token_expiration = WEEK_IN_SECONDS * 2;
-	$access_token_expiration  = MINUTE_IN_SECONDS * 5;
+	$access_token_expiration = MINUTE_IN_SECONDS * 5;
 
-	$access_token  = generate_access_token( $user, $access_token_expiration );
+	$access_token = generate_access_token( $user, $access_token_expiration );
 	$refresh_token = generate_refresh_token( $user, $refresh_token_expiration );
 
 	return array(
-		'accessToken'            => $access_token,
-		'accessTokenExpiration'  => ( time() + $access_token_expiration ),
-		'refreshToken'           => $refresh_token,
+		'accessToken' => $access_token,
+		'accessTokenExpiration' => ( time() + $access_token_expiration ),
+		'refreshToken' => $refresh_token,
 		'refreshTokenExpiration' => ( time() + $refresh_token_expiration ),
 	);
 }
@@ -467,7 +467,7 @@ function rest_telemetry_decision_permission_callback( \WP_REST_Request $request 
  * @return \WP_REST_Response|\WP_Error
  */
 function handle_rest_telemetry_decision_callback( \WP_REST_Request $request ) {
-	$body     = json_decode( $request->get_body(), true );
+	$body = json_decode( $request->get_body(), true );
 	$decision = $body['decision'] ?? 'remind';
 	if ( ! in_array( $decision, array( 'yes', 'no', 'remind' ), true ) ) {
 		$decision = 'remind';
@@ -492,10 +492,10 @@ function handle_rest_telemetry_decision_callback( \WP_REST_Request $request ) {
 	$response = array(
 		'decision' => $decision,
 		'settings' => array(
-			'enabled'  => faustwp_get_setting( 'enable_telemetry' ),
+			'enabled' => faustwp_get_setting( 'enable_telemetry' ),
 			'reminder' => faustwp_get_setting( 'telemetry_reminder' ),
 		),
-		'success'  => true,
+		'success' => true,
 	);
 	return rest_ensure_response( $response );
 }
@@ -560,7 +560,7 @@ function handle_rest_validate_public_wordpress_url_callback( \WP_REST_Request $r
 		$public_wordpress_url = $parameters['public_wordpress_url'];
 
 		// Check if the provided WordPress URL does not match the frontend URI.
-		if ( ! domains_match( $public_wordpress_url, $frontend_uri ) ) {
+		if ( ! strict_domain_match( $public_wordpress_url, $frontend_uri ) ) {
 			// Return 200 OK if the URLs do not match.
 			$response = new \WP_REST_Response( 'OK', 200 );
 		} else {

--- a/plugins/faustwp/includes/utilities/functions.php
+++ b/plugins/faustwp/includes/utilities/functions.php
@@ -62,8 +62,8 @@ function strict_domain_match( string $domain1, string $domain2 ): bool {
 	$host2   = isset( $parsed_domain2['host'] ) ? $parsed_domain2['host'] : null;
 	$scheme1 = isset( $parsed_domain1['scheme'] ) ? $parsed_domain1['scheme'] : 'http';
 	$scheme2 = isset( $parsed_domain2['scheme'] ) ? $parsed_domain2['scheme'] : 'http';
-	$port1   = ( $scheme1 === 'https' ? 443 : 80 ) === isset( $parsed_domain1['port'] ) ? (int) $parsed_domain1['port'] : null;
-	$port2   = ( $scheme2 === 'https' ? 443 : 80 ) === isset( $parsed_domain2['port'] ) ? (int) $parsed_domain2['port'] : null;
+	$port1   = isset( $parsed_domain1['port'] ) ? (int) $parsed_domain1['port'] : ( 'https' === $scheme1 ? 443 : 80 );
+	$port2   = isset( $parsed_domain2['port'] ) ? (int) $parsed_domain2['port'] : ( 'https' === $scheme2 ? 443 : 80 );
 
 	if ( empty( $host1 ) || empty( $host2 ) ) {
 		return false;

--- a/plugins/faustwp/includes/utilities/functions.php
+++ b/plugins/faustwp/includes/utilities/functions.php
@@ -58,12 +58,12 @@ function strict_domain_match( string $domain1, string $domain2 ): bool {
 	$parsed_domain2 = wp_parse_url( $domain2 );
 
 	// Extract components
-	$host1 = isset( $parsed_domain1['host'] ) ? $parsed_domain1['host'] : null;
-	$host2 = isset( $parsed_domain2['host'] ) ? $parsed_domain2['host'] : null;
+	$host1   = isset( $parsed_domain1['host'] ) ? $parsed_domain1['host'] : null;
+	$host2   = isset( $parsed_domain2['host'] ) ? $parsed_domain2['host'] : null;
 	$scheme1 = isset( $parsed_domain1['scheme'] ) ? $parsed_domain1['scheme'] : 'http';
 	$scheme2 = isset( $parsed_domain2['scheme'] ) ? $parsed_domain2['scheme'] : 'http';
-	$port1 = isset( $parsed_domain1['port'] ) ? (int) $parsed_domain1['port'] : ( $scheme1 === 'https' ? 443 : 80 );
-	$port2 = isset( $parsed_domain2['port'] ) ? (int) $parsed_domain2['port'] : ( $scheme2 === 'https' ? 443 : 80 );
+	$port1   = isset( $parsed_domain1['port'] ) ? (int) $parsed_domain1['port'] : ( $scheme1 === 'https' ? 443 : 80 );
+	$port2   = isset( $parsed_domain2['port'] ) ? (int) $parsed_domain2['port'] : ( $scheme2 === 'https' ? 443 : 80 );
 
 	if ( empty( $host1 ) || empty( $host2 ) ) {
 		return false;

--- a/plugins/faustwp/includes/utilities/functions.php
+++ b/plugins/faustwp/includes/utilities/functions.php
@@ -45,25 +45,33 @@ function plugin_version() {
 }
 
 /**
- * Checks if two domain strings represent the same domain.
+ * Performs a strict domain comparison
+ * Also checks for matching ports (if present).
  *
  * @param string $domain1 The first domain string.
  * @param string $domain2 The second domain string.
- * @return bool True if the domains match, false otherwise.
+ * @return bool True if the domains match (including localhost, loopback, and ports), false otherwise.
  */
-function domains_match( $domain1, $domain2 ) {
-	// Extract the domain part.
-	$extract_domain = function ( $url ) {
-		$parsed_url = wp_parse_url( $url, PHP_URL_HOST );
-		return $parsed_url ? $parsed_url : null;
-	};
+function strict_domain_match( string $domain1, string $domain2 ): bool {
+	// Parse URLs
+	$parsed_domain1 = wp_parse_url( $domain1 );
+	$parsed_domain2 = wp_parse_url( $domain2 );
 
-	$domain1 = $extract_domain( $domain1 );
-	$domain2 = $extract_domain( $domain2 );
+	// Extract components
+	$host1 = isset( $parsed_domain1['host'] ) ? $parsed_domain1['host'] : null;
+	$host2 = isset( $parsed_domain2['host'] ) ? $parsed_domain2['host'] : null;
+	$scheme1 = isset( $parsed_domain1['scheme'] ) ? $parsed_domain1['scheme'] : 'http';
+	$scheme2 = isset( $parsed_domain2['scheme'] ) ? $parsed_domain2['scheme'] : 'http';
+	$port1 = isset( $parsed_domain1['port'] ) ? (int) $parsed_domain1['port'] : ( $scheme1 === 'https' ? 443 : 80 );
+	$port2 = isset( $parsed_domain2['port'] ) ? (int) $parsed_domain2['port'] : ( $scheme2 === 'https' ? 443 : 80 );
 
-	// Remove "www" prefix from domain if present.
-	$domain1 = preg_replace( '/^www\./i', '', $domain1 );
-	$domain2 = preg_replace( '/^www\./i', '', $domain2 );
+	if ( empty( $host1 ) || empty( $host2 ) ) {
+		return false;
+	}
 
-	return null !== $domain1 && null !== $domain2 && $domain1 === $domain2;
+	// Normalize the hosts by removing 'www.' if present
+	$normalized_host1 = preg_replace( '/^www\./', '', $host1 );
+	$normalized_host2 = preg_replace( '/^www\./', '', $host2 );
+
+	return ( $normalized_host1 === $normalized_host2 ) && ( $scheme1 === $scheme2 ) && ( $port1 === $port2 );
 }

--- a/plugins/faustwp/includes/utilities/functions.php
+++ b/plugins/faustwp/includes/utilities/functions.php
@@ -53,23 +53,23 @@ function plugin_version() {
  * @return bool True if the domains match (including localhost, loopback, and ports), false otherwise.
  */
 function strict_domain_match( string $domain1, string $domain2 ): bool {
-	// Parse URLs
+	// Parse URLs.
 	$parsed_domain1 = wp_parse_url( $domain1 );
 	$parsed_domain2 = wp_parse_url( $domain2 );
 
-	// Extract components
+	// Extract components.
 	$host1   = isset( $parsed_domain1['host'] ) ? $parsed_domain1['host'] : null;
 	$host2   = isset( $parsed_domain2['host'] ) ? $parsed_domain2['host'] : null;
 	$scheme1 = isset( $parsed_domain1['scheme'] ) ? $parsed_domain1['scheme'] : 'http';
 	$scheme2 = isset( $parsed_domain2['scheme'] ) ? $parsed_domain2['scheme'] : 'http';
-	$port1   = isset( $parsed_domain1['port'] ) ? (int) $parsed_domain1['port'] : ( $scheme1 === 'https' ? 443 : 80 );
-	$port2   = isset( $parsed_domain2['port'] ) ? (int) $parsed_domain2['port'] : ( $scheme2 === 'https' ? 443 : 80 );
+	$port1   = ( $scheme1 === 'https' ? 443 : 80 ) === isset( $parsed_domain1['port'] ) ? (int) $parsed_domain1['port'] : null;
+	$port2   = ( $scheme2 === 'https' ? 443 : 80 ) === isset( $parsed_domain2['port'] ) ? (int) $parsed_domain2['port'] : null;
 
 	if ( empty( $host1 ) || empty( $host2 ) ) {
 		return false;
 	}
 
-	// Normalize the hosts by removing 'www.' if present
+	// Normalize the hosts by removing 'www.' if present.
 	$normalized_host1 = preg_replace( '/^www\./', '', $host1 );
 	$normalized_host2 = preg_replace( '/^www\./', '', $host2 );
 

--- a/plugins/faustwp/tests/unit/FunctionsTests.php
+++ b/plugins/faustwp/tests/unit/FunctionsTests.php
@@ -5,28 +5,32 @@ namespace WPE\FaustWP\Tests\Unit;
 use function WPE\FaustWP\Utilities\{strict_domain_match};
 
 class FunctionsTests extends FaustUnitTest {
-	public function testMatchValidDomainsWithPorts() {
+	public function test_match_valid_domains_with_ports() {
 		$this->assertTrue( strict_domain_match( 'https://example.com:443', 'https://example.com:443' ) );
-		$this->assertTrue( strict_domain_match( 'https://www.example.org:443', 'https://example.org:443' ) );
+		$this->assertTrue( strict_domain_match( 'http://example.com:80', 'http://example.com:80' ) );
+		$this->assertTrue( strict_domain_match( 'https://www.example.org:443', 'https://example.org:443' ) ); // Different subdomains but same domain and port
 	}
 
-	public function testMatchWithoutPorts() {
+	public function test_match_without_ports() {
 		$this->assertTrue( strict_domain_match( 'https://example.com', 'https://example.com' ) );
-		$this->assertTrue( strict_domain_match( 'http://www.example.org', 'http://example.org' ) );
+		$this->assertTrue( strict_domain_match( 'http://www.example.org', 'http://example.org' ) ); // Different subdomains
+		$this->assertTrue( strict_domain_match( 'https://example.com', 'https://example.com' ) );
+		$this->assertFalse( strict_domain_match( 'https://example.com', 'http://example.com' ) ); // Different schemes
 	}
 
-	public function testMatchDifferentPorts() {
+	public function test_match_different_ports() {
 		$this->assertFalse( strict_domain_match( 'https://example.com:443', 'https://example.com:80' ) );
 		$this->assertFalse( strict_domain_match( 'http://example.com:8080', 'http://example.com:80' ) );
-		$this->assertFalse( strict_domain_match( 'http://www.example.org:8080', 'http://example.org:80' ) );
+		$this->assertFalse( strict_domain_match( 'http://www.example.org:8080', 'http://example.org:80' ) ); // Different ports
 	}
 
-	public function testMatchDifferentProtocols() {
+	public function test_match_different_protocols() {
 		$this->assertFalse( strict_domain_match( 'https://example.com', 'http://example.com' ) );
 		$this->assertFalse( strict_domain_match( 'http://www.example.org', 'https://example.org' ) );
 	}
 
-	public function testSchemeMismatchSameDomainPort() {
+	public function test_scheme_mismatch_same_domain_port() {
 		$this->assertFalse( strict_domain_match( 'http://example.com:80', 'https://example.com:80' ) );
+		$this->assertFalse( strict_domain_match( 'https://example.com:443', 'http://example.com:443' ) );
 	}
 }

--- a/plugins/faustwp/tests/unit/FunctionsTests.php
+++ b/plugins/faustwp/tests/unit/FunctionsTests.php
@@ -2,23 +2,31 @@
 
 namespace WPE\FaustWP\Tests\Unit;
 
-use function WPE\FaustWP\Utilities\{domains_match};
+use function WPE\FaustWP\Utilities\{strict_domain_match};
 
 class FunctionsTests extends FaustUnitTest {
-	public function test_domains_match() {
-		// Test case 1: Same domains with different protocols
-		$this->assertTrue(domains_match("http://example.com", "https://example.com"));
+	public function testMatchValidDomainsWithPorts() {
+		$this->assertTrue( strict_domain_match( 'https://example.com:443', 'https://example.com:443' ) );
+		$this->assertTrue( strict_domain_match( 'https://www.example.org:443', 'https://example.org:443' ) );
+	}
 
-		// Test case 2: Same domains with trailing slashes
-		$this->assertTrue(domains_match("http://example.com/", "http://example.com"));
+	public function testMatchWithoutPorts() {
+		$this->assertTrue( strict_domain_match( 'https://example.com', 'https://example.com' ) );
+		$this->assertTrue( strict_domain_match( 'http://www.example.org', 'http://example.org' ) );
+	}
 
-		// Test case 3: Same domains with www prefix
-		$this->assertTrue(domains_match("http://www.example.com", "http://example.com"));
+	public function testMatchDifferentPorts() {
+		$this->assertFalse( strict_domain_match( 'https://example.com:443', 'https://example.com:80' ) );
+		$this->assertFalse( strict_domain_match( 'http://example.com:8080', 'http://example.com:80' ) );
+		$this->assertFalse( strict_domain_match( 'http://www.example.org:8080', 'http://example.org:80' ) );
+	}
 
-		// Test case 4: Different domains
-		$this->assertFalse(domains_match("http://example1.com", "http://example2.com"));
+	public function testMatchDifferentProtocols() {
+		$this->assertFalse( strict_domain_match( 'https://example.com', 'http://example.com' ) );
+		$this->assertFalse( strict_domain_match( 'http://www.example.org', 'https://example.org' ) );
+	}
 
-		// Test case 5: Same domains with different subdomains
-		$this->assertFalse(domains_match("http://1.example.com", "http://2.example.com"));
+	public function testSchemeMismatchSameDomainPort() {
+		$this->assertFalse( strict_domain_match( 'http://example.com:80', 'https://example.com:80' ) );
 	}
 }


### PR DESCRIPTION
## Tasks

- [ ] I have signed a [Contributor License Agreement (CLA)](https://github.com/wpengine/faustjs#contributor-license-agreement) with WP Engine.
- [ ] If a code change, I have written testing instructions that the whole team & outside contributors can understand.
- [ ] I have written and included a comprehensive [changeset](https://github.com/wpengine/faustjs/blob/canary/DEVELOPMENT.md#deployment) to properly document the changes I've made.

## Description

This PR enhances the domain_match function to handle a wider range of scenarios, including different ports, schemes, and subdomains. It also adds a comprehensive set of test cases to ensure the function behaves correctly in various situations.

## Related Issue(s):

(https://github.com/wpengine/faustjs/issues/1884)

## Testing

1. Create a front end Node environment runs on localhost:3000, and LocalWP environment runs on localhost with a different port.
2. Run the development server using `npm run dev -w examples/next/faustwp-getting-started`
3. The CLI tool should not fail the health check for WordPress URL validation.
## Screenshots

Alternatively if you can also try create a new front end Node environment with the same host as the LocalWP environment but in a different port.

<!--
If this is a visual change include relevant screenshots about the behavior of the application before and after this change.
-->

## Documentation Changes

<!--
List corresponding changes to the documentation.
-->

## Dependant PRs

<!--
List any dependent PR's that are awaiting review. Use the following syntax:

- #1234
-->
