### PR TITLE
docs: remove dated language and move towards toolkit language

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,15 +16,9 @@
 
 ## Introduction
 
-Faust.js is a framework for building front-end applications for headless WordPress sites. Faust.js provides tooling to reduce the pains of building a headless WordPress site (namely around data fetching, authentication, previews, and SSR/SSG) while offering a pleasant experience for both developers and publishers.
-
-## Getting Started
-
-Faust.js aims to be framework agnostic, so it can be used with any front-end framework. Visit one of the guides below for a starting point:
+Faust.js is a toolkit for building Next.js applications for headless WordPress sites. Faust.js provides tooling to reduce the pains of building a headless WordPress site (namely around data fetching, authentication, previews, and SSR/SSG) while offering a pleasant experience for both developers and publishers.
 
 - [Getting started with Next.js](https://faustjs.org/docs/getting-started)
-
-As we work towards our first release, we will be introducing support for other frameworks.
 
 ## System Requirements
 

--- a/packages/faustwp-cli/README.md
+++ b/packages/faustwp-cli/README.md
@@ -19,4 +19,4 @@
   </a>
 </p>
 
-`@faustwp/cli` provides a CLI to develop, build, and serve your Faust apps.
+`@faustwp/cli` provides a CLI to develop, build, and serve your Next.js apps built with Faust.js.

--- a/packages/faustwp-core/README.md
+++ b/packages/faustwp-core/README.md
@@ -19,4 +19,4 @@
   </a>
 </p>
 
-Faust is a framework that aims to make headless WordPress as streamlined as classic WordPress for both developers and publishers.
+Faust is a toolkit that aims to make headless WordPress as streamlined as classic WordPress for both developers and publishers.


### PR DESCRIPTION
## Description

I was going through the README.md and found some very dated aspirations and "Framework" language. I am updating these to represent current Faust goals and toolkit language.