### PR TITLE
Bug:  Fixing null/undefined theme argument for the WordPressBlocksProvider

### DIFF
--- a/.changeset/afraid-terms-shake.md
+++ b/.changeset/afraid-terms-shake.md
@@ -1,0 +1,5 @@
+---
+"@faustwp/blocks": patch
+---
+
+Bug:  Fixed an issue an issue with WordPressBlocksProvider and the theme argument to allow it to be optional and not throw an error. By default theme is now an empty object

--- a/packages/blocks/src/components/WordPressBlocksProvider.tsx
+++ b/packages/blocks/src/components/WordPressBlocksProvider.tsx
@@ -69,17 +69,19 @@ export function WordPressBlocksProvider(props: {
  * ```
  */
 export function useBlocksTheme(): BlocksTheme {
-
   // If it's an empty object, the provider hasn't been initialized.±
-	if (typeof WordPressBlocksContext === 'undefined' || typeof WordPressBlocksContext === 'undefined') {
-		throw new Error(
+  if (
+    typeof WordPressBlocksContext === 'undefined' ||
+    typeof WordPressBlocksContext === 'undefined'
+  ) {
+    throw new Error(
       'useBlocksTheme hook was called outside of context, make sure your app is wrapped with WordPressBlocksProvider',
     );
-	}
+  }
 
   const themeContext = React.useContext(WordPressThemeContext);
-	if (typeof themeContext === 'undefined') {
-		throw new Error(
+  if (typeof themeContext === 'undefined') {
+    throw new Error(
       'useBlocksTheme hook was called outside of context, make sure your app is wrapped with WordPressBlocksProvider',
     );
   }

--- a/packages/blocks/src/components/WordPressBlocksProvider.tsx
+++ b/packages/blocks/src/components/WordPressBlocksProvider.tsx
@@ -70,6 +70,7 @@ export function WordPressBlocksProvider(props: {
  */
 export function useBlocksTheme(): BlocksTheme {
 
+
   // If it's an empty object, the provider hasn't been initialized.
   if (WordPressBlocksContext == null || WordPressThemeContext == null) {
     throw new Error(
@@ -77,5 +78,12 @@ export function useBlocksTheme(): BlocksTheme {
     );
   }
 
-  return React.useContext(WordPressThemeContext);
+  const themeContext = React.useContext(WordPressThemeContext);
+  if (themeContext == null) {
+    throw new Error(
+      'useBlocksTheme hook was called outside of context, make sure your app is wrapped with WordPressBlocksProvider',
+    );
+  }
+
+  return themeContext;
 }

--- a/packages/blocks/src/components/WordPressBlocksProvider.tsx
+++ b/packages/blocks/src/components/WordPressBlocksProvider.tsx
@@ -68,21 +68,23 @@ export function WordPressBlocksProvider(props: {
  * const theme = useBlocksTheme();
  * ```
  */
-export function useBlocksTheme(): BlocksTheme {
+export function useBlocksTheme(): BlocksTheme | null {
 
-
-  // If it's an empty object, the provider hasn't been initialized.
-  if (WordPressBlocksContext == null || WordPressThemeContext == null) {
-    throw new Error(
+  // If it's an empty object, the provider hasn't been initialized.±
+	if (typeof WordPressBlocksContext === 'undefined') {
+		throw new Error(
       'useBlocksTheme hook was called outside of context, make sure your app is wrapped with WordPressBlocksProvider',
     );
+	}
+
+	// Theme is optional
+	if (typeof WordPressBlocksContext === 'undefined' || WordPressBlocksContext === null) {
+		return null;
   }
 
   const themeContext = React.useContext(WordPressThemeContext);
-  if (themeContext == null) {
-    throw new Error(
-      'useBlocksTheme hook was called outside of context, make sure your app is wrapped with WordPressBlocksProvider',
-    );
+	if (typeof themeContext === 'undefined' || themeContext === null) {
+		return null;
   }
 
   return themeContext;

--- a/packages/blocks/src/components/WordPressBlocksProvider.tsx
+++ b/packages/blocks/src/components/WordPressBlocksProvider.tsx
@@ -69,14 +69,13 @@ export function WordPressBlocksProvider(props: {
  * ```
  */
 export function useBlocksTheme(): BlocksTheme {
-  const themeContext = React.useContext(WordPressThemeContext);
 
   // If it's an empty object, the provider hasn't been initialized.
-  if (themeContext === undefined) {
+  if (WordPressBlocksContext == null || WordPressThemeContext == null) {
     throw new Error(
       'useBlocksTheme hook was called outside of context, make sure your app is wrapped with WordPressBlocksProvider',
     );
   }
 
-  return themeContext;
+  return React.useContext(WordPressThemeContext);;
 }

--- a/packages/blocks/src/components/WordPressBlocksProvider.tsx
+++ b/packages/blocks/src/components/WordPressBlocksProvider.tsx
@@ -77,5 +77,5 @@ export function useBlocksTheme(): BlocksTheme {
     );
   }
 
-  return React.useContext(WordPressThemeContext);;
+  return React.useContext(WordPressThemeContext);
 }

--- a/packages/blocks/src/components/WordPressBlocksProvider.tsx
+++ b/packages/blocks/src/components/WordPressBlocksProvider.tsx
@@ -68,23 +68,20 @@ export function WordPressBlocksProvider(props: {
  * const theme = useBlocksTheme();
  * ```
  */
-export function useBlocksTheme(): BlocksTheme | null {
+export function useBlocksTheme(): BlocksTheme {
 
   // If it's an empty object, the provider hasn't been initialized.±
-	if (typeof WordPressBlocksContext === 'undefined') {
+	if (typeof WordPressBlocksContext === 'undefined' || typeof WordPressBlocksContext === 'undefined') {
 		throw new Error(
       'useBlocksTheme hook was called outside of context, make sure your app is wrapped with WordPressBlocksProvider',
     );
 	}
 
-	// Theme is optional
-	if (typeof WordPressBlocksContext === 'undefined' || WordPressBlocksContext === null) {
-		return null;
-  }
-
   const themeContext = React.useContext(WordPressThemeContext);
-	if (typeof themeContext === 'undefined' || themeContext === null) {
-		return null;
+	if (typeof themeContext === 'undefined') {
+		throw new Error(
+      'useBlocksTheme hook was called outside of context, make sure your app is wrapped with WordPressBlocksProvider',
+    );
   }
 
   return themeContext;

--- a/packages/blocks/src/components/WordPressBlocksProvider.tsx
+++ b/packages/blocks/src/components/WordPressBlocksProvider.tsx
@@ -72,7 +72,7 @@ export function useBlocksTheme(): BlocksTheme {
   // If it's an empty object, the provider hasn't been initialized.±
   if (
     typeof WordPressBlocksContext === 'undefined' ||
-    typeof WordPressBlocksContext === 'undefined'
+    typeof WordPressThemeContext === 'undefined'
   ) {
     throw new Error(
       'useBlocksTheme hook was called outside of context, make sure your app is wrapped with WordPressBlocksProvider',

--- a/packages/blocks/src/components/WordPressBlocksProvider.tsx
+++ b/packages/blocks/src/components/WordPressBlocksProvider.tsx
@@ -74,7 +74,7 @@ export function useBlocksTheme(): BlocksTheme {
   // If it's an empty object, the provider hasn't been initialized.
   if (themeContext === undefined) {
     throw new Error(
-      'Testing useBlocksTheme hook was called outside of context, make sure your app is wrapped with WordPressBlocksProvider',
+      'useBlocksTheme hook was called outside of context, make sure your app is wrapped with WordPressBlocksProvider',
     );
   }
 

--- a/packages/blocks/src/components/WordPressBlocksProvider.tsx
+++ b/packages/blocks/src/components/WordPressBlocksProvider.tsx
@@ -48,7 +48,7 @@ export function WordPressBlocksProvider(props: {
   config: WordPressBlocksProviderConfig;
 }) {
   const { children, config } = props;
-  const { blocks, theme } = config;
+  const { blocks, theme = {} } = config;
 
   return (
     <WordPressBlocksContext.Provider value={blocks}>
@@ -69,5 +69,14 @@ export function WordPressBlocksProvider(props: {
  * ```
  */
 export function useBlocksTheme(): BlocksTheme {
-  return React.useContext(WordPressThemeContext) as BlocksTheme;
+  const themeContext = React.useContext(WordPressThemeContext);
+
+  // If it's an empty object, the provider hasn't been initialized.
+  if (themeContext === undefined) {
+    throw new Error(
+      'Testing useBlocksTheme hook was called outside of context, make sure your app is wrapped with WordPressBlocksProvider',
+    );
+  }
+
+  return themeContext;
 }

--- a/packages/blocks/src/components/WordPressBlocksProvider.tsx
+++ b/packages/blocks/src/components/WordPressBlocksProvider.tsx
@@ -69,22 +69,5 @@ export function WordPressBlocksProvider(props: {
  * ```
  */
 export function useBlocksTheme(): BlocksTheme {
-  // If it's an empty object, the provider hasn't been initialized.±
-  if (
-    typeof WordPressBlocksContext === 'undefined' ||
-    typeof WordPressThemeContext === 'undefined'
-  ) {
-    throw new Error(
-      'useBlocksTheme hook was called outside of context, make sure your app is wrapped with WordPressBlocksProvider',
-    );
-  }
-
-  const themeContext = React.useContext(WordPressThemeContext);
-  if (typeof themeContext === 'undefined') {
-    throw new Error(
-      'useBlocksTheme hook was called outside of context, make sure your app is wrapped with WordPressBlocksProvider',
-    );
-  }
-
-  return themeContext;
+  return React.useContext(WordPressThemeContext);
 }

--- a/packages/blocks/src/components/WordPressBlocksProvider.tsx
+++ b/packages/blocks/src/components/WordPressBlocksProvider.tsx
@@ -69,5 +69,5 @@ export function WordPressBlocksProvider(props: {
  * ```
  */
 export function useBlocksTheme(): BlocksTheme {
-  return React.useContext(WordPressThemeContext);
+  return React.useContext(WordPressThemeContext) as BlocksTheme;
 }

--- a/packages/blocks/tests/components/WordPressBlocksProvider.test.tsx
+++ b/packages/blocks/tests/components/WordPressBlocksProvider.test.tsx
@@ -11,6 +11,13 @@ import type { BlocksTheme } from '../../src/types/theme';
 import { renderHook } from '@testing-library/react';  // Import from @testing-library/react
 
 describe('useBlocksTheme', () => {
+  it('Throws an error if not used within WordPressBlocksProvider', () => {
+    // Assert that renderHook throws an error when used outside of WordPressBlocksProvider
+    expect(() => {
+      renderHook(() => useBlocksTheme());
+    }).toThrow('useBlocksTheme hook was called outside of context, make sure your app is wrapped with WordPressBlocksProvider');
+  });
+
   it('returns the passed in theme from WordPressBlocksProvider', () => {
     // Wrapping component to provide context
     const wrapper = ({ children }: PropsWithChildren<{}>) => {

--- a/packages/blocks/tests/components/WordPressBlocksProvider.test.tsx
+++ b/packages/blocks/tests/components/WordPressBlocksProvider.test.tsx
@@ -11,13 +11,6 @@ import type { BlocksTheme } from '../../src/types/theme';
 import { renderHook } from '@testing-library/react';  // Import from @testing-library/react
 
 describe('useBlocksTheme', () => {
-  it('Throws an error if not used within WordPressBlocksProvider', () => {
-    // Assert that renderHook throws an error when used outside of WordPressBlocksProvider
-    expect(() => {
-      renderHook(() => useBlocksTheme());
-    }).toThrow('useBlocksTheme hook was called outside of context, make sure your app is wrapped with WordPressBlocksProvider');
-  });
-
   it('returns the passed in theme from WordPressBlocksProvider', () => {
     // Wrapping component to provide context
     const wrapper = ({ children }: PropsWithChildren<{}>) => {


### PR DESCRIPTION
## Tasks

- [x] I have signed a [Contributor License Agreement (CLA)](https://github.com/wpengine/faustjs#contributor-license-agreement) with WP Engine.
- [x] If a code change, I have written testing instructions that the whole team & outside contributors can understand.
- [x] I have written and included a comprehensive [changeset](https://github.com/wpengine/faustjs/blob/canary/DEVELOPMENT.md#deployment) to properly document the changes I've made.

## Description

Fixed an issue with the theme argument for the WordPressBlockProvider to allow for null or undefined #1986

The condition to check if WordPressThemeContext is not needed as theme is an optional argument as per our docs - https://faustjs.org/reference/wordpressblocksprovider

e.g.

```js
      <WordPressBlocksProvider
        config={{
          blocks,
          theme: null
        }}>
        <Component {...pageProps} key={router.asPath} />
      </WordPressBlocksProvider>
```

So setting the theme argument null, undefined or not at all should not result in an error.


### How to replicate the issue

If you setup an Next.js app with Faust Blocks you should be able to replicate the error.


```bash
cd directory/
npx create-next-app@latest
cd my-app #assuming you set my-app as the project name
npm install @faustwp/blocks
```

**src/pages/_app.js**
```js
import "@/styles/globals.css";
import { WordPressBlocksProvider } from "@faustwp/blocks";
import blocks from "../wp-blocks";


export default function App({ Component, pageProps }) {

  return (
    <WordPressBlocksProvider config={{ blocks, theme: undefined}}>
      <Component {...pageProps} />
    </WordPressBlocksProvider>
  );
}
```


**src/pages/index.js**
```js
import { WordPressBlocksViewer } from "@faustwp/blocks";

export default function Home() {
  return (
    <div>
      <h1>Home</h1>
      <WordPressBlocksViewer blocks={
[
  {
    "name": "core/paragraph",
    "__typename": "CoreParagraph",
    "apiVersion": 3,
    "isDynamic": false,
    "attributes": {
      "cssClassName": null,
      "backgroundColor": null,
      "content": "A JavaScript framework that makes building headless WordPress simple and easy.",
      "style": null,
      "textColor": null,
      "fontSize": null,
      "fontFamily": null,
      "direction": null,
      "dropCap": false,
      "gradient": null,
      "align": null
    }
  },
  {
    "name": "core/paragraph",
    "__typename": "CoreParagraph",
    "apiVersion": 3,
    "isDynamic": false,
    "attributes": {
      "cssClassName": null,
      "backgroundColor": null,
      "content": "A familiar publisher experience, providing a cohesive experience with wp-admin. Easily extensible with built in filters, empowering developers to customize for different use cases.",
      "style": null,
      "textColor": null,
      "fontSize": null,
      "fontFamily": null,
      "direction": null,
      "dropCap": false,
      "gradient": null,
      "align": null
    }
  }
        ]
      } />
    </div>
  );
};

```

**src/wp-blocks/index.js**

```
import { CoreBlocks } from "@faustwp/blocks";

export default {
	...CoreBlocks,
};
```

if you run `npm run dev` you will get the following error:

```
useBlocksTheme hook was called outside of context, make sure your app is wrapped with WordPressBlocksProvider
```

The following PR fixes that issue.

<img width="1330" alt="Screenshot 2024-12-24 at 08 57 05" src="https://github.com/user-attachments/assets/d5dfdff4-7f77-4b52-ac34-3deb150d4948" />


### Further Discussion

After debugging this issue with @moonmeister we also found that the theme argument appears to be redundant.
If you have a look at any of the blocks, it is only passed to the getStyles component which doesn't use the theme argument.

e.g.

https://github.com/wpengine/faustjs/blob/canary/packages/blocks/src/blocks/CoreParagraph.tsx
https://github.com/wpengine/faustjs/blob/canary/packages/blocks/src/utils/get-styles/getStyles.ts
https://github.com/wpengine/faustjs/blob/canary/packages/blocks/src/utils/get-styles/getTextStyles.ts#L10


There is a question on whether this is needed as none of the style components use this argument.



## Related Issue(s):

#1986

## Testing

As described above using a next.js app


## Screenshots

<img width="1447" alt="Screenshot 2024-12-20 at 15 17 11" src="https://github.com/user-attachments/assets/29fde4c2-e33d-4b81-a382-493c09ec8b52" />


## Documentation Changes

<!--
List corresponding changes to the documentation.
-->

## Dependant PRs

<!--
List any dependent PR's that are awaiting review. Use the following syntax:

- #1234
-->
