### PR TITLE
fix: only remove non-faust Nav Menu locations if the user opts-in to it

### DIFF
--- a/.changeset/fast-queens-dress.md
+++ b/.changeset/fast-queens-dress.md
@@ -1,0 +1,5 @@
+---
+'@faustwp/wordpress-plugin': minor
+---
+
+Introduces a new setting on the Faust settings page that allows users to opt-in or out of Faust removing Nav Menu Locations that are not registered on the Faust Settings page.

--- a/.github/workflows/e2e-test-plugin.yml
+++ b/.github/workflows/e2e-test-plugin.yml
@@ -29,25 +29,25 @@ jobs:
       - name: Setup Containers
         working-directory: plugins/faustwp
         run: |
-          docker-compose build \
+          docker compose build \
             --build-arg WP_VERSION=6.4
-          docker-compose up -d
+          docker compose up -d
       - name: Sleep 15 seconds
         run: sleep 15
       - name: Maybe upgrade WP DB
         working-directory: plugins/faustwp
-        run: docker exec --workdir=/var/www/html/wp-content/plugins/faustwp $(docker-compose ps -q wordpress) wp core update-db --allow-root
+        run: docker exec --workdir=/var/www/html/wp-content/plugins/faustwp $(docker compose ps -q wordpress) wp core update-db --allow-root
       - name: Init Testing Environment
         working-directory: plugins/faustwp
-        run: docker exec --workdir=/var/www/html/wp-content/plugins/faustwp $(docker-compose ps -q wordpress) init-testing-environment.sh
+        run: docker exec --workdir=/var/www/html/wp-content/plugins/faustwp $(docker compose ps -q wordpress) init-testing-environment.sh
       - name: Install WP GraphQL
         working-directory: plugins/faustwp
         run: |
-          docker exec --workdir=/var/www/html/wp-content/plugins/faustwp $(docker-compose ps -q wordpress) wp plugin install wp-graphql --activate --allow-root
+          docker exec --workdir=/var/www/html/wp-content/plugins/faustwp $(docker compose ps -q wordpress) wp plugin install wp-graphql --activate --allow-root
       - name: Setup testing data
         working-directory: plugins/faustwp
         run: |
-          docker exec --workdir=/var/www/html/wp-content/plugins/faustwp $(docker-compose ps -q wordpress) wp db export tests/_data/dump.sql --allow-root
+          docker exec --workdir=/var/www/html/wp-content/plugins/faustwp $(docker compose ps -q wordpress) wp db export tests/_data/dump.sql --allow-root
       - name: Copy env file
         working-directory: plugins/faustwp
         run: cp .env.testing.example .env.testing

--- a/.github/workflows/unit-test-plugin-nightly.yml
+++ b/.github/workflows/unit-test-plugin-nightly.yml
@@ -16,9 +16,9 @@ jobs:
       - name: Create Docker Containers
         working-directory: ./plugins/faustwp
         run: |
-          docker-compose build \
+          docker compose build \
             --build-arg WP_VERSION=6.5
-          docker-compose up -d
+          docker compose up -d
 
       - name: Wait for db
         run: |
@@ -28,23 +28,23 @@ jobs:
 
       - name: Setup testing framework
         working-directory: ./plugins/faustwp
-        run: docker exec -e COVERAGE=1 $(docker-compose ps -q wordpress) init-testing-environment.sh
+        run: docker exec -e COVERAGE=1 $(docker compose ps -q wordpress) init-testing-environment.sh
 
       - name: Ensure Correct WordPress version
         working-directory: ./plugins/faustwp
         run: |
-            docker exec -w /var/www/html/wp-content/plugins/faustwp $(docker-compose ps -q wordpress) wp core version --allow-root
-            docker exec -w /var/www/html/wp-content/plugins/faustwp $(docker-compose ps -q wordpress) wp core upgrade --version=nightly --force --allow-root
-            docker exec -w /var/www/html/wp-content/plugins/faustwp $(docker-compose ps -q wordpress) wp core version --allow-root
+            docker exec -w /var/www/html/wp-content/plugins/faustwp $(docker compose ps -q wordpress) wp core version --allow-root
+            docker exec -w /var/www/html/wp-content/plugins/faustwp $(docker compose ps -q wordpress) wp core upgrade --version=nightly --force --allow-root
+            docker exec -w /var/www/html/wp-content/plugins/faustwp $(docker compose ps -q wordpress) wp core version --allow-root
 
       - name: Install and activate WP GraphQL
         working-directory: ./plugins/faustwp
-        run: docker exec -e COVERAGE=1 -w /var/www/html/wp-content/plugins/faustwp $(docker-compose ps -q wordpress) wp plugin install wp-graphql --activate --allow-root
+        run: docker exec -e COVERAGE=1 -w /var/www/html/wp-content/plugins/faustwp $(docker compose ps -q wordpress) wp plugin install wp-graphql --activate --allow-root
 
       - name: Install Dependencies
         working-directory: ./plugins/faustwp
-        run: docker exec -e COVERAGE=1 -w /var/www/html/wp-content/plugins/faustwp $(docker-compose ps -q wordpress) composer install
+        run: docker exec -e COVERAGE=1 -w /var/www/html/wp-content/plugins/faustwp $(docker compose ps -q wordpress) composer install
 
       - name: Run unit tests
         working-directory: ./plugins/faustwp
-        run: docker exec -e COVERAGE=1 -w /var/www/html/wp-content/plugins/faustwp $(docker-compose ps -q wordpress) composer test
+        run: docker exec -e COVERAGE=1 -w /var/www/html/wp-content/plugins/faustwp $(docker compose ps -q wordpress) composer test

--- a/.github/workflows/unit-test-plugin.yml
+++ b/.github/workflows/unit-test-plugin.yml
@@ -33,16 +33,16 @@ jobs:
 
       - name: Setup testing framework
         working-directory: ./plugins/faustwp
-        run: docker exec -e COVERAGE=1 $(docker-compose ps -q wordpress) init-testing-environment.sh
+        run: docker exec -e COVERAGE=1 $(docker compose ps -q wordpress) init-testing-environment.sh
 
       - name: Install and activate WP GraphQL
         working-directory: ./plugins/faustwp
-        run: docker exec -e COVERAGE=1 -w /var/www/html/wp-content/plugins/faustwp $(docker-compose ps -q wordpress) wp plugin install wp-graphql --activate --allow-root
+        run: docker exec -e COVERAGE=1 -w /var/www/html/wp-content/plugins/faustwp $(docker compose ps -q wordpress) wp plugin install wp-graphql --activate --allow-root
 
       - name: Install Dependencies
         working-directory: ./plugins/faustwp
-        run: docker exec -e COVERAGE=1 -w /var/www/html/wp-content/plugins/faustwp $(docker-compose ps -q wordpress) composer install
+        run: docker exec -e COVERAGE=1 -w /var/www/html/wp-content/plugins/faustwp $(docker compose ps -q wordpress) composer install
 
       - name: Run unit tests
         working-directory: ./plugins/faustwp
-        run: docker exec -e COVERAGE=1 -w /var/www/html/wp-content/plugins/faustwp $(docker-compose ps -q wordpress) composer test
+        run: docker exec -e COVERAGE=1 -w /var/www/html/wp-content/plugins/faustwp $(docker compose ps -q wordpress) composer test

--- a/.github/workflows/unit-test-plugin.yml
+++ b/.github/workflows/unit-test-plugin.yml
@@ -21,9 +21,9 @@ jobs:
           WP_VERSION: ${{ matrix.wordpress }}
         working-directory: ./plugins/faustwp
         run: |
-          docker-compose build \
+          docker compose build \
             --build-arg WP_VERSION=${{ matrix.wordpress }}
-          docker-compose up -d
+          docker compose up -d
 
       - name: Wait for db
         run: |

--- a/plugins/faustwp/includes/menus/callbacks.php
+++ b/plugins/faustwp/includes/menus/callbacks.php
@@ -23,7 +23,7 @@ function remove_menu_locations() {
 
 	$remove_menus = faustwp_get_setting( 'remove_additional_menu_locations', false );
 
-	// If additional menus are not set to be removed, do nothing
+	// If additional menus are not set to be removed, do nothing.
 	if ( false === $remove_menus ) {
 		return;
 	}

--- a/plugins/faustwp/includes/menus/callbacks.php
+++ b/plugins/faustwp/includes/menus/callbacks.php
@@ -20,6 +20,14 @@ add_action( 'after_setup_theme', __NAMESPACE__ . '\\remove_menu_locations', 100 
  * Unregisters menu locations such as those provided by the active PHP theme.
  */
 function remove_menu_locations() {
+
+	$remove_menus = faustwp_get_setting( 'remove_additional_menu_locations', false );
+
+	// If additional menus are not set to be removed, do nothing
+	if ( false === $remove_menus ) {
+		return;
+	}
+
 	$menus = array_keys( get_registered_nav_menus() );
 
 	array_walk( $menus, 'unregister_nav_menu' );

--- a/plugins/faustwp/includes/settings/callbacks.php
+++ b/plugins/faustwp/includes/settings/callbacks.php
@@ -160,6 +160,14 @@ function register_settings_fields() {
 	);
 
 	add_settings_field(
+		'remove_additional_menu_locations',
+		__( 'Remove Additional Nav Menu Locations', 'faustwp' ),
+		__NAMESPACE__ . '\\display_remove_additional_menu_locations_field',
+		'faustwp-settings',
+		'settings_section',
+	);
+
+	add_settings_field(
 		'enable_disable',
 		__( 'Features', 'faustwp' ),
 		__NAMESPACE__ . '\\display_enable_disable_fields',
@@ -214,6 +222,7 @@ function sanitize_faustwp_settings( $settings, $option ) {
 				$settings[ $name ] = sanitize_text_field( $value );
 				break;
 
+			case 'remove_additional_menu_locations':
 			case 'enable_redirects':
 			case 'enable_rewrites':
 			case 'disable_theme':
@@ -324,6 +333,16 @@ function display_menu_locations_field() {
 	<p class="description">
 		<?php esc_html_e( 'A comma-separated list of menu locations. Assign menus to locations at Appearance → Menus.', 'faustwp' ); ?>
 	</p>
+	<?php
+}
+
+function display_remove_additional_menu_locations_field() {
+	$removed = faustwp_get_setting( 'remove_additional_menu_locations', false );
+	?>
+	<label for="disable_theme">
+		<input type="checkbox" id="disable_theme" name="faustwp_settings[remove_additional_menu_locations]" value="1" <?php checked( $removed ); ?> /><?php esc_html_e( 'Remove all Nav Menu locations that are not registered on this screen.', 'faustwp' ); ?>
+		<p class="description"><?php esc_html_e( 'By checking this, the only Nav Menu locations will be the ones registered on this page. Leaving this un-checked will combine the menu locations on this page with menu locations registered by other plugins or themes. This has an impact on the nav menu manager in the WordPress admin and API access to menus.', 'faustwp' ); ?></p>
+	</label>
 	<?php
 }
 

--- a/plugins/faustwp/includes/settings/callbacks.php
+++ b/plugins/faustwp/includes/settings/callbacks.php
@@ -339,8 +339,8 @@ function display_menu_locations_field() {
 function display_remove_additional_menu_locations_field() {
 	$removed = faustwp_get_setting( 'remove_additional_menu_locations', false );
 	?>
-	<label for="disable_theme">
-		<input type="checkbox" id="disable_theme" name="faustwp_settings[remove_additional_menu_locations]" value="1" <?php checked( $removed ); ?> /><?php esc_html_e( 'Remove all Nav Menu locations that are not registered on this screen.', 'faustwp' ); ?>
+	<label for="remove_additional_menu_locations">
+		<input type="checkbox" id="remove_additional_menu_locations" name="faustwp_settings[remove_additional_menu_locations]" value="1" <?php checked( $removed ); ?> /><?php esc_html_e( 'Remove all Nav Menu locations that are not registered on this screen.', 'faustwp' ); ?>
 		<p class="description"><?php esc_html_e( 'By checking this, the only Nav Menu locations will be the ones registered on this page. Leaving this un-checked will combine the menu locations on this page with menu locations registered by other plugins or themes. This has an impact on the nav menu manager in the WordPress admin and API access to menus.', 'faustwp' ); ?></p>
 	</label>
 	<?php

--- a/plugins/faustwp/includes/settings/callbacks.php
+++ b/plugins/faustwp/includes/settings/callbacks.php
@@ -164,7 +164,7 @@ function register_settings_fields() {
 		__( 'Remove Additional Nav Menu Locations', 'faustwp' ),
 		__NAMESPACE__ . '\\display_remove_additional_menu_locations_field',
 		'faustwp-settings',
-		'settings_section',
+		'settings_section'
 	);
 
 	add_settings_field(
@@ -336,6 +336,13 @@ function display_menu_locations_field() {
 	<?php
 }
 
+/**
+ * Callback for WordPress add_settings_field() method parameter.
+ *
+ * Display the "Remove Additional Menu Locations" checkbox field.
+ *
+ * @return void
+ */
 function display_remove_additional_menu_locations_field() {
 	$removed = faustwp_get_setting( 'remove_additional_menu_locations', false );
 	?>

--- a/plugins/faustwp/tests/acceptance/SettingsCest.php
+++ b/plugins/faustwp/tests/acceptance/SettingsCest.php
@@ -133,7 +133,7 @@ class SettingsCest
 		$I->amOnFaustWPSettingsPage();
 
 		$I->dontSeeCheckboxIsChecked('#remove_additional_menu_locations');
-		$I->checkField('#remove_additional_menu_locations');
+		$I->checkOption('#remove_additional_menu_locations');
 		$I->click("Save Changes");
 
 		$I->see("Settings saved.");

--- a/plugins/faustwp/tests/acceptance/SettingsCest.php
+++ b/plugins/faustwp/tests/acceptance/SettingsCest.php
@@ -126,4 +126,17 @@ class SettingsCest
         $I->cancelPopup();
         $I->seeInField('faustwp_settings[secret_key]', $secret_key);
     }
+
+	public function i_can_check_remove_all_nav_menus_not_registered_by_faust(AcceptanceTester $I)
+	{
+		$I->loginAsAdmin();
+		$I->amOnFaustWPSettingsPage();
+
+		$I->dontSeeCheckboxIsChecked('#remove_additional_menu_locations');
+		$I->checkField('#remove_additional_menu_locations');
+		$I->click("Save Changes");
+
+		$I->see("Settings saved.");
+		$I->seeCheckboxIsChecked('#remove_additional_menu_locations');
+	}
 }


### PR DESCRIPTION
## Description

Currently when the FaustWP plugin is active, all registered Nav Menu locations are removed. 

While some users want to use Faust to manage their menu locations, some users manage menu locations in code or using other plugins and do not want Faust to remove all other menu locations. 

This PR adds a new setting that allows user to opt-in or out of the removal of non-Faust Nav Menu locations.

## Related Issue(s):

closes #1925 

## Testing


With the following code in place: 

```php
function register_my_menus() {
    register_nav_menu( 'test-primary', __( 'Test Primary Menu' ) );
}
add_action( 'after_setup_theme', 'register_my_menus' );
```

If the setting is checked:

![CleanShot 2024-08-05 at 10 50 18@2x](https://github.com/user-attachments/assets/8fe129e5-2586-4ba3-92a4-b41c3657a753)

Then I have only the 2 Faust registered menus in the WP Nav Menu Manager:

![CleanShot 2024-08-05 at 10 53 31@2x](https://github.com/user-attachments/assets/59941b1d-2640-42c9-841c-a140e1c3f6ec)

And if the setting is NOT checked:

![CleanShot 2024-08-05 at 10 53 17@2x](https://github.com/user-attachments/assets/914ab6a3-7a09-42dd-8ce3-0c7186802d11)

Then I have the 2 Faust Menus as well as the menu registered via custom code

![CleanShot 2024-08-05 at 10 53 09@2x](https://github.com/user-attachments/assets/335c7f1d-174b-491a-b3ba-d9b4e1b54e94)




## Documentation Changes



## Dependant PRs

n/a
