### PR TITLE
Bug: Fixed content replacment to allow null values

### DIFF
--- a/.changeset/afraid-panthers-pay.md
+++ b/.changeset/afraid-panthers-pay.md
@@ -1,0 +1,5 @@
+---
+"@faustwp/wordpress-plugin": patch
+---
+
+Bug: Fixed an issue with the function content_replacement throwing a 500 error for a null value. 

--- a/plugins/faustwp/includes/replacement/callbacks.php
+++ b/plugins/faustwp/includes/replacement/callbacks.php
@@ -27,11 +27,11 @@ add_filter( 'wpgraphql_content_blocks_resolver_content', __NAMESPACE__ . '\\cont
 /**
  * Callback for WordPress 'the_content' filter.
  *
- * @param string $content The post content.
+ * @param ?string $content The post content.
  *
- * @return string The post content.
+ * @return ?string The post content.
  */
-function content_replacement( $content = '' ) {
+function content_replacement( ?string $content ) {
 
 	if ( ! $content ) {
 		return $content;

--- a/plugins/faustwp/includes/replacement/callbacks.php
+++ b/plugins/faustwp/includes/replacement/callbacks.php
@@ -5,6 +5,8 @@
  * @package FaustWP
  */
 
+declare(strict_types=1);
+
 namespace WPE\FaustWP\Replacement;
 
 use function WPE\FaustWP\Settings\{

--- a/plugins/faustwp/includes/replacement/callbacks.php
+++ b/plugins/faustwp/includes/replacement/callbacks.php
@@ -27,44 +27,43 @@ add_filter( 'wpgraphql_content_blocks_resolver_content', __NAMESPACE__ . '\\cont
 /**
  * Callback for WordPress 'the_content' filter.
  *
- * @param string $content The post content.
+ * @param null|string $content The post content.
  *
- * @return string The post content.
+ * @return null|string The post content.
  */
-function content_replacement( string $content ): string {
+function content_replacement( $content ) {
 
-	if ( ! $content ) {
-		return '';
-	}
+	try {
+		if ( ! $content ) {
+			return $content;
+		}
+		$replace_content_urls = domain_replacement_enabled();
+		$replace_media_urls   = ! use_wp_domain_for_media();
+		if ( ! $replace_content_urls && ! $replace_media_urls ) {
+			return $content;
+		}
+		$wp_site_urls = faustwp_get_wp_site_urls( site_url() );
+		if ( empty( $wp_site_urls ) ) {
+			return $content;
+		}
+		$relative_upload_url = faustwp_get_relative_upload_url( $wp_site_urls, wp_upload_dir()['baseurl'] );
+		$wp_media_urls       = faustwp_get_wp_media_urls( $wp_site_urls, $relative_upload_url );
+		$frontend_uri        = (string) faustwp_get_setting( 'frontend_uri' ) ?? '/';
+		if ( $replace_content_urls && $replace_media_urls ) {
+			return str_replace( $wp_site_urls, $frontend_uri, $content );
+		}
+		if ( $replace_media_urls ) {
+			return str_replace( $wp_media_urls, $frontend_uri . $relative_upload_url, $content );
+		}
+		$site_urls_pattern = implode( '|', array_map( 'preg_quote', $wp_site_urls ) );
+		$pattern           = '#(' . $site_urls_pattern . ')(?!' . $relative_upload_url . '(\/|$))#';
 
-	$replace_content_urls = domain_replacement_enabled();
-	$replace_media_urls   = ! use_wp_domain_for_media();
-
-	if ( ! $replace_content_urls && ! $replace_media_urls ) {
+		return preg_replace( $pattern, $frontend_uri, $content );
+	} catch ( \Exception $e ) {
+		// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+		error_log( 'Error replacing content URLs: ' . $e->getMessage() );
 		return $content;
 	}
-
-	$wp_site_urls = faustwp_get_wp_site_urls( site_url() );
-	if ( empty( $wp_site_urls ) ) {
-		return $content;
-	}
-
-	$relative_upload_url = faustwp_get_relative_upload_url( $wp_site_urls, wp_upload_dir()['baseurl'] );
-	$wp_media_urls       = faustwp_get_wp_media_urls( $wp_site_urls, $relative_upload_url );
-	$frontend_uri        = (string) faustwp_get_setting( 'frontend_uri' ) ?? '/';
-
-	if ( $replace_content_urls && $replace_media_urls ) {
-		return str_replace( $wp_site_urls, $frontend_uri, $content );
-	}
-
-	if ( $replace_media_urls ) {
-		return str_replace( $wp_media_urls, $frontend_uri . $relative_upload_url, $content );
-	}
-
-	$site_urls_pattern = implode( '|', array_map( 'preg_quote', $wp_site_urls ) );
-	$pattern           = '#(' . $site_urls_pattern . ')(?!' . $relative_upload_url . '(\/|$))#';
-
-	return preg_replace( $pattern, $frontend_uri, $content );
 }
 
 /**

--- a/plugins/faustwp/includes/replacement/callbacks.php
+++ b/plugins/faustwp/includes/replacement/callbacks.php
@@ -27,43 +27,37 @@ add_filter( 'wpgraphql_content_blocks_resolver_content', __NAMESPACE__ . '\\cont
 /**
  * Callback for WordPress 'the_content' filter.
  *
- * @param null|string $content The post content.
+ * @param string $content The post content.
  *
- * @return null|string The post content.
+ * @return string The post content.
  */
-function content_replacement( $content ) {
+function content_replacement( $content = '' ) {
 
-	try {
-		if ( ! $content ) {
-			return $content;
-		}
-		$replace_content_urls = domain_replacement_enabled();
-		$replace_media_urls   = ! use_wp_domain_for_media();
-		if ( ! $replace_content_urls && ! $replace_media_urls ) {
-			return $content;
-		}
-		$wp_site_urls = faustwp_get_wp_site_urls( site_url() );
-		if ( empty( $wp_site_urls ) ) {
-			return $content;
-		}
-		$relative_upload_url = faustwp_get_relative_upload_url( $wp_site_urls, wp_upload_dir()['baseurl'] );
-		$wp_media_urls       = faustwp_get_wp_media_urls( $wp_site_urls, $relative_upload_url );
-		$frontend_uri        = (string) faustwp_get_setting( 'frontend_uri' ) ?? '/';
-		if ( $replace_content_urls && $replace_media_urls ) {
-			return str_replace( $wp_site_urls, $frontend_uri, $content );
-		}
-		if ( $replace_media_urls ) {
-			return str_replace( $wp_media_urls, $frontend_uri . $relative_upload_url, $content );
-		}
-		$site_urls_pattern = implode( '|', array_map( 'preg_quote', $wp_site_urls ) );
-		$pattern           = '#(' . $site_urls_pattern . ')(?!' . $relative_upload_url . '(\/|$))#';
-
-		return preg_replace( $pattern, $frontend_uri, $content );
-	} catch ( \Exception $e ) {
-		// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
-		error_log( 'Error replacing content URLs: ' . $e->getMessage() );
+	if ( ! $content ) {
 		return $content;
 	}
+	$replace_content_urls = domain_replacement_enabled();
+	$replace_media_urls   = ! use_wp_domain_for_media();
+	if ( ! $replace_content_urls && ! $replace_media_urls ) {
+		return $content;
+	}
+	$wp_site_urls = faustwp_get_wp_site_urls( site_url() );
+	if ( empty( $wp_site_urls ) ) {
+		return $content;
+	}
+	$relative_upload_url = faustwp_get_relative_upload_url( $wp_site_urls, wp_upload_dir()['baseurl'] );
+	$wp_media_urls       = faustwp_get_wp_media_urls( $wp_site_urls, $relative_upload_url );
+	$frontend_uri        = (string) faustwp_get_setting( 'frontend_uri' ) ?? '/';
+	if ( $replace_content_urls && $replace_media_urls ) {
+		return str_replace( $wp_site_urls, $frontend_uri, $content );
+	}
+	if ( $replace_media_urls ) {
+		return str_replace( $wp_media_urls, $frontend_uri . $relative_upload_url, $content );
+	}
+	$site_urls_pattern = implode( '|', array_map( 'preg_quote', $wp_site_urls ) );
+	$pattern           = '#(' . $site_urls_pattern . ')(?!' . $relative_upload_url . '(\/|$))#';
+
+	return preg_replace( $pattern, $frontend_uri, $content );
 }
 
 /**

--- a/plugins/faustwp/includes/replacement/functions.php
+++ b/plugins/faustwp/includes/replacement/functions.php
@@ -5,6 +5,8 @@
  * @package FaustWP
  */
 
+declare(strict_types=1);
+
 namespace WPE\FaustWP\Replacement;
 
 use function WPE\FaustWP\Settings\{
@@ -144,7 +146,7 @@ function faustwp_get_wp_site_urls( string $site_url ): array {
 
 	$host_url = wp_parse_url( $site_url, PHP_URL_HOST );
 
-	$is_https = strpos( $site_url, 0, 6 ) === 'https:';
+	$is_https = strpos( $site_url, 'https://' ) === 0;
 
 	return apply_filters(
 		'faustwp_get_wp_site_urls',

--- a/plugins/faustwp/tests/integration/ReplacementCallbacksTests.php
+++ b/plugins/faustwp/tests/integration/ReplacementCallbacksTests.php
@@ -96,7 +96,7 @@ class ReplacementCallbacksTests extends \WP_UnitTestCase {
 	/**
 	 * Test to make sure content rep can accept null values
 	 */
-	public function test_content_replacement_for_null_content_replacement() {
+	public function test_content_replacement_for_null_values() {
 		$this->assertNull(content_replacement( null ) );
 	}
 

--- a/plugins/faustwp/tests/integration/ReplacementCallbacksTests.php
+++ b/plugins/faustwp/tests/integration/ReplacementCallbacksTests.php
@@ -92,6 +92,14 @@ class ReplacementCallbacksTests extends \WP_UnitTestCase {
 		self::assertSame( 10, has_action( 'wp_calculate_image_srcset', 'WPE\FaustWP\Replacement\image_source_srcset_replacement' ) );
 	}
 
+
+	/**
+	 * Test to make sure content rep can accept null values
+	 */
+	public function test_content_replacement_for_null_content_replacement() {
+		$this->assertNull(content_replacement( null ) );
+	}
+
 	/**
 	 * Tests content_replacement() returns original value when content replacement is not enabled.
 	 */

--- a/plugins/faustwp/tests/integration/ReplacementCallbacksTests.php
+++ b/plugins/faustwp/tests/integration/ReplacementCallbacksTests.php
@@ -96,8 +96,11 @@ class ReplacementCallbacksTests extends \WP_UnitTestCase {
 	/**
 	 * Test to make sure content rep can accept null values
 	 */
-	public function test_content_replacement_for_null_values() {
-		$this->assertNull(content_replacement( null ) );
+	public function test_content_replacement_for_different_types() {
+		$this->assertNull(content_replacement( null));
+		$this->assertEmpty(content_replacement(''));
+		$content = '<p>This is a string with no URLs to be replaced.</p>';
+		$this->assertEquals($content, content_replacement($content));
 	}
 
 	/**


### PR DESCRIPTION
Fixes #2037 

## Tasks

- [x] I have signed a [Contributor License Agreement (CLA)](https://github.com/wpengine/faustjs#contributor-license-agreement) with WP Engine.
- [x] If a code change, I have written testing instructions that the whole team & outside contributors can understand.
- [x] I have written and included a comprehensive [changeset](https://github.com/wpengine/faustjs/blob/canary/DEVELOPMENT.md#deployment) to properly document the changes I've made.

## Description

Issue since 1.6.0 where by if you pass a null value for content_replacement it will throw a 500 error.

In 1.6.0 we changed the method signature for content_replacement from `content_replacement($content)` to `content_replacement( string $content)` which caused issues for anyone passing a null value for content replacement in Faust WP.

## Related Issue(s):

#2037 

## Testing

Tested locally with both single and multisite. 

## Screenshots

Testing content replacement on multisite.

<img width="1481" alt="image" src="https://github.com/user-attachments/assets/b81f55c2-e942-4688-ba1b-2229a2fcecd9" />

## Documentation Changes

N/A

## Dependant PRs

N/A
