### PR TITLE
[Bug] Add missing textarea control handler.

### DIFF
--- a/.changeset/orange-birds-invent.md
+++ b/.changeset/orange-birds-invent.md
@@ -1,0 +1,23 @@
+---
+'@faustwp/block-editor-utils': patch
+---
+
+Adds missing TextAreaControl handler when specifing a `control: 'textarea'` in Component.config.editorFields.
+
+Adding this configuration to your blocks will render TextAreaControls component in the editor.
+
+```js
+// Component.js
+
+Component.config = {
+  name: 'CreateBlockBlockB',
+  editorFields: {
+    textArea: {
+      type: 'string',
+      label: 'My Message',
+      location: 'editor',
+      control: 'textarea' // <--- Render a TextAreaControl field in the Gutenberg editor
+    },
+  },
+};
+```

--- a/packages/block-editor-utils/src/controls/TextArea.tsx
+++ b/packages/block-editor-utils/src/controls/TextArea.tsx
@@ -1,0 +1,21 @@
+import * as React from 'react';
+import { TextareaControl } from '@wordpress/components';
+import { ControlProps } from '../types/index.js';
+
+function TextArea<T extends Record<string, any>>({
+  config,
+  props,
+}: ControlProps<T>) {
+  const onChange = (newContent: string) => {
+    props.setAttributes({ [config.name]: newContent });
+  };
+  return (
+    <TextareaControl
+      label={config.label}
+      value={props.attributes[config.name]}
+      onChange={onChange}
+    />
+  );
+}
+
+export default TextArea;

--- a/packages/block-editor-utils/src/controls/index.ts
+++ b/packages/block-editor-utils/src/controls/index.ts
@@ -7,6 +7,7 @@ import Select from './Select.js';
 import Radio from './Radio.js';
 import Range from './Range.js';
 import Rich from './RichText.js';
+import TextArea from './TextArea.js';
 
 registerControl('text', Text);
 registerControl('number', NumberField);
@@ -16,3 +17,4 @@ registerControl('select', Select);
 registerControl('radio', Radio);
 registerControl('range', Range);
 registerControl('rich-text', Rich);
+registerControl('textarea', TextArea);


### PR DESCRIPTION
## Tasks

- [x] I have signed a [Contributor License Agreement (CLA)](https://github.com/wpengine/faustjs#contributor-license-agreement) with WP Engine.
- [x] If a code change, I have written testing instructions that the whole team & outside contributors can understand.
- [x] I have written and included a comprehensive [changeset](https://github.com/wpengine/faustjs/blob/canary/DEVELOPMENT.md#deployment) to properly document the changes I've made.

## Description

This PR adds a missing TextAreaControl within the custom block editorFields configuration.

## Related Issue(s):

https://github.com/wpengine/faustjs/issues/1895

## Testing

1. Inside the `/example/next/block-support` package add the following fields in the block-b Component.config that includes a `control: 'textarea'`

```js
Component.config = {
  name: 'CreateBlockBlockB',
  editorFields: {
    message: {
      type: 'string',
      label: 'My Message',
      location: 'editor',
    },
    textArea: {
      type: 'string',
      label: 'My Message',
      location: 'editor',
      control: 'textarea'
    },
  },
};
```

Also update the block.json to recognize the new attribute
```js
"attributes": {
		"message": {
			"type": "string",
			"default": "Hello World"
		},
		"textArea": {
			"type": "string",
			"default": "Hello World"
		},

```

2. Build and push the blocks to WordPress:
```
$ npm run blockset -w examples/next/block-support 
```

3. Inside the block editor you should be able to view the textArea field rendered as textarea control instead of being empty.

## Screenshots
<img width="827" alt="Screenshot 2024-05-30 at 16 35 12" src="https://github.com/wpengine/faustjs/assets/328805/f970eeeb-8bfa-4dd5-af8a-8cf4272ad442">



## Documentation Changes

<!--
List corresponding changes to the documentation.
-->

## Dependant PRs

<!--
List any dependent PR's that are awaiting review. Use the following syntax:

- #1234
-->
