### PR TITLE
ci: remove ignores that are breaking PR checks

### DIFF
--- a/.github/workflows/check-packages.yml
+++ b/.github/workflows/check-packages.yml
@@ -3,9 +3,6 @@ name: Package Code Quality
 on:
   pull_request:
     branches: [canary]
-    paths-ignore:
-      - '**/*.md'
-      - '**/*.php'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
removes php/md ignores that are breaking checks on PRs that only include changes in these file types