### PR TITLE
chore: simplify pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,45 +1,13 @@
-## Tasks
-
 - [ ] I have signed a [Contributor License Agreement (CLA)](https://github.com/wpengine/faustjs#contributor-license-agreement) with WP Engine.
-- [ ] If a code change, I have written testing instructions that the whole team & outside contributors can understand.
-- [ ] I have written and included a comprehensive [changeset](https://github.com/wpengine/faustjs/blob/canary/DEVELOPMENT.md#deployment) to properly document the changes I've made.
 
 ## Description
 
-<!--
-Include a summary of the change and some contextual information.
--->
+<!-- What does this PR do and why? -->
 
-## Related Issue(s):
+## Related Issues
 
-<!--
-Provide the GitHub issue(s) number for issue tracking purposes, use the following syntax:
-
-- #1234
--->
+<!-- Link related issues: #1234 -->
 
 ## Testing
 
-<!--
-Describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Also list any relevant details for your test configuration such as how to test the changes locally or in staging.
--->
-
-## Screenshots
-
-<!--
-If this is a visual change include relevant screenshots about the behavior of the application before and after this change.
--->
-
-## Documentation Changes
-
-<!--
-List corresponding changes to the documentation.
--->
-
-## Dependant PRs
-
-<!--
-List any dependent PR's that are awaiting review. Use the following syntax:
-
-- #1234
--->
+<!-- How can this be tested? -->


### PR DESCRIPTION
## Summary

- Strips the PR template down to the essentials: CLA checkbox, description, related issues, and testing
- Removes changeset checkbox, screenshots, documentation changes, and dependent PRs sections
- Keeps it lightweight and welcoming for community contributions