### PR TITLE
Introduce configurable "sitemap index path" for enhanced plugin compatibility

### DIFF
--- a/.changeset/long-humans-type.md
+++ b/.changeset/long-humans-type.md
@@ -1,0 +1,19 @@
+---
+'@faustwp/core': minor
+---
+
+- Added support for configuring a custom sitemap index path via the `sitemapIndexPath` option in `getSitemapProps`, enhancing compatibility with plugins like RankMath that modify the default sitemap path.
+
+  ```javascript
+  import { getSitemapProps } from '@faustwp/core';
+
+  export default function Sitemap() {}
+
+  export function getServerSideProps(ctx) {
+    return getSitemapProps(ctx, {
+      sitemapIndexPath: '/sitemap_index.xml', // RankMath changes the default sitemap path to this
+      frontendUrl: process.env.NEXT_PUBLIC_SITE_URL,
+      sitemapPathsToIgnore: ['/wp-sitemap-users-*'],
+    });
+  }
+  ```

--- a/examples/next/block-support/.env.local.sample
+++ b/examples/next/block-support/.env.local.sample
@@ -3,3 +3,6 @@ NEXT_PUBLIC_WORDPRESS_URL=https://faustexample.wpengine.com
 
 # Plugin secret found in WordPress Settings->Faust
 # FAUST_SECRET_KEY=YOUR_PLUGIN_SECRET
+
+# Needed for sitemaps (no naming requirements for this, NEXT_PUBLIC_SITE_URL is just an example)
+NEXT_PUBLIC_SITE_URL=http://localhost:3000

--- a/examples/next/block-support/pages/sitemap.xml.js
+++ b/examples/next/block-support/pages/sitemap.xml.js
@@ -1,0 +1,11 @@
+import { getSitemapProps } from '@faustwp/core';
+
+export default function Sitemap() {}
+
+export function getServerSideProps(ctx) {
+  return getSitemapProps(ctx, {
+    // sitemapIndexPath: '/sitemap_index.xml', // Update the sitemap path if a WordPress plugin is used that changes the default path.
+    frontendUrl: process.env.NEXT_PUBLIC_SITE_URL,
+    sitemapPathsToIgnore: ['/wp-sitemap-users-*'],
+  });
+}

--- a/packages/faustwp-core/src/server/sitemaps/createSitemaps.ts
+++ b/packages/faustwp-core/src/server/sitemaps/createSitemaps.ts
@@ -56,7 +56,7 @@ export async function createRootSitemapIndex(
   req: NextRequest | IncomingMessage,
   config: GetSitemapPropsConfig,
 ): Promise<Response | undefined> {
-  const { pages, sitemapPathsToIgnore, frontendUrl } = config;
+  const { pages, sitemapPathsToIgnore, frontendUrl, sitemapIndexPath } = config;
 
   if (!req.url) {
     throw new Error('Request object must have URL');
@@ -66,7 +66,7 @@ export async function createRootSitemapIndex(
   // fetch sitemap from WP
   const trimmedWpUrl = trim(getWpUrl(), '/');
   const trimmedFrontendUrl = trim(frontendUrl, '/');
-  const trimmedSitemapIndexPath = trim(SITEMAP_INDEX_PATH, '/');
+  const trimmedSitemapIndexPath = trim(sitemapIndexPath || SITEMAP_INDEX_PATH, '/');
   const wpSitemapUrl = `${trimmedWpUrl}/${trimmedSitemapIndexPath}`;
 
   let sitemaps: SitemapSchemaSitemapElement[] = [];
@@ -90,6 +90,11 @@ export async function createRootSitemapIndex(
 
   // Don't proxy the sitemap index if the response was not ok.
   if (!res.ok) {
+    console.error(`Failed to fetch sitemap index from WordPress at ${wpSitemapUrl}`);
+    console.error('Possible solutions:');
+    console.error('- Check that sitemapIndexPath is correct in the options passed to getSitemapProps. (some WordPress plugins change the default sitemap path)');
+    console.error(`- Consider flushing permalinks in WordPress.`)
+
     return undefined;
   }
 

--- a/packages/faustwp-core/src/server/sitemaps/createSitemaps.ts
+++ b/packages/faustwp-core/src/server/sitemaps/createSitemaps.ts
@@ -66,7 +66,10 @@ export async function createRootSitemapIndex(
   // fetch sitemap from WP
   const trimmedWpUrl = trim(getWpUrl(), '/');
   const trimmedFrontendUrl = trim(frontendUrl, '/');
-  const trimmedSitemapIndexPath = trim(sitemapIndexPath || SITEMAP_INDEX_PATH, '/');
+  const trimmedSitemapIndexPath = trim(
+    sitemapIndexPath || SITEMAP_INDEX_PATH,
+    '/',
+  );
   const wpSitemapUrl = `${trimmedWpUrl}/${trimmedSitemapIndexPath}`;
 
   let sitemaps: SitemapSchemaSitemapElement[] = [];
@@ -90,10 +93,14 @@ export async function createRootSitemapIndex(
 
   // Don't proxy the sitemap index if the response was not ok.
   if (!res.ok) {
-    console.error(`Failed to fetch sitemap index from WordPress at ${wpSitemapUrl}`);
+    console.error(
+      `Failed to fetch sitemap index from WordPress at ${wpSitemapUrl}`,
+    );
     console.error('Possible solutions:');
-    console.error('- Check that sitemapIndexPath is correct in the options passed to getSitemapProps. (some WordPress plugins change the default sitemap path)');
-    console.error(`- Consider flushing permalinks in WordPress.`)
+    console.error(
+      '- Check that sitemapIndexPath is correct in the options passed to getSitemapProps. (some WordPress plugins change the default sitemap path)',
+    );
+    console.error(`- Consider flushing permalinks in WordPress.`);
 
     return undefined;
   }

--- a/packages/faustwp-core/src/server/sitemaps/getSitemapProps.tsx
+++ b/packages/faustwp-core/src/server/sitemaps/getSitemapProps.tsx
@@ -44,6 +44,10 @@ export type GetSitemapPropsConfig = {
    */
   sitemapPathsToIgnore?: string[];
   /**
+   * The path to the sitemap index file in WordPress.
+   */
+  sitemapIndexPath?: string;
+  /**
    * Next.js pages you want included in you sitemap. When provided, an index
    * will be created specifically for these pages.
    */


### PR DESCRIPTION
## Description

This PR introduces a new feature allowing the configuration of a custom sitemap index path via the `sitemapIndexPath` option in the getSitemapProps function. This is particularly useful for ensuring compatibility with WordPress plugins like RankMath that modify the default sitemap path.

To configure a custom sitemap index path, update your getServerSideProps function in your Next.js page as follows:

```js
import { getSitemapProps } from '@faustwp/core';

export default function Sitemap() {}

export function getServerSideProps(ctx) {
  return getSitemapProps(ctx, {
    sitemapIndexPath: '/sitemap_index.xml', // Specify the custom sitemap index path
    frontendUrl: process.env.NEXT_PUBLIC_SITE_URL,
  });
}
```

This is particularly useful when using WordPress plugins like RankMath that change the default sitemap path from `/wp-sitemap.xml` to another path, such as `/sitemap_index.xml`.

## Related Issue(s):

- #1885

## Testing

1. Enable RankMath and ensure it changes the sitemap index path to `/sitemap_index.xml`.
2. Update getServerSideProps with sitemapIndexPath: `/sitemap_index.xml`.
3. Deploy the application.
4. Visit /sitemap.xml and verify the sitemap loads correctly.
5. Confirm all expected URLs are present and no 404 errors occur.
