### PR TITLE
Small fix for Github actions to upload assets to the correct release

### DIFF
--- a/.changeset/beige-shrimps-look.md
+++ b/.changeset/beige-shrimps-look.md
@@ -1,0 +1,6 @@
+---
+"@faustwp/wordpress-plugin": patch
+---
+
+Fix for adding assets to the correct release for Github Actions.
+Small fix for Github actions to upload assets to the correct release

--- a/.github/actions/release-plugin/action.yml
+++ b/.github/actions/release-plugin/action.yml
@@ -28,6 +28,13 @@ runs:
       run: sudo apt-get update && sudo apt-get install zip rsync -y
       shell: bash
 
+    - id: create-asset-release-version
+      name: Create asset release version without quotes
+      run: |
+        ASSET_RELEASE_VERSION=$(echo ${{ env.VERSION }} | tr -d '"')
+        echo "ASSET_RELEASE_VERSION=$ASSET_RELEASE_VERSION" >> $GITHUB_ENV
+      shell: bash
+
     - id: zip-main-release-for-github
       name: Zip plugin for the main release
       run: |
@@ -73,7 +80,7 @@ runs:
         token: ${{ inputs.github_token }}
         files: ${{ env.zip-path }}
         asset_name: faustwp.${{ env.VERSION }}.zip
-        tag_name: "@faustwp/wordpress-plugin@${{ env.VERSION }}"
+        tag_name: "@faustwp/wordpress-plugin@${{ env.ASSET_RELEASE_VERSION }}"
         overwrite: true
 
     - id: upload-org-release-to-github
@@ -83,7 +90,7 @@ runs:
         token: ${{ inputs.github_token }}
         files: ${{ env.org-zip-path }}
         asset_name: faustwp.${{ env.VERSION }}.org.zip
-        tag_name: "@faustwp/wordpress-plugin@${{ env.VERSION }}"
+        tag_name: "@faustwp/wordpress-plugin@${{ env.ASSET_RELEASE_VERSION }}"
         overwrite: true
 
     - id: generate-info-json
@@ -100,5 +107,5 @@ runs:
         token: ${{ inputs.github_token }}
         files: ${{ env.info-json-path }}
         asset_name: info.json
-        tag_name: "@faustwp/wordpress-plugin@${{ env.VERSION }}"
+        tag_name: "@faustwp/wordpress-plugin@${{ env.ASSET_RELEASE_VERSION }}"
         overwrite: true


### PR DESCRIPTION
## Tasks

- [x] I have signed a [Contributor License Agreement (CLA)](https://github.com/wpengine/faustjs#contributor-license-agreement) with WP Engine.
- [x] If a code change, I have written testing instructions that the whole team & outside contributors can understand.
- [x] I have written and included a comprehensive [changeset](https://github.com/wpengine/faustjs/blob/canary/DEVELOPMENT.md#deployment) to properly document the changes I've made.

## Description

This should fix a small issue with the release tag for the assets. See attached of the last release and it was uploading to `@faustwp/wordpress-plugin@"1.8.2"` instead of `@faustwp/wordpress-plugin@1.8.2`. Note the quotes around 1.8.2

<img width="1291" alt="Screenshot 2025-03-10 at 10 56 36" src="https://github.com/user-attachments/assets/3ac32822-76fb-4ff3-b192-ceb9f01034d0" />


## Related Issue(s):

<!--
Provide the GitHub issue(s) number for issue tracking purposes, use the following syntax:

- #1234
-->

## Testing

<!--
Describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Also list any relevant details for your test configuration such as how to test the changes locally or in staging.
-->

## Screenshots

<!--
If this is a visual change include relevant screenshots about the behavior of the application before and after this change.
-->

## Documentation Changes

<!--
List corresponding changes to the documentation.
-->

## Dependant PRs

<!--
List any dependent PR's that are awaiting review. Use the following syntax:

- #1234
-->
