### PR TITLE
bug: Updating faust tutorial docs to fix issue with next.config.js

### DIFF
--- a/docs/tutorial/learn-faust/index.md
+++ b/docs/tutorial/learn-faust/index.md
@@ -40,6 +40,17 @@ npx create-next-app \
 - When asked for the name of your project, enter `faust-tutorial`.
 - When asked if it's okay to install the `create-next-app` package, answer `y` to confirm.
 
+
+> [!IMPORTANT]
+Some users are experiencing issues with the next.config.js file missing some key parts of the file. If you run into any issues when running Next.js application we recommend running the following:
+
+``sh
+cd faust-tutorial && \
+rm next.config.js && \
+curl -s https://raw.githubusercontent.com/wpengine/faustjs/canary/examples/next/tutorial/next.config.js > next.config.js
+```
+
+
 ### 2. Set up headless WordPress backend
 
 Initial set up steps:


### PR DESCRIPTION
Issue whereby some users are missing the first line of next.config.js

## Tasks

- [x] I have signed a [Contributor License Agreement (CLA)](https://github.com/wpengine/faustjs#contributor-license-agreement) with WP Engine.
- [x] If a code change, I have written testing instructions that the whole team & outside contributors can understand.
- [x] I have written and included a comprehensive [changeset](https://github.com/wpengine/faustjs/blob/canary/DEVELOPMENT.md#deployment) to properly document the changes I've made.

## Description

See #2073 

It seems that some users including myself are missing the first line of the next.config.js file leading to errors such as "withFaust is not defined".

Added a note to the docs on how to fix this issue if it happens


## Related Issue(s):

#2073 

## Testing

<!--
Describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Also list any relevant details for your test configuration such as how to test the changes locally or in staging.
-->

## Screenshots

<!--
If this is a visual change include relevant screenshots about the behavior of the application before and after this change.
-->

## Documentation Changes

<!--
List corresponding changes to the documentation.
-->

## Dependant PRs

<!--
List any dependent PR's that are awaiting review. Use the following syntax:

- #1234
-->
