### PR TITLE
Fix: Ensure Accurate Detection of WordPress Previews via URL Query Parameters

### DIFF
--- a/.changeset/heavy-rats-enjoy.md
+++ b/.changeset/heavy-rats-enjoy.md
@@ -1,0 +1,5 @@
+---
+'@faustwp/core': patch
+---
+
+Bug: Fixes issue with review detection via query string is too greedy and catches non WP previews

--- a/packages/faustwp-core/src/components/WordPressTemplate.tsx
+++ b/packages/faustwp-core/src/components/WordPressTemplate.tsx
@@ -15,6 +15,7 @@ import { useAuth } from '../hooks/useAuth.js';
 import { SEED_QUERY, SeedNode } from '../queries/seedQuery.js';
 import { FaustContext, FaustQueries } from '../store/FaustContext.js';
 import { getQueryParam } from '../utils/convert.js';
+import { isWordPressPreview } from '../utils/isWordPressPreview.js';
 
 export type FaustProps = {
   __SEED_NODE__?: SeedNode | null;
@@ -204,9 +205,8 @@ export function WordPressTemplate(props: WordPressTemplateProps) {
       return;
     }
 
-    setIsPreview(window.location.search.includes('preview=true'));
+    setIsPreview(isWordPressPreview(window.location.search));
   }, []);
-
   /**
    * If we are on a preview route and there is no authenticated user, redirect
    * them to the login page

--- a/packages/faustwp-core/src/utils/isWordPressPreview.ts
+++ b/packages/faustwp-core/src/utils/isWordPressPreview.ts
@@ -1,0 +1,5 @@
+// Helper function to check if the URL is a WordPress preview
+export function isWordPressPreview(search: string) {
+  const params = new URLSearchParams(search);
+  return params.has('preview') && params.get('preview') === 'true';
+}

--- a/packages/faustwp-core/tests/components/WordPressTemplate.test.tsx
+++ b/packages/faustwp-core/tests/components/WordPressTemplate.test.tsx
@@ -27,56 +27,6 @@ describe('<WordPressTemplate />', () => {
     );
   });
 
-  test('Properly determines whether or not the given URL is a preview or not', async () => {
-    const getConfigSpy = jest.spyOn(getConfig, 'getConfig').mockReturnValue({
-      templates: {},
-    });
-
-    const useAuthSpy = jest.spyOn(useAuth, 'useAuth').mockReturnValue({
-      isAuthenticated: false,
-      isReady: true,
-      loginUrl: null,
-    });
-
-    delete (window as any).location;
-    window.location = new URL('http://localhost:3000') as any as Location;
-
-    const stringIncludesSpy = jest.spyOn(String.prototype, 'includes');
-
-    await act(async () => {
-      render(
-        <WordPressTemplate.WordPressTemplate
-          __SEED_NODE__={{ databaseId: '1' }}
-          __TEMPLATE_QUERY_DATA__={{ fakeData: true }}
-        />,
-      );
-    });
-
-    expect(window.location.search.includes).toHaveBeenLastCalledWith(
-      'preview=true',
-    );
-    expect(window.location.search.includes).toReturnWith(false);
-
-    delete (window as any).location;
-    window.location = new URL(
-      'http://localhost:3000?preview=true&p=40',
-    ) as any as Location;
-
-    await act(async () => {
-      render(
-        <WordPressTemplate.WordPressTemplate
-          __SEED_NODE__={{ databaseId: '1' }}
-          __TEMPLATE_QUERY_DATA__={{ fakeData: true }}
-        />,
-      );
-    });
-
-    expect(window.location.search.includes).toHaveBeenLastCalledWith(
-      'preview=true',
-    );
-    expect(window.location.search.includes).toReturnWith(true);
-  });
-
   test('Properly redirects to login URL on preview route with no logged in user', async () => {
     const getConfigSpy = jest.spyOn(getConfig, 'getConfig').mockReturnValue({
       templates: {},

--- a/packages/faustwp-core/tests/utils/isWordPressPreview.test.ts
+++ b/packages/faustwp-core/tests/utils/isWordPressPreview.test.ts
@@ -1,0 +1,23 @@
+import { isWordPressPreview } from '../../src/utils/isWordPressPreview';
+
+describe('isWordPressPreview', () => {
+  it('returns true if the search string contains preview=true', () => {
+    expect(isWordPressPreview('?preview=true')).toBe(true);
+    expect(isWordPressPreview('?foo=bar&preview=true')).toBe(true);
+  });
+
+  it('returns false if the search string does not contain preview=true', () => {
+    expect(isWordPressPreview('?preview=false')).toBe(false);
+    expect(isWordPressPreview('?foo=bar')).toBe(false);
+    expect(isWordPressPreview('?otpreview=true')).toBe(false);
+  });
+
+  it('returns false if the search string is empty', () => {
+    expect(isWordPressPreview('')).toBe(false);
+  });
+
+  it('returns false if the preview parameter is not exactly true', () => {
+    expect(isWordPressPreview('?preview=1')).toBe(false);
+    expect(isWordPressPreview('?preview=yes')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Tasks

- [ ] I have signed a [Contributor License Agreement (CLA)](https://github.com/wpengine/faustjs#contributor-license-agreement) with WP Engine.
- [ ] If a code change, I have written testing instructions that the whole team & outside contributors can understand.
- [ ] I have written and included a comprehensive [changeset](https://github.com/wpengine/faustjs/blob/canary/DEVELOPMENT.md#deployment) to properly document the changes I've made.

## Description

This PR addresses a bug in the WordPressTemplate component where the detection of WordPress preview URLs was overly broad, potentially catching non-WordPress preview URLs. The fix introduces a more precise method for determining if the URL is a WordPress preview.

## Related Issue(s):

https://github.com/wpengine/faustjs/issues/1903

## Problem
The previous implementation checked if the URL query string contained preview=true using a simple string includes method. This approach could incorrectly identify non-WordPress previews as WordPress previews if they happened to have a similar query parameter structure.

## Solution
* Introduced a utility function isWordPressPreview to accurately check for the presence of preview=true in the URL query parameters.
* Updated the WordPressTemplate component to use this utility function for determining if the URL is a WordPress preview.
* Refactored the related unit tests to reflect these changes and ensure comprehensive test coverage.


## Testing

Faust should not be redirecting logged out users (visitors) to the WP admin  if the page contains a search query that contains the string `preview=`.

For example:

http://localhost:3000/posts/add-table?otpreview=true

## Screenshots

<!--
If this is a visual change include relevant screenshots about the behavior of the application before and after this change.
-->

## Documentation Changes

<!--
List corresponding changes to the documentation.
-->

## Dependant PRs

<!--
List any dependent PR's that are awaiting review. Use the following syntax:

- #1234
-->
