### PR TITLE
Adding a filter for optional change of public redirect status codes

### DIFF
--- a/.changeset/tasty-walls-thank.md
+++ b/.changeset/tasty-walls-thank.md
@@ -1,0 +1,5 @@
+---
+'@faustwp/wordpress-plugin': minor
+---
+
+Added new filter `faustwp_public_redirect_status_code`, allowing WordPress plugins and themes to choose the [HTTP status code](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status) to use when generating redirects when the [enable public route redirects](https://faustjs.org/docs/faustwp/settings#enabling-public-route-redirects) setting is active.

--- a/plugins/faustwp/includes/deny-public-access/callbacks.php
+++ b/plugins/faustwp/includes/deny-public-access/callbacks.php
@@ -60,7 +60,7 @@ function deny_public_access() {
 	// Get the request uri with query params.
 	$request_uri = home_url( add_query_arg( null, null ) );
 
-	$response_code = 302;
+	$response_code = apply_filters( 'faustwp_public_redirect_status_code', 302 );
 	$redirect_url  = str_replace( trailingslashit( get_home_url() ), $frontend_uri, $request_uri );
 	$protocols     = array( 'http', 'https' );
 


### PR DESCRIPTION
Adding support for users to change the redirect status code from a `302` to another code of their choice, likely `301`.

## Tasks

- [x] I have signed a [Contributor License Agreement (CLA)](https://github.com/wpengine/faustjs#contributor-license-agreement) with WP Engine.
- [x] If a code change, I have written testing instructions that the whole team & outside contributors can understand.
- [x] I have written and included a comprehensive [changeset](https://github.com/wpengine/faustjs/blob/canary/DEVELOPMENT.md#deployment) to properly document the changes I've made.

## Description

Added new filter `faustwp_public_redirect_status_code`, allowing WordPress plugins and themes to choose the [HTTP status code](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status) to use when generating redirects when the [enable public route redirects](https://faustjs.org/docs/faustwp/settings#enabling-public-route-redirects) setting is active.

## Related Issue(s):

None

## Testing

I added this locally and ensured that the redirects were still `302` status codes.  I then added this in my theme's `functions.php` file to test it

```php
add_filter('faustwp_public_redirect_status_code', function ($status_code) {
	return 301;
}, 10, 1);
```

Then I tried calling the exact same URL which resulted in a `301` status code with _no change_ to other headers including the `x-redirect-by: WP Engine Headless plugin` header

## Screenshots

none

## Documentation Changes

There is nowhere in the repo docs that cover this functionality but there _is_ the following on the live site:

https://faustjs.org/reference/faust-wordpress-plugin-filters

So I am writing here markdown that will get you close, if not all the way to an update for that page which i do not know how to edit:

`faustwp_exclude_from_public_redirect`: Choose the [HTTP status code](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status) to use when generating redirects when the [enable public route redirects](https://faustjs.org/docs/faustwp/settings#enabling-public-route-redirects) setting is active.

Parameter: $status_code (int): HTTP Status code to use on redirects. Default: `302`

Example Usage
```php
// Make the homepage redirect 301 while all others remain unchanged
add_filter('faustwp_public_redirect_status_code', function ($status_code) {
  if(is_front_page()){
    return 301;
  }
  return $status_code;
}, 10, 1);
```


## Dependant PRs

none