### PR TITLE
Fix duplicate items on Learn Faust page

### DIFF
--- a/docs/tutorial/learn-faust/index.md
+++ b/docs/tutorial/learn-faust/index.md
@@ -68,12 +68,8 @@ Follow these steps to set up your Faust.js frontend:
 
 - Open a separate terminal window from the one running your WordPress backend to run the commands that follow.
 - Run `npm install` to install the Next.js app's NPM packages.
-- In a separate terminal window from the one running your WordPress backend, run `npm install` to install the Next.js app's NPM packages.
 - Find the `.env.local.example` file and rename it to `.env.local`. This is where we'll store our environment variables.
 - Once again, in the WordPress admin sidebar, go to `Settings` > `Faust` to access the Faust.js settings page. Copy the value you see for the `Secret Key` and paste that in as the value of `FAUST_SECRET_KEY` in your `.env.local` file and save it. Faust.js uses this secret key to send authenticated request to WordPress.
-  ![Faust Secret Key setting](./images/faust-secret-key-setting.png)
-  ![Faust Secret Key setting](./images/faust-secret-key-setting.png)
-
   ![Faust Secret Key setting](./images/faust-secret-key-setting.png)
 
   Your `.env.local` file should now look like this, where `ABC123` is the secret key you copied from the Faust settings page:


### PR DESCRIPTION
## Tasks

- [ ] I have signed a [Contributor License Agreement (CLA)](https://github.com/wpengine/faustjs#contributor-license-agreement) with WP Engine.
- [ ] If a code change, I have written testing instructions that the whole team & outside contributors can understand.
- [ ] I have written and included a comprehensive [changeset](https://github.com/wpengine/faustjs/blob/canary/DEVELOPMENT.md#deployment) to properly document the changes I've made.

## Description

There were some duplicate instructions and screenshots on the page that I've removed

## Related Issue(s):

<!--
Provide the GitHub issue(s) number for issue tracking purposes, use the following syntax:

- #1234
-->

## Testing

<!--
Describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Also list any relevant details for your test configuration such as how to test the changes locally or in staging.
-->

## Screenshots

<!--
If this is a visual change include relevant screenshots about the behavior of the application before and after this change.
-->

## Documentation Changes

<!--
List corresponding changes to the documentation.
-->

## Dependant PRs

<!--
List any dependent PR's that are awaiting review. Use the following syntax:

- #1234
-->
