### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 # Code Owners
-*       @wpengine/merlin
+*       @wpengine/headless-open-source
 
 # jira:[18721] is where issues related to this repository should be ticketed


### PR DESCRIPTION
These changes update the codeownership to "@wpengine/headless-open-source"