### PR TITLE
fix: faust tutorial with faust not defined error

### DIFF
--- a/docs/tutorial/learn-faust/index.md
+++ b/docs/tutorial/learn-faust/index.md
@@ -40,17 +40,6 @@ npx create-next-app \
 - When asked for the name of your project, enter `faust-tutorial`.
 - When asked if it's okay to install the `create-next-app` package, answer `y` to confirm.
 
-
-> [!IMPORTANT]
-Some users are experiencing issues with the next.config.js file missing some key parts of the file. If you run into any issues when running Next.js application we recommend running the following:
-
-``sh
-cd faust-tutorial && \
-rm next.config.js && \
-curl -s https://raw.githubusercontent.com/wpengine/faustjs/canary/examples/next/tutorial/next.config.js > next.config.js
-```
-
-
 ### 2. Set up headless WordPress backend
 
 Initial set up steps:

--- a/docs/tutorial/learn-faust/index.md
+++ b/docs/tutorial/learn-faust/index.md
@@ -40,6 +40,17 @@ npx create-next-app \
 - When asked for the name of your project, enter `faust-tutorial`.
 - When asked if it's okay to install the `create-next-app` package, answer `y` to confirm.
 
+
+> [!IMPORTANT]
+Some users are experiencing issues with the next.config.js file missing some key parts of the file. If you run into any issues when running Next.js application we recommend running the following:
+
+``sh
+cd faust-tutorial && \
+rm next.config.js && \
+curl -s https://raw.githubusercontent.com/wpengine/faustjs/canary/examples/next/tutorial/next.config.js > next.config.js
+```
+
+
 ### 2. Set up headless WordPress backend
 
 Initial set up steps:

--- a/examples/next/tutorial/next.config.js
+++ b/examples/next/tutorial/next.config.js
@@ -1,5 +1,5 @@
-const { withFaust, getWpHostname } = require('@faustwp/core');
 const { createSecureHeaders } = require('next-secure-headers');
+const { withFaust, getWpHostname } = require('@faustwp/core');
 
 /**
  * @type {import('next').NextConfig}


### PR DESCRIPTION
## Tasks

- [x] I have signed a [Contributor License Agreement (CLA)](https://github.com/wpengine/faustjs#contributor-license-agreement) with WP Engine.
- [x] If a code change, I have written testing instructions that the whole team & outside contributors can understand.
- [x] I have written and included a comprehensive [changeset](https://github.com/wpengine/faustjs/blob/canary/DEVELOPMENT.md#deployment) to properly document the changes I've made.

## Description

Fixes #2073 

A very odd issue with when you run the code below, the first line of the next.config.js is missing so you get an error saying 
`withFaust is not defined...` as the first line `const { withFaust, getWpHostname } = require('@faustwp/core');` is removed.

```
npx create-next-app \
    -e https://github.com/wpengine/faustjs/tree/canary \
    --example-path examples/next/tutorial \
    --use-npm
```

The fix was to switch the first two lines around as I think maybe when we install npm packages, the first line above `createSecureHeaders` is being removed.




## Related Issue(s):

#2073 

## Testing

```bash
npx create-next-app \    
    -e https://github.com/wpengine/faustjs/tree/bug/fix-faust-tutorial-with-faust-not-defined \
    --example-path examples/next/tutorial \
    --use-npm
```

and then output the file 

```
cat my-app/next.config.js 
const { createSecureHeaders } = require('next-secure-headers');
const { withFaust, getWpHostname } = require('@faustwp/core');

/**
 * @type {import('next').NextConfig}
 **/
module.exports = withFaust({
	reactStrictMode: true,
	sassOptions: {
		includePaths: ['node_modules'],
	},
	images: {
		domains: [getWpHostname()],
	},
	async headers() {
		return [
			{
				source: '/:path*',
				headers: createSecureHeaders({
					xssProtection: false,
				}),
			},
		];
	},
});
```

Followed the rest of the tutorial and I was able to get `npm run dev` to work - https://faustjs.org/docs/tutorial/learn-faust/

## Screenshots

<img width="526" alt="Screenshot 2025-03-25 at 11 00 45" src="https://github.com/user-attachments/assets/39bf2b8a-70f5-4e95-b4fc-84740bd9ee1b" />

<img width="684" alt="Screenshot 2025-03-25 at 11 00 54" src="https://github.com/user-attachments/assets/9e829199-29ce-47f3-ac6e-da1cc2f6525e" />



