### PR TITLE
fix(cli): #1966 Migrates blockset command dependency to use glob now …

### DIFF
--- a/.changeset/tender-beers-shout.md
+++ b/.changeset/tender-beers-shout.md
@@ -1,0 +1,5 @@
+---
+'@faustwp/cli': patch
+---
+
+Migrates blockset command dependency to use glob now supporting Promises and resolving error coming from now deprecated glob-promise dependency

--- a/package-lock.json
+++ b/package-lock.json
@@ -9357,6 +9357,7 @@
     },
     "node_modules/@types/minimatch": {
       "version": "5.1.2",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/minimist": {
@@ -16514,31 +16515,6 @@
       },
       "engines": {
         "node": ">=10.13.0"
-      }
-    },
-    "node_modules/glob-promise": {
-      "version": "6.0.5",
-      "license": "MIT",
-      "dependencies": {
-        "@types/glob": "^8.0.0"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "type": "individual",
-        "url": "https://github.com/sponsors/ahmadnassri"
-      },
-      "peerDependencies": {
-        "glob": "^8.0.3"
-      }
-    },
-    "node_modules/glob-promise/node_modules/@types/glob": {
-      "version": "8.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "@types/minimatch": "^5.1.2",
-        "@types/node": "*"
       }
     },
     "node_modules/glob-to-regexp": {
@@ -31646,7 +31622,6 @@
         "form-data": "^4.0.0",
         "fs-extra": "^11.1.1",
         "glob": "^10.3",
-        "glob-promise": "^6.0.5",
         "isomorphic-fetch": "^3.0.0",
         "lodash": "^4.17.21",
         "webpack-cli": "5.1.4"
@@ -36085,7 +36060,7 @@
     },
     "plugins/faustwp": {
       "name": "@faustwp/wordpress-plugin",
-      "version": "1.4.1"
+      "version": "1.5.0"
     }
   }
 }

--- a/packages/faustwp-cli/package.json
+++ b/packages/faustwp-cli/package.json
@@ -30,7 +30,6 @@
     "form-data": "^4.0.0",
     "fs-extra": "^11.1.1",
     "glob": "^10.3",
-    "glob-promise": "^6.0.5",
     "isomorphic-fetch": "^3.0.0",
     "lodash": "^4.17.21",
     "webpack-cli": "5.1.4"

--- a/packages/faustwp-cli/src/blockset.ts
+++ b/packages/faustwp-cli/src/blockset.ts
@@ -1,7 +1,7 @@
 import fetch from 'isomorphic-fetch';
 import path from 'path';
 import fs from 'fs-extra';
-import glob from 'glob-promise';
+import { glob } from 'glob';
 import FormData from 'form-data';
 import archiver from 'archiver';
 import { spawnSync } from 'child_process';


### PR DESCRIPTION
Migrates `blockset` command dependency to use the `glob` package directly now supporting Promises and resolving the existing error coming from now deprecated glob-promise dependency used in @faustwp/cli