### PR TITLE
chore: remove legacy sonar path

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,5 +1,5 @@
 sonar.projectKey=faustjs
-sonar.sources=examples/next/getting-started/src,plugins/faustwp/includes,packages
+sonar.sources=plugins/faustwp/includes,packages
 sonar.tests=plugins/faustwp/tests,packages
 sonar.test.inclusions=**/test/**
 sonar.exclusions=schema.generated.ts,**/test/**


### PR DESCRIPTION
Quick fix to keep sonar from complaining about the deleted example code for legacy faust.