### PR TITLE
Update "tested up to" version for faustwp WordPress plugin.

### DIFF
--- a/.changeset/poor-cats-arrive.md
+++ b/.changeset/poor-cats-arrive.md
@@ -1,0 +1,5 @@
+---
+'@faustwp/wordpress-plugin': patch
+---
+
+Tested up to WordPress v6.6.1

--- a/plugins/faustwp/readme.txt
+++ b/plugins/faustwp/readme.txt
@@ -2,7 +2,7 @@
 Contributors: antpb, apmatthe, blakewpe, chriswiegman, claygriffiths, jasonkonen, joefusco, markkelnar, matthewguywright, mindctrl, modernnerd, rfmeier, TeresaGobble, thdespou, wpengine
 Tags: faustjs, faust, headless, decoupled, composable-architecture
 Requires at least: 5.7
-Tested up to: 6.5
+Tested up to: 6.6.1
 Stable tag: 1.4.0
 Requires PHP: 7.2
 License: GPLv2 or later


### PR DESCRIPTION
This PR is a follow up to https://github.com/wpengine/faustjs/pull/1928, aiming to kick off a new deploy of the plugin to WordPress.org that was previously failing.