### PR TITLE
fix: #2081 resolve URL with locale prefix in getWordPressProps

### DIFF
--- a/.changeset/angry-lands-rush.md
+++ b/.changeset/angry-lands-rush.md
@@ -1,0 +1,5 @@
+---
+'@faustwp/core': patch
+---
+
+Fixed an issue with the `getWordPressProps` function where the resolved URL was not correctly set for non-SSR contexts.

--- a/packages/faustwp-core/src/getWordPressProps.tsx
+++ b/packages/faustwp-core/src/getWordPressProps.tsx
@@ -107,6 +107,10 @@ export async function getWordPressProps(
 		ctx.res.setHeader('x-using', 'faust');
 	}
 
+	if (ctx.locale !== ctx.defaultLocale && resolvedUrl !== '/') {
+		resolvedUrl = `/${ctx.locale}${resolvedUrl}`;
+	}
+
 	resolvedUrl = hooks.applyFilters('resolvedUrl', resolvedUrl, {
 		nextContext: ctx,
 	}) as string | null;


### PR DESCRIPTION
## Tasks

- [x] I have signed a [Contributor License Agreement (CLA)](https://github.com/wpengine/faustjs#contributor-license-agreement) with WP Engine.
- [ ] If a code change, I have written testing instructions that the whole team & outside contributors can understand.
- [x] I have written and included a comprehensive [changeset](https://github.com/wpengine/faustjs/blob/canary/DEVELOPMENT.md#deployment) to properly document the changes I've made.

## Description
Fixes #2081
<!--
Include a summary of the change and some contextual information.
-->

## Related Issue(s):

<!--
Provide the GitHub issue(s) number for issue tracking purposes, use the following syntax:

- #1234
-->

## Testing

<!--
Describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Also list any relevant details for your test configuration such as how to test the changes locally or in staging.
-->

## Screenshots

<!--
If this is a visual change include relevant screenshots about the behavior of the application before and after this change.
-->

## Documentation Changes

<!--
List corresponding changes to the documentation.
-->

## Dependant PRs

<!--
List any dependent PR's that are awaiting review. Use the following syntax:

- #1234
-->
