### PR TITLE
fix(FeaturedImage): prevent simultaneous width and fill props usage

### DIFF
--- a/examples/next/faustwp-getting-started/components/FeaturedImage/FeaturedImage.js
+++ b/examples/next/faustwp-getting-started/components/FeaturedImage/FeaturedImage.js
@@ -10,25 +10,33 @@ export default function FeaturedImage({
   ...props
 }) {
   const src = image?.sourceUrl;
-  const { altText } = image || '';
 
-  width = width ? width : image?.mediaDetails?.width;
-  height = height ? height : image?.mediaDetails?.height;
+  if (!src) return null;
+
+  const { altText = '', mediaDetails = {} } = image ?? {};
+
   layout = layout ?? 'fill';
 
-  return src && width && height ? (
+  const dimensions = {
+    width: layout === 'fill' ? undefined : width ?? mediaDetails?.width,
+    height: layout === 'fill' ? undefined : height ?? mediaDetails?.height
+  };
+
+  if (layout !== 'fill' && (!dimensions.width || !dimensions.height)) return null;
+
+  return (
     <figure className={className}>
       <Image
         src={src}
         alt={altText}
-        layout={layout}
-        width={width}
-        height={height}
+        fill={layout}
+        width={dimensions.width}
+        height={dimensions.height}
         priority={priority}
         {...props}
       />
     </figure>
-  ) : null;
+  );
 }
 
 FeaturedImage.fragments = {


### PR DESCRIPTION
## Description

This PR fixes the issue where the FeaturedImage component from the example was experiencing conflicts between width and fill properties. The error occurred when both properties were being passed simultaneously.

Changes made:

- Prevented simultaneous usage of width and fill properties
- Added proper property validation
- Updated the layout handling logic to ensure these props are mutually exclusive

## Testing

Local Testing:

`npm run dev`

- Navigate to pages with FeaturedImage components
- Verify images render correctly with 'fill' layout
- Verify images render correctly with explicit width/height

## Screenshots

<img width="1059" alt="Screenshot 2024-12-09 at 10 40 46" src="https://github.com/user-attachments/assets/78394120-cb19-4260-bf80-510ad757d4e1" />


