### PR TITLE
chore: Exclude "next" branch from GH workflows

### DIFF
--- a/.github/workflows/lint-plugin.yml
+++ b/.github/workflows/lint-plugin.yml
@@ -2,6 +2,9 @@ name: Lint Plugin
 
 on:
   pull_request:
+    branches-ignore:
+      - 'next'
+      - 'next/**' 
     paths-ignore:
       - '**/*.md'
 

--- a/.github/workflows/lint-plugin.yml
+++ b/.github/workflows/lint-plugin.yml
@@ -4,7 +4,6 @@ on:
   pull_request:
     branches-ignore:
       - 'next'
-      - 'next/**' 
     paths-ignore:
       - '**/*.md'
 

--- a/.github/workflows/nextjs-bundle-analysis.yml
+++ b/.github/workflows/nextjs-bundle-analysis.yml
@@ -9,6 +9,8 @@ on:
   pull_request:
     branches-ignore:
       - 'main'
+      - 'next'
+      - 'next/**'
   push:
     branches:
       - 'canary'

--- a/.github/workflows/nextjs-bundle-analysis.yml
+++ b/.github/workflows/nextjs-bundle-analysis.yml
@@ -10,7 +10,6 @@ on:
     branches-ignore:
       - 'main'
       - 'next'
-      - 'next/**'
   push:
     branches:
       - 'canary'

--- a/.github/workflows/unit-test-packages.yml
+++ b/.github/workflows/unit-test-packages.yml
@@ -4,7 +4,6 @@ on:
   pull_request:
     branches-ignore:
       - 'next'
-      - 'next/**'
     paths-ignore:
       - '**/*.md'
 

--- a/.github/workflows/unit-test-packages.yml
+++ b/.github/workflows/unit-test-packages.yml
@@ -2,6 +2,9 @@ name: Test Packages
 
 on:
   pull_request:
+    branches-ignore:
+      - 'next'
+      - 'next/**'
     paths-ignore:
       - '**/*.md'
 

--- a/.github/workflows/unit-test-plugin-nightly.yml
+++ b/.github/workflows/unit-test-plugin-nightly.yml
@@ -2,6 +2,9 @@ name: Unit Test Plugin / WordPress Nightly
 
 on:
   pull_request:
+    branches-ignore:
+      - 'next'
+      - 'next/**'
     paths-ignore:
       - '**/*.md'
 

--- a/.github/workflows/unit-test-plugin-nightly.yml
+++ b/.github/workflows/unit-test-plugin-nightly.yml
@@ -4,7 +4,6 @@ on:
   pull_request:
     branches-ignore:
       - 'next'
-      - 'next/**'
     paths-ignore:
       - '**/*.md'
 

--- a/.github/workflows/unit-test-plugin.yml
+++ b/.github/workflows/unit-test-plugin.yml
@@ -4,7 +4,6 @@ on:
   pull_request:
     branches-ignore:
       - 'next'
-      - 'next/**'
     paths-ignore:
       - '**/*.md'
 

--- a/.github/workflows/unit-test-plugin.yml
+++ b/.github/workflows/unit-test-plugin.yml
@@ -2,6 +2,9 @@ name: Unit Test Plugin
 
 on:
   pull_request:
+    branches-ignore:
+      - 'next'
+      - 'next/**'
     paths-ignore:
       - '**/*.md'
 


### PR DESCRIPTION
## Tasks

- [x] I have signed a [Contributor License Agreement (CLA)](https://github.com/wpengine/faustjs#contributor-license-agreement) with WP Engine.
- [ ] If a code change, I have written testing instructions that the whole team & outside contributors can understand.
- [ ] I have written and included a comprehensive [changeset](https://github.com/wpengine/faustjs/blob/canary/DEVELOPMENT.md#deployment) to properly document the changes I've made.

## Description
The `next` branch is an experimental branch for the ongoing work on the new Faust. To prevent unnecessary warnings and reduce CI resource usage, we need to disable workflows on this branch.


## Related Issue(s):

- #2161 

## Testing

<!--
Describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Also list any relevant details for your test configuration such as how to test the changes locally or in staging.
-->

## Screenshots

<!--
If this is a visual change include relevant screenshots about the behavior of the application before and after this change.
-->

## Documentation Changes

<!--
List corresponding changes to the documentation.
-->

## Dependant PRs

<!--
List any dependent PR's that are awaiting review. Use the following syntax:

- #1234
-->
