### PR TITLE
Bug: Fixes issue with blocks not showing in the block editor when running blockset command on WP >=v6.5

### DIFF
--- a/.changeset/wet-ladybugs-rush.md
+++ b/.changeset/wet-ladybugs-rush.md
@@ -1,0 +1,5 @@
+---
+'@faustwp/wordpress-plugin': patch
+---
+
+Bug: Fixes issue with blocks not showing in the block editor when running blockset command on WP >=v6.5

--- a/plugins/faustwp/includes/blocks/functions.php
+++ b/plugins/faustwp/includes/blocks/functions.php
@@ -187,7 +187,7 @@ function register_block_asset( $metadata, $field_name, $block_name, $dependencie
 	}
 
 	// Generate a handle and register the asset.
-	$handle = $block_name . '-' . strtolower( $field_name );
+	$handle = generate_block_asset_handle( $metadata['name'], $field_name );
 	if ( strpos( strtolower( $field_name ), 'script' ) !== false ) {
 		wp_register_script( $handle, $full_url, $dependencies, $version, true );
 	} elseif ( strpos( strtolower( $field_name ), 'style' ) !== false ) {


### PR DESCRIPTION
## Tasks

- [ ] I have signed a [Contributor License Agreement (CLA)](https://github.com/wpengine/faustjs#contributor-license-agreement) with WP Engine.
- [ ] If a code change, I have written testing instructions that the whole team & outside contributors can understand.
- [ ] I have written and included a comprehensive [changeset](https://github.com/wpengine/faustjs/blob/canary/DEVELOPMENT.md#deployment) to properly document the changes I've made.

## Description

Fixes issue when blocks not showing in the block editor when running the `blockset` command on WP >=v6.5 

## Related Issue(s):

https://github.com/wpengine/faustjs/issues/1880

## Testing

1. Run `faust blockset` to publish blocks from the `examples/next/block-support` package on a Wordpress Version 6.5 or higher
2. Blocks should show in the editor list. Previously the blocks would not appear in this list.

## Screenshots

<!--
If this is a visual change include relevant screenshots about the behavior of the application before and after this change.
-->

## Documentation Changes

<!--
List corresponding changes to the documentation.
-->

## Dependant PRs

<!--
List any dependent PR's that are awaiting review. Use the following syntax:

- #1234
-->
