### PR TITLE
Fix for faustwp releases to upload assets to the correct release.

### DIFF
--- a/.changeset/ninety-roses-knock.md
+++ b/.changeset/ninety-roses-knock.md
@@ -1,0 +1,5 @@
+---
+"@faustwp/wordpress-plugin": patch
+---
+
+Fix for adding assets to the correct release for Github Actions.

--- a/.github/actions/release-plugin/action.yml
+++ b/.github/actions/release-plugin/action.yml
@@ -73,7 +73,7 @@ runs:
         token: ${{ inputs.github_token }}
         files: ${{ env.zip-path }}
         asset_name: faustwp.${{ env.VERSION }}.zip
-        tag_name: canary
+        tag_name: "@faustwp/wordpress-plugin@${{ env.VERSION }}"
         overwrite: true
 
     - id: upload-org-release-to-github
@@ -83,7 +83,7 @@ runs:
         token: ${{ inputs.github_token }}
         files: ${{ env.org-zip-path }}
         asset_name: faustwp.${{ env.VERSION }}.org.zip
-        tag_name: canary
+        tag_name: "@faustwp/wordpress-plugin@${{ env.VERSION }}"
         overwrite: true
 
     - id: generate-info-json
@@ -100,5 +100,5 @@ runs:
         token: ${{ inputs.github_token }}
         files: ${{ env.info-json-path }}
         asset_name: info.json
-        tag_name: canary
+        tag_name: "@faustwp/wordpress-plugin@${{ env.VERSION }}"
         overwrite: true


### PR DESCRIPTION
## Tasks

- [x] I have signed a [Contributor License Agreement (CLA)](https://github.com/wpengine/faustjs#contributor-license-agreement) with WP Engine.
- [x] If a code change, I have written testing instructions that the whole team & outside contributors can understand.
- [x] I have written and included a comprehensive [changeset](https://github.com/wpengine/faustjs/blob/canary/DEVELOPMENT.md#deployment) to properly document the changes I've made.

## Description

In the latest release, we fixed most issues. The only outstanding issue is that the assets were being added to a new canary release.



## Related Issue(s):

<!--
Provide the GitHub issue(s) number for issue tracking purposes, use the following syntax:

- #1234
-->

## Testing

<!--
Describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Also list any relevant details for your test configuration such as how to test the changes locally or in staging.
-->

## Screenshots

<!--
If this is a visual change include relevant screenshots about the behavior of the application before and after this change.
-->

## Documentation Changes

<!--
List corresponding changes to the documentation.
-->

## Dependant PRs

<!--
List any dependent PR's that are awaiting review. Use the following syntax:

- #1234
-->
