### PR TITLE
docs: add seed query to docs nav

### DIFF
--- a/docs/nav.json
+++ b/docs/nav.json
@@ -140,6 +140,10 @@
 				"route": "/docs/explanation/telemetry/"
 			},
 			{
+				"title": "Seed Query",
+				"route": "/docs/explanation/seed-query/"
+			},
+			{
 				"title": "WordPress Blocks FAQ",
 				"route": "/docs/explanation/blocks-faq/"
 			},


### PR DESCRIPTION
Description
Adding seed query documentation to nav.json.

Related Issue(s):
https://github.com/wpengine/faustjs.org/issues/329