### PR TITLE
Refactor: Added CoreListItem block to fix repeating sublist issue

### DIFF
--- a/.changeset/brown-games-jog.md
+++ b/.changeset/brown-games-jog.md
@@ -1,0 +1,52 @@
+---
+'@faustwp/blocks': major
+---
+
+### WHAT
+
+Refactor: Added CoreListItem block to fix repeating sublist issue
+
+- Added CoreListItem block
+- Updated CoreList block
+- Updated Corelist.test to accomodate new HTML structure
+- Added a new scenario to test nested lists
+
+### WHY
+
+CoreList was rendering values attribute, which happens to return nested list items multiple times.
+
+### HOW
+
+You need to add new CoreListItem fragments to your queries:
+
+```javascript
+gql`
+  ${blocks.CoreListItem.fragments.entry}
+`;
+```
+
+Example query:
+
+```javascript
+SingleTemplate.query = gql`
+  ${blocks.CoreList.fragments.entry}
+  ${blocks.CoreListItem.fragments.entry}
+  query GetPost(
+    $uri: ID!
+  ) {
+    post(id: $uri, idType: URI) {
+      title
+      content
+      editorBlocks {
+        name
+        __typename
+        renderedHtml
+        id: clientId
+        parentId: parentClientId
+        ...${blocks.CoreList.fragments.key}
+        ...${blocks.CoreListItem.fragments.key}
+      }
+    }
+  }
+`;
+```

--- a/.changeset/brown-games-jog.md
+++ b/.changeset/brown-games-jog.md
@@ -1,5 +1,5 @@
 ---
-'@faustwp/blocks': major
+'@faustwp/blocks': minor
 ---
 
 ### WHAT

--- a/packages/blocks/src/blocks/CoreList.tsx
+++ b/packages/blocks/src/blocks/CoreList.tsx
@@ -7,8 +7,9 @@ import {
   WordPressBlocksViewer,
 } from '../components/WordPressBlocksViewer.js';
 import { getStyles } from '../utils/index.js';
+import { CoreListItemFragmentProps } from './CoreListItem.js';
 
-export type CoreListFragmentProps = ContentBlock & {
+export type CoreListFragmentProps = Omit<ContentBlock, 'innerBlocks'> & {
   attributes?: {
     anchor?: string;
     backgroundColor?: string;
@@ -26,32 +27,57 @@ export type CoreListFragmentProps = ContentBlock & {
     values?: string;
     cssClassName?: string;
   };
-  innerBlocks?: Array<BlockWithAttributes | null>;
+  innerBlocks?: Array<BlockWithAttributes | CoreListItemFragmentProps | null>;
 };
 
 export function CoreList(props: CoreListFragmentProps) {
   const theme = useBlocksTheme();
   const style = getStyles(theme, { ...props });
-  const { attributes, innerBlocks } = props;
+  const { attributes } = props;
 
   if (!attributes?.values) {
     return null;
   }
 
+  const innerBlocks = props?.innerBlocks ?? [];
+  const hasInnerBlocks = innerBlocks.some((ib) => ib?.attributes);
+
   const ListLevel = attributes?.ordered ? 'ol' : 'ul';
+
+  if (process.env.NODE_ENV === 'development' && !hasInnerBlocks) {
+    console.warn(`[Faust.js] To ensure compatibility with the next major release, update your template queries to use 'blocks.CoreListItem.fragments'. 
+                  
+Without this update, CoreList will NOT render list items in the next major version.
+
+This warning is shown only in development mode.
+    `);
+  }
+
+  const listProps = {
+    style,
+    className: attributes?.cssClassName,
+    reversed:
+      attributes?.ordered && attributes?.reversed === true ? true : undefined,
+    start:
+      attributes?.ordered && attributes?.start ? attributes?.start : undefined,
+  };
+
+  if (hasInnerBlocks) {
+    return (
+      // eslint-disable-next-line react/jsx-props-no-spreading
+      <ListLevel {...listProps}>
+        <WordPressBlocksViewer blocks={innerBlocks} />
+      </ListLevel>
+    );
+  }
 
   return (
     <ListLevel
-      style={style}
-      className={attributes?.cssClassName}
-      reversed={
-        attributes?.ordered && attributes?.reversed === true ? true : undefined
-      }
-      start={
-        attributes?.ordered && attributes?.start ? attributes?.start : undefined
-      }>
-      <WordPressBlocksViewer blocks={innerBlocks ?? []} />
-    </ListLevel>
+      // eslint-disable-next-line react/jsx-props-no-spreading
+      {...listProps}
+      // eslint-disable-next-line react/no-danger
+      dangerouslySetInnerHTML={{ __html: attributes.values }}
+    />
   );
 }
 

--- a/packages/blocks/src/blocks/CoreListItem.tsx
+++ b/packages/blocks/src/blocks/CoreListItem.tsx
@@ -8,80 +8,75 @@ import {
 } from '../components/WordPressBlocksViewer.js';
 import { getStyles } from '../utils/index.js';
 
-export type CoreListFragmentProps = ContentBlock & {
+export type CoreListItemFragmentProps = ContentBlock & {
   attributes?: {
+    content?: string;
     anchor?: string;
     backgroundColor?: string;
+    borderColor?: string;
     className?: string;
     fontFamily?: string;
     fontSize?: string;
     gradient?: string;
     lock?: string;
-    ordered?: boolean;
-    reversed?: boolean;
-    start?: number;
+    metadata?: string;
+    placeholder?: string;
     style?: string;
     textColor?: string;
-    type?: string;
-    values?: string;
-    cssClassName?: string;
   };
   innerBlocks?: Array<BlockWithAttributes | null>;
 };
 
-export function CoreList(props: CoreListFragmentProps) {
+export function CoreListItem(props: CoreListItemFragmentProps) {
   const theme = useBlocksTheme();
   const style = getStyles(theme, { ...props });
   const { attributes, innerBlocks } = props;
 
-  if (!attributes?.values) {
+  const content = attributes?.content;
+
+  if (!content) {
     return null;
   }
 
-  const ListLevel = attributes?.ordered ? 'ol' : 'ul';
+  const ownContent = content ? content.split('\n')[0] : '';
 
   return (
-    <ListLevel
-      style={style}
-      className={attributes?.cssClassName}
-      reversed={
-        attributes?.ordered && attributes?.reversed === true ? true : undefined
-      }
-      start={
-        attributes?.ordered && attributes?.start ? attributes?.start : undefined
-      }>
+    <li style={style} className={attributes?.className}>
+      <div
+        // eslint-disable-next-line react/no-danger
+        dangerouslySetInnerHTML={{ __html: ownContent }}
+      />
+
       <WordPressBlocksViewer blocks={innerBlocks ?? []} />
-    </ListLevel>
+    </li>
   );
 }
 
-CoreList.fragments = {
-  key: `CoreListBlockFragment`,
+CoreListItem.fragments = {
+  key: `CoreListItemFragment`,
   entry: gql`
-    fragment CoreListBlockFragment on CoreList {
+    fragment CoreListItemFragment on CoreListItem {
       attributes {
+        content
         anchor
         backgroundColor
+        borderColor
         className
         fontFamily
         fontSize
         gradient
         lock
-        ordered
-        reversed
-        start
+        metadata
+        placeholder
         style
         textColor
-        type
-        values
-        cssClassName
       }
     }
   `,
 };
 
-CoreList.config = {
-  name: 'CoreList',
+CoreListItem.config = {
+  name: 'CoreListItem',
 };
 
-CoreList.displayName = 'CoreList';
+CoreListItem.displayName = 'CoreListItem';

--- a/packages/blocks/src/blocks/index.ts
+++ b/packages/blocks/src/blocks/index.ts
@@ -10,6 +10,7 @@ import { CoreImage } from './CoreImage.js';
 import { CoreSeparator } from './CoreSeparator.js';
 import { CoreList } from './CoreList.js';
 import { CoreHeading } from './CoreHeading.js';
+import { CoreListItem } from './CoreListItem.js';
 
 export default {
   CoreParagraph: CoreParagraph,
@@ -20,6 +21,7 @@ export default {
   CoreImage: CoreImage,
   CoreSeparator: CoreSeparator,
   CoreList: CoreList,
+  CoreListItem: CoreListItem,
   CoreButton: CoreButton,
   CoreButtons: CoreButtons,
   CoreHeading: CoreHeading,

--- a/packages/blocks/src/types/blocks.ts
+++ b/packages/blocks/src/types/blocks.ts
@@ -6,6 +6,7 @@ type BlockKeys =
   | 'core/heading'
   | 'core/gallery'
   | 'core/list'
+  | 'core/list-item'
   | 'core/quote'
   | 'core/shortcode'
   | 'core/archives'

--- a/packages/blocks/tests/blocks/CoreList.test.tsx
+++ b/packages/blocks/tests/blocks/CoreList.test.tsx
@@ -4,10 +4,16 @@ import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import { WordPressBlocksProvider } from '../../src/components/WordPressBlocksProvider';
 import { CoreList, CoreListFragmentProps } from '../../src/blocks/CoreList';
+import { CoreListItem } from '../../src/blocks/CoreListItem';
 
 function renderProvider(props: CoreListFragmentProps) {
+  const blocks = {
+    CoreListItem,
+    CoreList,
+  };
+
   return render(
-    <WordPressBlocksProvider config={{ blocks: {}, theme: {} }}>
+    <WordPressBlocksProvider config={{ blocks, theme: {} }}>
       <CoreList {...props} />
     </WordPressBlocksProvider>,
   );
@@ -18,13 +24,124 @@ describe('<CoreList />', () => {
     renderProvider({
       attributes: {
         values: '<li>Some Item</li><li>Another Item</li><li>One more item</li>',
+        ordered: true,
       },
+      innerBlocks: [
+        {
+          __typename: 'CoreListItem',
+          attributes: {
+            content: 'Some Item',
+          },
+        },
+        {
+          __typename: 'CoreListItem',
+          attributes: {
+            content: 'Another Item',
+          },
+        },
+        {
+          __typename: 'CoreListItem',
+          attributes: {
+            content: 'One more item',
+          },
+        },
+      ],
     });
 
     expect(screen.getByRole('list')).toBeInTheDocument();
+    expect(screen.getByRole('list')).toHaveProperty('nodeName', 'OL');
     expect(
-      screen.getAllByRole('listitem').map((el) => el.textContent),
+      screen
+        .getAllByRole('listitem')
+        .map((el) => el.querySelector('div')?.textContent),
     ).toStrictEqual(['Some Item', 'Another Item', 'One more item']);
+  });
+
+  test('renders deep lists', () => {
+    const tree = renderProvider({
+      attributes: {
+        values:
+          '<li>Level 1\n<ul class="wp-block-list">\n<li>Level 2\n<ul class="wp-block-list">\n<li>Level 3</li>\n</ul>\n</li>\n</ul>\n</li><li>Level 2\n<ul class="wp-block-list">\n<li>Level 3</li>\n</ul>\n</li><li>Level 3</li><li>Level 2\n<ul class="wp-block-list">\n<li>Level 3</li>\n</ul>\n</li><li>Level 3</li><li>Level 3</li>',
+        cssClassName: 'wp-block-list',
+      },
+      innerBlocks: [
+        {
+          __typename: 'CoreListItem',
+          attributes: {
+            content:
+              'Level 1\n<ul class="wp-block-list">\n<li>Level 2\n<ul class="wp-block-list">\n<li>Level 3</li>\n</ul>\n</li>\n</ul>\nLevel 2\n<ul class="wp-block-list">\n<li>Level 3</li>\n</ul>\nLevel 3',
+          },
+          innerBlocks: [
+            {
+              __typename: 'CoreList',
+              attributes: {
+                values:
+                  '<li>Level 2\n<ul class="wp-block-list">\n<li>Level 3</li>\n</ul>\n</li><li>Level 3</li><li>Level 3</li>',
+                cssClassName: 'wp-block-list',
+              },
+              innerBlocks: [
+                {
+                  __typename: 'CoreListItem',
+                  attributes: {
+                    content:
+                      'Level 2\n<ul class="wp-block-list">\n<li>Level 3</li>\n</ul>\nLevel 3',
+                  },
+                  innerBlocks: [
+                    {
+                      __typename: 'CoreList',
+                      attributes: {
+                        values: '<li>Level 3</li>',
+                        cssClassName: 'wp-block-list',
+                      },
+                      innerBlocks: [
+                        {
+                          __typename: 'CoreListItem',
+                          attributes: {
+                            content: 'Level 3',
+                          },
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(tree.container).toMatchInlineSnapshot(`
+      <div>
+        <ul
+          class="wp-block-list"
+        >
+          <li>
+            <div>
+              Level 1
+            </div>
+            <ul
+              class="wp-block-list"
+            >
+              <li>
+                <div>
+                  Level 2
+                </div>
+                <ul
+                  class="wp-block-list"
+                >
+                  <li>
+                    <div>
+                      Level 3
+                    </div>
+                  </li>
+                </ul>
+              </li>
+            </ul>
+          </li>
+        </ul>
+      </div>
+    `);
   });
 
   test('applies the correct styles', () => {
@@ -40,6 +157,26 @@ describe('<CoreList />', () => {
         cssClassName:
           'has-background-color has-text-color has-background has-large-font-size',
       },
+      innerBlocks: [
+        {
+          __typename: 'CoreListItem',
+          attributes: {
+            content: 'My',
+          },
+        },
+        {
+          __typename: 'CoreListItem',
+          attributes: {
+            content: 'Ordered',
+          },
+        },
+        {
+          __typename: 'CoreListItem',
+          attributes: {
+            content: 'List',
+          },
+        },
+      ],
     });
 
     expect(tree.container).toMatchInlineSnapshot(`
@@ -51,13 +188,19 @@ describe('<CoreList />', () => {
         style="background-color: rgb(91, 43, 43);"
       >
         <li>
-          My
+          <div>
+            My
+          </div>
         </li>
         <li>
-          Unordered
+          <div>
+            Ordered
+          </div>
         </li>
         <li>
-          List
+          <div>
+            List
+          </div>
         </li>
       </ol>
     </div>


### PR DESCRIPTION
## Tasks

- [x] I have signed a [Contributor License Agreement (CLA)](https://github.com/wpengine/faustjs#contributor-license-agreement) with WP Engine.
- [x] If a code change, I have written testing instructions that the whole team & outside contributors can understand.
- [x] I have written and included a comprehensive [changeset](https://github.com/wpengine/faustjs/blob/canary/DEVELOPMENT.md#deployment) to properly document the changes I've made.

## Description
CoreList was rendering values attribute, which happens to return nested list items multiple times. New CoreListItem block fixes this issue by recursively rendering nested lists.

## Related Issue(s):

- [CoreListItem return sublist html in attributes.content](https://github.com/wpengine/wp-graphql-content-blocks/issues/253)
- #2034

## Testing

1. Setup a basic headless project with to be able to render blocks (https://toolkit.faustjs.org/docs/how-to/rendering-blocks/) 
2. Add the `single` component to `wp-templates` folder with the component below. This component has CoreListItem fragments (`${blocks.CoreListItem.fragments.entry}`) to support CoreListItem

```javascript
import { gql } from "@apollo/client";
import { WordPressBlocksViewer } from "@faustwp/blocks";
import { flatListToHierarchical } from "@faustwp/core";
import blocks from "../wp-blocks";

export default function PostTemplate({ data }) {
  const { title, editorBlocks } = data?.post ?? { title: "" };
  const blockList = flatListToHierarchical(editorBlocks, {
    childrenKey: "innerBlocks",
  });

  return (
    <div className='is-layout-constrained'>
      <h1>{title}</h1>

      <WordPressBlocksViewer blocks={blockList} />
    </div>
  );
}

PostTemplate.query = gql`
  ${blocks.CoreParagraph.fragments.entry}
  ${blocks.CoreColumns.fragments.entry}
  ${blocks.CoreColumn.fragments.entry}
  ${blocks.CoreCode.fragments.entry}
  ${blocks.CoreButtons.fragments.entry}
  ${blocks.CoreButton.fragments.entry}
  ${blocks.CoreQuote.fragments.entry}
  ${blocks.CoreImage.fragments.entry}
  ${blocks.CoreSeparator.fragments.entry}
  ${blocks.CoreList.fragments.entry}
  ${blocks.CoreListItem.fragments.entry}
  ${blocks.CoreHeading.fragments.entry}
  query GetPost(
    $uri: ID!

  ) {
    post(id: $uri, idType: URI) {
      title
      content
      editorBlocks {
        name
        __typename
        renderedHtml
        id: clientId
        parentId: parentClientId
        ...${blocks.CoreParagraph.fragments.key}
        ...${blocks.CoreColumns.fragments.key}
        ...${blocks.CoreColumn.fragments.key}
        ...${blocks.CoreCode.fragments.key}
        ...${blocks.CoreButtons.fragments.key}
        ...${blocks.CoreButton.fragments.key}
        ...${blocks.CoreQuote.fragments.key}
        ...${blocks.CoreImage.fragments.key}
        ...${blocks.CoreSeparator.fragments.key}
        ...${blocks.CoreList.fragments.key}
        ...${blocks.CoreListItem.fragments.key}
        ...${blocks.CoreHeading.fragments.key}
      }
    }
  }
`;

PostTemplate.variables = (seedQuery) => {
  return {
    uri: seedQuery?.uri,
  };
};
```
3. Create a post at your WordPress dashboard and add a list block to the post. Add nested list items to test the behavior.
4. Run your nextjs project and check your post at `http://localhost:3000/{your-post-slug}`

## Screenshots

Before             |  After
:-------------------------:|:-------------------------:
![Screenshot 2025-02-17 at 16 37 35](https://github.com/user-attachments/assets/2b559131-0a50-426c-a9dd-ebe081b219b1)  |  ![Screenshot 2025-02-17 at 16 36 37](https://github.com/user-attachments/assets/b6c1df1e-9212-4bd5-8df0-c9e52b5cce2d)


## Documentation Changes

N/A

## Dependant PRs

N/A
