### PR TITLE
chore: fixed variable name for GitHub Actions token

### DIFF
--- a/.changeset/fuzzy-glasses-fry.md
+++ b/.changeset/fuzzy-glasses-fry.md
@@ -1,0 +1,5 @@
+---
+"@faustwp/wordpress-plugin": patch
+---
+
+Fixed the token variable name for Github actions

--- a/.github/actions/release-plugin/action.yml
+++ b/.github/actions/release-plugin/action.yml
@@ -58,10 +58,10 @@ runs:
       shell: bash
 
     - id: upload-main-release-to-github
-      name: Uploads the main release zip file to Github
+      name: Uploads the main release zip file to GitHub
       uses: softprops/action-gh-release@v2
       with:
-        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        token: ${{ secrets.GITHUB_TOKEN }}
         files: ${{ steps.zip.outputs.zip-path }}
         asset_name: faustwp-${{ env.VERSION }}.zip
         overwrite: true
@@ -70,7 +70,7 @@ runs:
       name: Uploads the non wpe-updater release zip file to Github
       uses: softprops/action-gh-release@v2
       with:
-        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        token: ${{ secrets.GITHUB_TOKEN }}
         files: ${{ steps.zip-org.outputs.zip-path }}
         asset_name: faustwp-${{ env.VERSION }}.org.zip
         overwrite: true

--- a/.github/actions/release-plugin/action.yml
+++ b/.github/actions/release-plugin/action.yml
@@ -67,7 +67,7 @@ runs:
         overwrite: true
 
     - id: upload-org-release-to-github
-      name: Uploads the non wpe-updater release zip file to Github
+      name: Uploads the non wpe-updater release zip file to GitHub
       uses: softprops/action-gh-release@v2
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/packages/block-editor-utils/CHANGELOG.md
+++ b/packages/block-editor-utils/CHANGELOG.md
@@ -24,15 +24,15 @@
   // Component.js
 
   Component.config = {
-    name: 'CreateBlockBlockB',
-    editorFields: {
-      textArea: {
-        type: 'string',
-        label: 'My Message',
-        location: 'editor',
-        control: 'textarea', // <--- Render a TextAreaControl field in the Gutenberg editor
-      },
-    },
+  	name: 'CreateBlockBlockB',
+  	editorFields: {
+  		textArea: {
+  			type: 'string',
+  			label: 'My Message',
+  			location: 'editor',
+  			control: 'textarea', // <--- Render a TextAreaControl field in the Gutenberg editor
+  		},
+  	},
   };
   ```
 
@@ -66,9 +66,9 @@
 
   ```js
   <div
-    style={styles}
-    className="rich-text"
-    dangerouslySetInnerHTML={{ __html: attributes.richText }}
+  	style={styles}
+  	className="rich-text"
+  	dangerouslySetInnerHTML={{ __html: attributes.richText }}
   />
   ```
 
@@ -119,9 +119,9 @@
   import save from './save';
 
   registerFaustBlock(MyFirstBlock, {
-    blockJson: metadata,
-    editFn: Edit,
-    saveFn: save,
+  	blockJson: metadata,
+  	editFn: Edit,
+  	saveFn: save,
   });
   ```
 

--- a/packages/faustwp-core/CHANGELOG.md
+++ b/packages/faustwp-core/CHANGELOG.md
@@ -24,11 +24,11 @@
   export default function Sitemap() {}
 
   export function getServerSideProps(ctx) {
-    return getSitemapProps(ctx, {
-      sitemapIndexPath: '/sitemap_index.xml', // RankMath changes the default sitemap path to this
-      frontendUrl: process.env.NEXT_PUBLIC_SITE_URL,
-      sitemapPathsToIgnore: ['/wp-sitemap-users-*'],
-    });
+  	return getSitemapProps(ctx, {
+  		sitemapIndexPath: '/sitemap_index.xml', // RankMath changes the default sitemap path to this
+  		frontendUrl: process.env.NEXT_PUBLIC_SITE_URL,
+  		sitemapPathsToIgnore: ['/wp-sitemap-users-*'],
+  	});
   }
   ```
 
@@ -132,7 +132,7 @@
 
   ```jsx
   <ToolbarItem onKeyDown={handleKeyDown} onClick={handleClick}>
-    Log Out
+  	Log Out
   </ToolbarItem>
   ```
 
@@ -238,18 +238,18 @@
   import { FaustPage } from '@faustwp/core';
 
   type GetPageData = {
-    generalSettings: {
-      title: string;
-    };
+  	generalSettings: {
+  		title: string;
+  	};
   };
 
   type PageProps = {
-    myProp: string;
+  	myProp: string;
   };
 
   const Page: FaustPage<GetPageData, PageProps> = (props) => {
-    const { myProp, data } = props;
-    return <></>;
+  	const { myProp, data } = props;
+  	return <></>;
   };
   ```
 
@@ -318,9 +318,9 @@
   export default function Sitemap() {}
 
   export function getServerSideProps(context) {
-    return getSitemapProps(context, {
-      frontendUrl: process.env.FRONTEND_URL, // Set the FRONTEND_URL as an env var
-    });
+  	return getSitemapProps(context, {
+  		frontendUrl: process.env.FRONTEND_URL, // Set the FRONTEND_URL as an env var
+  	});
   }
   ```
 
@@ -350,7 +350,7 @@
   import { FaustHooks, FaustPlugin } from '@faustwp/core';
 
   export class MyPlugin implements FaustPlugin {
-    apply(hooks: FaustHooks) {}
+  	apply(hooks: FaustHooks) {}
   }
   ```
 


### PR DESCRIPTION
repo_token is incorrect and should be named as token.

See - https://github.com/marketplace/actions/gh-release#-external-release-notes

Related to #2030 

## Tasks

- [x] I have signed a [Contributor License Agreement (CLA)](https://github.com/wpengine/faustjs#contributor-license-agreement) with WP Engine.
- [x] If a code change, I have written testing instructions that the whole team & outside contributors can understand.
- [x] I have written and included a comprehensive [changeset](https://github.com/wpengine/faustjs/blob/canary/DEVELOPMENT.md#deployment) to properly document the changes I've made.

## Description

<!--
Include a summary of the change and some contextual information.
-->

## Related Issue(s):

#2030

## Testing

We cannot test till go live but we can just re-run the failed action.

## Screenshots
<img width="1036" alt="Screenshot 2025-02-24 at 18 00 25" src="https://github.com/user-attachments/assets/fedc967b-1c5e-415e-8111-29529afc05a2" />


## Documentation Changes

N/A

## Dependant PRs

N/A
