### PR TITLE
fix: disable nightly releases for the forks

### DIFF
--- a/.github/workflows/nightly-releases.yml
+++ b/.github/workflows/nightly-releases.yml
@@ -22,6 +22,7 @@ on:
 
 jobs:
   release_nightly_canary:
+    if: github.repository_owner == 'wpengine'
     name: Release Nightly Canary
     runs-on: ubuntu-22.04
     steps:

--- a/packages/block-editor-utils/CHANGELOG.md
+++ b/packages/block-editor-utils/CHANGELOG.md
@@ -36,15 +36,15 @@
   // Component.js
 
   Component.config = {
-    name: 'CreateBlockBlockB',
-    editorFields: {
-      textArea: {
-        type: 'string',
-        label: 'My Message',
-        location: 'editor',
-        control: 'textarea', // <--- Render a TextAreaControl field in the Gutenberg editor
-      },
-    },
+  	name: 'CreateBlockBlockB',
+  	editorFields: {
+  		textArea: {
+  			type: 'string',
+  			label: 'My Message',
+  			location: 'editor',
+  			control: 'textarea', // <--- Render a TextAreaControl field in the Gutenberg editor
+  		},
+  	},
   };
   ```
 
@@ -78,9 +78,9 @@
 
   ```js
   <div
-    style={styles}
-    className="rich-text"
-    dangerouslySetInnerHTML={{ __html: attributes.richText }}
+  	style={styles}
+  	className="rich-text"
+  	dangerouslySetInnerHTML={{ __html: attributes.richText }}
   />
   ```
 
@@ -131,9 +131,9 @@
   import save from './save';
 
   registerFaustBlock(MyFirstBlock, {
-    blockJson: metadata,
-    editFn: Edit,
-    saveFn: save,
+  	blockJson: metadata,
+  	editFn: Edit,
+  	saveFn: save,
   });
   ```
 

--- a/packages/faustwp-core/CHANGELOG.md
+++ b/packages/faustwp-core/CHANGELOG.md
@@ -38,11 +38,11 @@
   export default function Sitemap() {}
 
   export function getServerSideProps(ctx) {
-    return getSitemapProps(ctx, {
-      sitemapIndexPath: '/sitemap_index.xml', // RankMath changes the default sitemap path to this
-      frontendUrl: process.env.NEXT_PUBLIC_SITE_URL,
-      sitemapPathsToIgnore: ['/wp-sitemap-users-*'],
-    });
+  	return getSitemapProps(ctx, {
+  		sitemapIndexPath: '/sitemap_index.xml', // RankMath changes the default sitemap path to this
+  		frontendUrl: process.env.NEXT_PUBLIC_SITE_URL,
+  		sitemapPathsToIgnore: ['/wp-sitemap-users-*'],
+  	});
   }
   ```
 
@@ -146,7 +146,7 @@
 
   ```jsx
   <ToolbarItem onKeyDown={handleKeyDown} onClick={handleClick}>
-    Log Out
+  	Log Out
   </ToolbarItem>
   ```
 
@@ -252,18 +252,18 @@
   import { FaustPage } from '@faustwp/core';
 
   type GetPageData = {
-    generalSettings: {
-      title: string;
-    };
+  	generalSettings: {
+  		title: string;
+  	};
   };
 
   type PageProps = {
-    myProp: string;
+  	myProp: string;
   };
 
   const Page: FaustPage<GetPageData, PageProps> = (props) => {
-    const { myProp, data } = props;
-    return <></>;
+  	const { myProp, data } = props;
+  	return <></>;
   };
   ```
 
@@ -332,9 +332,9 @@
   export default function Sitemap() {}
 
   export function getServerSideProps(context) {
-    return getSitemapProps(context, {
-      frontendUrl: process.env.FRONTEND_URL, // Set the FRONTEND_URL as an env var
-    });
+  	return getSitemapProps(context, {
+  		frontendUrl: process.env.FRONTEND_URL, // Set the FRONTEND_URL as an env var
+  	});
   }
   ```
 
@@ -364,7 +364,7 @@
   import { FaustHooks, FaustPlugin } from '@faustwp/core';
 
   export class MyPlugin implements FaustPlugin {
-    apply(hooks: FaustHooks) {}
+  	apply(hooks: FaustHooks) {}
   }
   ```
 


### PR DESCRIPTION
## Description

This update adds a condition to the Nightly Releases workflow to ensure it only runs for repositories owned by WPE. This prevents the workflow from running on forked repositories. 

## Related Issue(s):

- #2102 