### PR TITLE
fix: add error message for WordPress 500 errors

### DIFF
--- a/.changeset/few-bats-remember.md
+++ b/.changeset/few-bats-remember.md
@@ -1,0 +1,5 @@
+---
+'@faustwp/cli': patch
+---
+
+Previously, WordPress connection failures lacked clear feedback. This update adds a proper error message when a 500 error occurs, improving debugging and usability.

--- a/packages/faustwp-cli/src/healthCheck/validateNextWordPressUrl.ts
+++ b/packages/faustwp-cli/src/healthCheck/validateNextWordPressUrl.ts
@@ -28,7 +28,7 @@ export async function validateNextWordPressUrl(): Promise<void> {
 				warnLog(
 					'Route not found: Please update your FaustWP plugin to the latest version.',
 				);
-			} else if (response.status === 500) {
+			} else if (response.status >= 500 && response.status < 600) {
 				// Handle WordPress server error
 				errorLog(
 					'Could not connect to the WordPress server. Please check your WordPress URL or server status, as your site may not function correctly.',

--- a/packages/faustwp-cli/src/healthCheck/validateNextWordPressUrl.ts
+++ b/packages/faustwp-cli/src/healthCheck/validateNextWordPressUrl.ts
@@ -28,6 +28,11 @@ export async function validateNextWordPressUrl(): Promise<void> {
 				warnLog(
 					'Route not found: Please update your FaustWP plugin to the latest version.',
 				);
+			} else if (response.status === 500) {
+				// Handle WordPress server error
+				errorLog(
+					'Could not connect to the WordPress server. Please check your WordPress URL or server status, as your site may not function correctly.',
+				);
 			} else {
 				errorLog(
 					'Validation Failed: Your Faust front-end site URL value is misconfigured. It should NOT match the `NEXT_PUBLIC_WORDPRESS_URL.`',


### PR DESCRIPTION
## Tasks

- [x] I have signed a [Contributor License Agreement (CLA)](https://github.com/wpengine/faustjs#contributor-license-agreement) with WP Engine.
- [x] If a code change, I have written testing instructions that the whole team & outside contributors can understand.
- [x] I have written and included a comprehensive [changeset](https://github.com/wpengine/faustjs/blob/canary/DEVELOPMENT.md#deployment) to properly document the changes I've made.

## Description

Previously, WordPress connection failures lacked clear feedback. This update adds a proper error message when a 500 error occurs, improving debugging and usability.

## Related Issue(s):

#2139 

## Testing

Automated tests and manual test on local env 

## Screenshots

<!--
If this is a visual change include relevant screenshots about the behavior of the application before and after this change.
-->

## Documentation Changes

<!--
List corresponding changes to the documentation.
-->

## Dependant PRs

<!--
List any dependent PR's that are awaiting review. Use the following syntax:

- #1234
-->
