### PR TITLE
chore: Updated FaustWP preview link action for all draft post types

### DIFF
--- a/.changeset/honest-shirts-exist.md
+++ b/.changeset/honest-shirts-exist.md
@@ -1,0 +1,8 @@
+---
+"@faustwp/wordpress-plugin": major
+---
+
+chore: Updated FaustWP to create a preview link for all draft post types.
+
+Removed actions `rest_prepare_post` and `rest_prepare_page` from the callback functions.
+Added a new action for `rest_api_init` to add `rest_prepare_{$post_type}` action for all publicably queryable post types including custom post types.

--- a/plugins/faustwp/composer.json
+++ b/plugins/faustwp/composer.json
@@ -34,7 +34,7 @@
     "lint": "parallel-lint -e php --no-colors --exclude vendor .",
     "phpcs": "phpcs",
     "phpcs:fix": "phpcbf",
-    "phpstan": "phpstan analyze --ansi --memory-limit=1G",
+    "phpstan": "phpstan --ansi --memory-limit=1G",
     "suite": [
       "@lint",
       "@phpcs",

--- a/plugins/faustwp/composer.json
+++ b/plugins/faustwp/composer.json
@@ -34,7 +34,7 @@
     "lint": "parallel-lint -e php --no-colors --exclude vendor .",
     "phpcs": "phpcs",
     "phpcs:fix": "phpcbf",
-    "phpstan": "phpstan --ansi --memory-limit=1G",
+    "phpstan": "phpstan analyze --ansi --memory-limit=1G",
     "suite": [
       "@lint",
       "@phpcs",

--- a/plugins/faustwp/includes/replacement/callbacks.php
+++ b/plugins/faustwp/includes/replacement/callbacks.php
@@ -343,12 +343,13 @@ add_filter( 'rest_post_dispatch', __NAMESPACE__ . '\\rest_post_dispatch', 10, 3 
 /**
  * Adds the preview link to rest responses.
  *
- * @param WP_REST_Response $response The rest response object.
- * @param WP_Post          $post Post object.
+ * @param WP_HTTP_Response $response The rest response object.
+ * @param WP_REST_Server   $post Post object.
+ * @param WP_REST_Request  $request The request object.
  *
  * @return WP_REST_Response The rest response object.
  */
-function rest_post_dispatch( $response, $post ) {
+function rest_post_dispatch( $response, $post, $request ) {
 
 	if ( isset( $post->post_status ) && 'draft' === $post->post_status ) {
 		$response->data['link'] = get_preview_post_link( $post->ID );

--- a/plugins/faustwp/includes/replacement/callbacks.php
+++ b/plugins/faustwp/includes/replacement/callbacks.php
@@ -321,8 +321,43 @@ function enqueue_preview_scripts() {
 	);
 }
 
-add_filter( 'rest_prepare_post', __NAMESPACE__ . '\\preview_link_in_rest_response', 10, 2 );
-add_filter( 'rest_prepare_page', __NAMESPACE__ . '\\preview_link_in_rest_response', 10, 2 );
+add_filter( 'rest_api_init', __NAMESPACE__ . '\\register_preview_link_hooks_for_all_draft_post_types' );
+
+/**
+ * Registers the preview link hooks for all post types.
+ */
+function register_preview_link_hooks_for_all_draft_post_types() {
+	$post_types = get_post_types(
+		array(
+			'public' => true,
+		)
+	);
+
+	foreach ( $post_types as $post_type ) {
+		add_filter( 'rest_prepare_' . $post_type, __NAMESPACE__ . '\\preview_link_in_rest_response', 10, 2 );
+	}
+}
+
+add_filter( 'rest_post_dispatch', __NAMESPACE__ . '\\rest_post_dispatch', 10, 3 );
+
+/**
+ * Adds the preview link to rest responses.
+ *
+ * @param WP_REST_Response $response The rest response object.
+ * @param WP_Post          $post Post object.
+ *
+ * @return WP_REST_Response The rest response object.
+ */
+function rest_post_dispatch( $response, $post ) {
+
+	if ( isset( $post->post_status ) && 'draft' === $post->post_status ) {
+		$response->data['link'] = get_preview_post_link( $post->ID );
+	}
+
+	return $response;
+}
+
+
 /**
  * Adds the preview link to rest responses.
  *

--- a/plugins/faustwp/includes/replacement/callbacks.php
+++ b/plugins/faustwp/includes/replacement/callbacks.php
@@ -338,27 +338,6 @@ function register_preview_link_hooks_for_all_draft_post_types() {
 	}
 }
 
-add_filter( 'rest_post_dispatch', __NAMESPACE__ . '\\rest_post_dispatch', 10, 3 );
-
-/**
- * Adds the preview link to rest responses.
- *
- * @param WP_HTTP_Response $response The rest response object.
- * @param WP_REST_Server   $post Post object.
- * @param WP_REST_Request  $request The request object.
- *
- * @return WP_REST_Response The rest response object.
- */
-function rest_post_dispatch( $response, $post, $request ) {
-
-	if ( isset( $post->post_status ) && 'draft' === $post->post_status ) {
-		$response->data['link'] = get_preview_post_link( $post->ID );
-	}
-
-	return $response;
-}
-
-
 /**
  * Adds the preview link to rest responses.
  *

--- a/plugins/faustwp/tests/integration/ReplacementCallbacksTests.php
+++ b/plugins/faustwp/tests/integration/ReplacementCallbacksTests.php
@@ -48,11 +48,10 @@ class ReplacementCallbacksTests extends \WP_UnitTestCase {
 		$this->assertSame( 1000, has_action( 'preview_post_link', 'WPE\FaustWP\Replacement\post_preview_link' ) );
 	}
 
-	public function test_preview_rest_prepare_post_filter() {
+	public function test_rest_api_init_filter() {
+		$this->assertSame( 10, has_action( 'rest_api_init', 'WPE\FaustWP\Replacement\register_preview_link_hooks_for_all_draft_post_types' ) );
+		do_action( 'rest_api_init' );
 		$this->assertSame( 10, has_action( 'rest_prepare_post', 'WPE\FaustWP\Replacement\preview_link_in_rest_response' ) );
-	}
-
-	public function test_preview_rest_prepare_page_filter() {
 		$this->assertSame( 10, has_action( 'rest_prepare_page', 'WPE\FaustWP\Replacement\preview_link_in_rest_response' ) );
 	}
 


### PR DESCRIPTION
## Tasks

- [x] I have signed a [Contributor License Agreement (CLA)](https://github.com/wpengine/faustjs#contributor-license-agreement) with WP Engine.
- [x] If a code change, I have written testing instructions that the whole team & outside contributors can understand.
- [x] I have written and included a comprehensive [changeset](https://github.com/wpengine/faustjs/blob/canary/DEVELOPMENT.md#deployment) to properly document the changes I've made.

## Description

Fixes #1920 

Currently FaustWP only adds a preview link for the post and page post types `rest_prepare_post` and `rest_prepare_page`. We should be adding a preview link for all queryable post types and this PR addresses this issue.

We loop through all queryable post types in the action `rest_api_init` which is called before `rest_prepare_{$post_type}` and add a action for each post type.

## Related Issue(s):

#1920 

## Setup for Testing

**Environment**

- WordPress 6.7.2
- PHP 8.2 
- Nginx
- Local 

**Plugins**

 - FaustWP
- WPGraphQL - https://wordpress.org/plugins/wp-graphql/
- ACF - https://wordpress.org/plugins/advanced-custom-fields/
- WPGraphQL for ACF - https://wordpress.org/plugins/wpgraphql-acf/

**Custom Post Types**

I setup one custom post type called "Events" using ACF. 


**Frontend**

I followed the following setup guides 

- Basic Setup -  https://faustjs.org/docs/how-to/basic-setup/
- Post Previews - https://faustjs.org/docs/how-to/post-previews/

For the custom post type I had the following template

```
// src/wp-templates/index.js
import SingleTemplate from "./single";
import PageTemplate from "./page";
import EventTemplate from "./single-events";

const templates = {
    single: SingleTemplate,
    page: PageTemplate,
    "single-events": EventTemplate,
};

export default templates;
```

```
//src/wp-templates/single-events.js
import { gql } from "@apollo/client";

export default function Component(props) {
    if (props.loading) {
        return <>Loading...</>;
    }

    const { title, content } = props?.data?.post;

    return (
        <>
            <h1>{title}</h1>
            <div dangerouslySetInnerHTML={{ __html: content }} />
        </>
    );
}

Component.query = gql`
    query GetPost($databaseId: ID!, $asPreview: Boolean = false) {
        post(id: $databaseId, idType: DATABASE_ID, asPreview: $asPreview) {
            title
            content
        }
    }
`;

// Variables function to provide the required arguments to the query
Component.variables = ({ databaseId }, ctx) => {
    return {
        databaseId,
        asPreview: ctx?.asPreview,
    };
};
```


## Testing

- Created a published post, page and CPT. Checked that the preview link works inside the WP editor
- Created a draft postm page and CPT. Checked that the preview link works inside the WPE editor and also the post grid.


**Example URLS from test**

- http://localhost:3000/preview?post_type=events&p=57&preview=true&previewPathname=%2F%3Fpost_type%3Devents%26p%3D57&typeName=Event
- http://localhost:3000/preview?preview_id=34&preview_nonce=22b578c303&preview=true&previewPathname=%2Fevents%2Fmy-sample-event%2F&p=34&typeName=Event
- http://localhost:3000/preview?p=39&preview=true&previewPathname=%2F%3Fp%3D39&typeName=Post


## Screenshots

https://github.com/user-attachments/assets/a9fc740f-5ab0-439b-8575-d84ca9659446




## Documentation Changes

N/A

## Dependant PRs

N/A
