### PR TITLE
Feature to add anchor attribute to core/paragraph block

### DIFF
--- a/.changeset/popular-glasses-occur.md
+++ b/.changeset/popular-glasses-occur.md
@@ -3,3 +3,9 @@
 ---
 
 Update of the CoreParagraph block to support the native WP anchor attribute. GitHub issue: "[[feat] Add anchor attribute to core/paragraph block](https://github.com/wpengine/faustjs/issues/1954)"
+
+Introduces new field to `core/paragraph` block: `anchor`. This field allows users to add an anchor to the paragraph block. The anchor is used to create a link to a specific part of the page. The anchor is added to the block's wrapper element as an ID attribute.
+
+**Files changed:**
+  - packages/blocks/src/blocks/CoreParagraph.tsx (added anchor attribute)
+  - packages/blocks/package.json (updated package version to 6.0.0)

--- a/.changeset/popular-glasses-occur.md
+++ b/.changeset/popular-glasses-occur.md
@@ -1,0 +1,5 @@
+---
+'@faustwp/blocks': major
+---
+
+Update of the CoreParagraph block to support the native WP anchor attribute. GitHub issue: "[[feat] Add anchor attribute to core/paragraph block](https://github.com/wpengine/faustjs/issues/1954)"

--- a/packages/blocks/package.json
+++ b/packages/blocks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@faustwp/blocks",
-  "version": "5.1.0",
+  "version": "6.0.0",
   "description": "Faust Blocks",
   "main": "dist/cjs/index.js",
   "module": "dist/mjs/index.js",

--- a/packages/blocks/package.json
+++ b/packages/blocks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@faustwp/blocks",
-  "version": "5.0.0",
+  "version": "5.1.0",
   "description": "Faust Blocks",
   "main": "dist/cjs/index.js",
   "module": "dist/mjs/index.js",

--- a/packages/blocks/src/blocks/CoreParagraph.tsx
+++ b/packages/blocks/src/blocks/CoreParagraph.tsx
@@ -19,6 +19,7 @@ export type CoreParagraphFragmentProps = ContentBlock & {
     dropCap?: string;
     gradient?: string;
     align?: string;
+    anchor?: string;
   };
 };
 
@@ -30,6 +31,7 @@ export function CoreParagraph(props: CoreParagraphFragmentProps) {
     <p
       style={style}
       className={attributes?.cssClassName}
+      id={attributes?.anchor}
       // eslint-disable-next-line react/no-danger
       dangerouslySetInnerHTML={{ __html: attributes?.content ?? '' }}
     />
@@ -52,6 +54,7 @@ CoreParagraph.fragments = {
         dropCap
         gradient
         align
+        anchor
       }
     }
   `,

--- a/packages/blocks/tests/blocks/CoreParagraph.test.tsx
+++ b/packages/blocks/tests/blocks/CoreParagraph.test.tsx
@@ -42,4 +42,20 @@ describe('<CoreParagraph />', () => {
       </p>
     `);
   });
+
+  test('applies the HTML anchor attribute properly', () => {
+    renderProvider({
+      attributes: {
+        anchor: 'test-anchor',
+        content: 'Hello World',
+      },
+    });
+    expect(screen.queryByText('Hello World')).toMatchInlineSnapshot(`
+      <p
+        id="test-anchor"
+      >
+        Hello World
+      </p>
+    `);
+  });
 });


### PR DESCRIPTION
## Tasks

- [x] I have signed a [Contributor License Agreement (CLA)](https://github.com/wpengine/faustjs#contributor-license-agreement) with WP Engine.
- [x] If a code change, I have written testing instructions that the whole team & outside contributors can understand.
- [x] I have written and included a comprehensive [changeset](https://github.com/wpengine/faustjs/blob/canary/DEVELOPMENT.md#deployment) to properly document the changes I've made.
  - Note: Last referenced version of `@faustjs/blocks` package on canary branch by the `changeset` package was `4.0.1` but in the code was version `5.0.0`, so that is the reason why my changeset entry is marked as major change.

## Description

As mentioned in the following [feature request](https://github.com/wpengine/faustjs/issues/1954), an anchor attribute was added in the `@faustjs/blocks` package and the `CoreParagraph` block.

## Related Issue(s):

[[feat] Add anchor attribute to core/paragraph block #1954](https://github.com/wpengine/faustjs/issues/1954)

## Testing

1. In the WordPress application add native Gutenberg feature HTML Anchor to any paragraph block.
2. Check front end Faust application and see if the paragraph is properly rendered with `id` tag of HTML anchor value.
3. Additionally, run `npm run test` from the `@faustjs/blocks` package root to run all blocks code tests

**Note**: This feature is needed only for the templates where the content is being rendered with the `WordPressBlocksViewer` component.

## Screenshots

<!--
If this is a visual change include relevant screenshots about the behavior of the application before and after this change.
-->

## Documentation Changes

<!--
List corresponding changes to the documentation.
-->

## Dependant PRs

<!--
List any dependent PR's that are awaiting review. Use the following syntax:

- #1234
-->
