### PR TITLE
Adds the `react-refresh` package to avoid having to manually do so.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "eslint-plugin-simple-import-sort": "^7.0.0",
         "prettier": "^2.4.1",
         "prettier-linter-helpers": "^1.0.0",
+        "react-refresh": "^0.14.2",
         "rimraf": "^3.0.2"
       },
       "engines": {
@@ -23990,6 +23991,15 @@
     "node_modules/react-is": {
       "version": "16.13.1",
       "license": "MIT"
+    },
+    "node_modules/react-refresh": {
+      "version": "0.14.2",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.2.tgz",
+      "integrity": "sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/react-remove-scroll": {
       "version": "2.5.5",

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "eslint-plugin-simple-import-sort": "^7.0.0",
     "prettier": "^2.4.1",
     "prettier-linter-helpers": "^1.0.0",
+    "react-refresh": "^0.14.2",
     "rimraf": "^3.0.2"
   },
   "overrides": {


### PR DESCRIPTION
## Tasks

- [x] I have signed a [Contributor License Agreement (CLA)](https://github.com/wpengine/faustjs#contributor-license-agreement) with WP Engine.
- [x] If a code change, I have written testing instructions that the whole team & outside contributors can understand.
- [x] I have written and included a comprehensive [changeset](https://github.com/wpengine/faustjs/blob/canary/DEVELOPMENT.md#deployment) to properly document the changes I've made.

## Description

Adds the `react-refresh` package, which is required during many builds, to avoid having to remember to manually install it when working with Faust. This should make it easier for new devs.
