### PR TITLE
fix: cannot query field "align" on type "CoreQuoteAttributes"'

### DIFF
--- a/.changeset/smart-pumas-act.md
+++ b/.changeset/smart-pumas-act.md
@@ -3,3 +3,5 @@
 ---
 
 Updates the GraphQL fragment associated with the CoreQuote component to be compatible with WordPress 6.6
+
+Adds `legacyBehavior` to CoreButton link to work on Next.js v13.

--- a/.changeset/smart-pumas-act.md
+++ b/.changeset/smart-pumas-act.md
@@ -1,0 +1,5 @@
+---
+'@faustwp/blocks': major
+---
+
+Updates the GraphQL fragment associated with the CoreQuote component to be compatible with WordPress 6.6

--- a/packages/blocks/src/blocks/CoreButton.tsx
+++ b/packages/blocks/src/blocks/CoreButton.tsx
@@ -35,7 +35,7 @@ export function CoreButton(props: CoreButtonFragmentProps) {
         aria-label={attributes?.text}
         id={attributes?.anchor}
         className={attributes?.cssClassName}>
-        <Link href={attributes?.url}>
+        <Link legacyBehavior href={attributes?.url}>
           <a
             target={linkTarget}
             className={attributes?.linkClassName}

--- a/packages/blocks/src/blocks/CoreQuote.tsx
+++ b/packages/blocks/src/blocks/CoreQuote.tsx
@@ -6,7 +6,7 @@ import { getStyles } from '../utils/index.js';
 
 export type CoreQuoteFragmentProps = ContentBlock & {
   attributes?: {
-    align?: string;
+    textAlign?: string;
     anchor?: string;
     backgroundColor?: string;
     citation?: string;

--- a/packages/blocks/src/blocks/CoreQuote.tsx
+++ b/packages/blocks/src/blocks/CoreQuote.tsx
@@ -52,7 +52,7 @@ CoreQuote.fragments = {
   entry: gql`
     fragment CoreQuoteBlockFragment on CoreQuote {
       attributes {
-        align
+        textAlign
         anchor
         backgroundColor
         citation


### PR DESCRIPTION
## Description

- update query fragment on CoreQuote to be compatible with WordPress 6.6

## Related Issue(s):

closes #1932 
