### PR TITLE
ci: Migrate npm publishing to OIDC and consolidate into reusable workflow

### DIFF
--- a/.github/workflows/nightly-releases.yml
+++ b/.github/workflows/nightly-releases.yml
@@ -12,6 +12,12 @@ name: Nightly Releases
 # * * * * *
 
 on:
+  workflow_dispatch:
+    inputs:
+      package:
+        description: 'Specific package to publish (e.g., @faustwp/cli). Leave empty for all.'
+        required: false
+        default: ''
   schedule:
     # Monday-Friday at 8:35pm UTC / 3:35pm CST
 
@@ -20,35 +26,16 @@ on:
     # middle of the hour, there is less chance of delay.
     - cron: '35 20 * * 1-5'
 
+permissions:
+  contents: read       # For checking out the repo
+  id-token: write      # For npm OIDC authentication
+
 jobs:
   release_nightly_canary:
     if: github.repository_owner == 'wpengine'
     name: Release Nightly Canary
-    runs-on: ubuntu-22.04
-    steps:
-      - name: Checkout repo
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Setup Node.js 18.x
-        uses: actions/setup-node@v4
-        with:
-          node-version: 18.x
-
-      - name: Install Dependencies
-        run: npm ci
-
-      - name: Create .npmrc
-        run: |
-          cat << EOF > "$HOME/.npmrc"
-            //registry.npmjs.org/:_authToken=$NPM_TOKEN
-          EOF
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-
-      # https://github.com/atlassian/changesets/blob/master/docs/snapshot-releases.md
-      - name: Release to NPM
-        run: |
-          npm run version:nightly
-          npm run release:nightly
+    # https://github.com/atlassian/changesets/blob/master/docs/snapshot-releases.md
+    uses: ./.github/workflows/npm-publish.yml
+    with:
+      pre-build-command: npm run version:nightly
+      publish-command: ${{ inputs.package && format('npm publish -w {0} --tag canary', inputs.package) || 'changeset publish --tag canary' }}

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,55 @@
+name: Publish to npm
+
+on:
+  workflow_call:
+    inputs:
+      pre-build-command:
+        description: 'Command to run before building (e.g., snapshot versioning)'
+        type: string
+        required: false
+        default: ''
+      publish-command:
+        description: 'Command to run for publishing'
+        type: string
+        required: true
+      push-tags:
+        description: 'Whether to push git tags after publishing'
+        type: boolean
+        required: false
+        default: false
+
+# No permissions block — inherits from caller workflow.
+# Release caller grants contents: write + id-token: write (enables git push and OIDC).
+# Nightly caller grants contents: read + id-token: write (enables checkout and OIDC).
+
+jobs:
+  publish:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js 22.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install Dependencies
+        run: npm ci
+
+      - name: Pre-build
+        if: inputs.pre-build-command != ''
+        run: ${{ inputs.pre-build-command }}
+
+      - name: Build packages
+        run: npm run build
+
+      - name: Publish to npm
+        run: ${{ inputs.publish-command }}
+
+      - name: Push tags
+        if: inputs.push-tags
+        run: git push --follow-tags

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -40,6 +40,17 @@ jobs:
       - name: Install Dependencies
         run: npm ci
 
+      - name: Upgrade npm for OIDC support
+        run: npm install -g npm@^11.5.1
+
+      - name: Verify OIDC token availability
+        run: |
+          if [ -z "${ACTIONS_ID_TOKEN_REQUEST_URL}" ]; then
+            echo "::error::OIDC token not available. Ensure the caller workflow has 'id-token: write' permission."
+            exit 1
+          fi
+          echo "OIDC token endpoint available"
+
       - name: Pre-build
         if: inputs.pre-build-command != ''
         run: ${{ inputs.pre-build-command }}

--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -45,5 +45,5 @@ jobs:
     if: needs.changesets.outputs.has-changesets == 'false'
     uses: ./.github/workflows/npm-publish.yml
     with:
-      publish-command: changeset publish
+      publish-command: npx changeset publish
       push-tags: true

--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -6,14 +6,16 @@ on:
       - canary
 
 permissions:
-  contents: write      # For creating releases/tags
+  contents: write      # For creating releases/tags and pushing tags
   pull-requests: write # For creating version PRs
   id-token: write      # For npm OIDC authentication
 
 jobs:
-  release_packages:
-    name: Release Packages
+  changesets:
+    name: Manage Changesets
     runs-on: ubuntu-22.04
+    outputs:
+      has-changesets: ${{ steps.changesets.outputs.hasChangesets }}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
@@ -25,34 +27,23 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 22.x
-          registry-url: 'https://registry.npmjs.org'
 
       - name: Install Dependencies
         run: npm ci
 
-      - name: Create Release Pull Request or Publish to npm
+      - name: Create Release Pull Request
         id: changesets
         uses: changesets/action@v1
         with:
-          # This expects you to have a script called release which does a build for your packages and calls changeset publish
-          publish: npm run release
           version: npm run version
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Save Plugin version
-        run: |
-          json=${{ toJSON(steps.changesets.outputs.publishedPackages) }}
-          echo PLUGIN_VERSION=$(echo "$json" | jq '.[] | select(.name == "@faustwp/wordpress-plugin") | .version') >> $GITHUB_ENV
-      - name: Deploy WordPress plugin
-        # Checks the changesets publishedPackages output
-        # If there is a published package named "@faustwp/wordpress-plugin"
-        # Then deploy the WordPress plugin
-        # https://github.com/changesets/action#outputs
-        if: steps.changesets.outputs.published && contains(steps.changesets.outputs.publishedPackages, '"@faustwp/wordpress-plugin"')
-        uses: ./.github/actions/release-plugin
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-        env:
-          PLUGIN_DIR: plugins/faustwp
-          SLUG: faustwp
-          VERSION: ${{ env.PLUGIN_VERSION }}
+
+  publish:
+    name: Publish to npm
+    needs: changesets
+    if: needs.changesets.outputs.has-changesets == 'false'
+    uses: ./.github/workflows/npm-publish.yml
+    with:
+      publish-command: changeset publish
+      push-tags: true


### PR DESCRIPTION
## Summary

Migrates npm publishing from legacy token-based auth (`NPM_TOKEN` + `.npmrc`) to [OIDC trusted publishing](https://github.blog/changelog/2025-12-09-npm-classic-tokens-revoked-session-based-auth-and-cli-token-management-now-available/), and consolidates all publish logic into a single reusable workflow.

## What changed

### New reusable publish workflow (`.github/workflows/npm-publish.yml`)

Both nightly and release publishing previously duplicated the same checkout → setup → build → publish steps inline. This PR extracts them into a shared `npm-publish.yml` workflow that accepts a publish command, an optional pre-build command, and a flag for pushing git tags.

The workflow runs on Node 22.x, upgrades npm to >=11.5.1 (the minimum version that supports OIDC), and verifies the OIDC token is available before attempting to publish.

### Nightly releases (`.github/workflows/nightly-releases.yml`)

  - Replaced the inline job with a call to the reusable workflow
  - Added a `workflow_dispatch` trigger so individual packages can be published on demand
  - Set explicit `id-token: write` permission for OIDC
  - Upgraded from Node 18.x to 22.x
  - Removed `NPM_TOKEN` secret and `.npmrc` creation

### Release workflow (`.github/workflows/release-packages.yml`)

  - Split into two jobs: `changesets` (version management + PR creation) and `publish` (delegates to the reusable workflow)
  - Publishing only runs when there are no pending changesets, meaning versions have already been applied
  - Added `id-token: write` permission for OIDC
  - Upgraded from Node 18.x to 22.x
  - Removed `NPM_TOKEN` secret and `.npmrc` creation
  - Removed the WordPress plugin deployment step (`.github/actions/release-plugin`)

## Why

npm is revoking classic automation tokens in favor of OIDC trusted publishing. OIDC eliminates long-lived secrets and ties publish permissions directly to the GitHub Actions workflow identity. The reusable workflow ensures both release paths stay consistent and reduces duplication.