### PR TITLE
Fix: Tutorial clone issue

### DIFF
--- a/docs/tutorial/learn-faust/index.md
+++ b/docs/tutorial/learn-faust/index.md
@@ -31,7 +31,7 @@ The steps below will get you up-and-running with the pre-built app you will use 
 - Run the command below to set up the example Next.js app we will use for the tutorial.
 
 ```sh
-npx degit wpengine/faustjs/examples/next/tutorial --force faust-tutorial
+npx degit wpengine/faustjs/examples/next/tutorial faust-tutorial
 ```
 
 ### 2. Set up headless WordPress backend

--- a/docs/tutorial/learn-faust/index.md
+++ b/docs/tutorial/learn-faust/index.md
@@ -31,14 +31,8 @@ The steps below will get you up-and-running with the pre-built app you will use 
 - Run the command below to set up the example Next.js app we will use for the tutorial.
 
 ```sh
-npx create-next-app \
-    -e https://github.com/wpengine/faustjs/tree/canary \
-    --example-path examples/next/tutorial \
-    --use-npm
+npx degit wpengine/faustjs/examples/next/tutorial --force faust-tutorial
 ```
-
-- When asked for the name of your project, enter `faust-tutorial`.
-- When asked if it's okay to install the `create-next-app` package, answer `y` to confirm.
 
 ### 2. Set up headless WordPress backend
 


### PR DESCRIPTION
Using npx degit instead to clone the tutorial as currently when using npx create-next-app npx is retrieving data from npx degit wpengine/faustjs/examples/next/tutorial --force my-app which has out of date cached data.

## Tasks

- [x] I have signed a [Contributor License Agreement (CLA)](https://github.com/wpengine/faustjs#contributor-license-agreement) with WP Engine.
- [x] If a code change, I have written testing instructions that the whole team & outside contributors can understand.
- [x] I have written and included a comprehensive [changeset](https://github.com/wpengine/faustjs/blob/canary/DEVELOPMENT.md#deployment) to properly document the changes I've made.

## Description


## Related Issue(s):

https://github.com/wpengine/faustjs.org/issues/316


## Testing

<!--
Describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Also list any relevant details for your test configuration such as how to test the changes locally or in staging.
-->

## Screenshots

<!--
If this is a visual change include relevant screenshots about the behavior of the application before and after this change.
-->

## Documentation Changes

<!--
List corresponding changes to the documentation.
-->

## Dependant PRs

<!--
List any dependent PR's that are awaiting review. Use the following syntax:

- #1234
-->
