### PR TITLE
fix: Resolve dynamic templates to inner component before rendering to…

### DIFF
--- a/.changeset/shaky-toes-open.md
+++ b/.changeset/shaky-toes-open.md
@@ -1,0 +1,5 @@
+---
+'@faustwp/core': patch
+---
+
+Fixed an issue where dynamic template components were rendered via the next/dynamic wrapper directly, causing hydration mismatches and double renders, by resolving the dynamic component to its inner function and storing it in state before rendering.

--- a/.github/workflows/check-packages.yml
+++ b/.github/workflows/check-packages.yml
@@ -26,6 +26,10 @@ jobs:
         uses: actions/checkout@v4
       - name: Set up Node.js
         uses: ./.github/actions/cache-restore
+        id: cache-node-modules
+      - name: Install dependencies
+        if: steps.cache-node-modules.outputs.cache-hit != 'true'
+        run: npm ci
       - name: Check Linting
         run: npm run lint
   check_format:
@@ -37,5 +41,9 @@ jobs:
         uses: actions/checkout@v4
       - name: Set up Node.js
         uses: ./.github/actions/cache-restore
+        id: cache-node-modules
+      - name: Install dependencies
+        if: steps.cache-node-modules.outputs.cache-hit != 'true'
+        run: npm ci
       - name: Check Formatting
         run: npm run test:format

--- a/examples/next/faustwp-getting-started/wp-templates/category.js
+++ b/examples/next/faustwp-getting-started/wp-templates/category.js
@@ -43,7 +43,7 @@ const GET_CATEGORY_QUERY = gql`
 
 export default function Component(props) {
 	const { generalSettings, headerMenuItems, footerMenuItems } =
-		useFaustQuery(GET_LAYOUT_QUERY);
+		useFaustQuery(GET_LAYOUT_QUERY) ?? {};
 	const { nodeByUri } = useFaustQuery(GET_CATEGORY_QUERY) ?? {};
 
 	const { title: siteTitle, description: siteDescription } =

--- a/examples/next/faustwp-getting-started/wp-templates/index.js
+++ b/examples/next/faustwp-getting-started/wp-templates/index.js
@@ -1,25 +1,10 @@
 import dynamic from 'next/dynamic';
 import { default as FrontPage } from './front-page.js';
 
-const category = dynamic(() => import('./category.js'), {
-	loading: () => <p>Loading Category Template...</p>,
-	ssr: false,
-});
-
-const tag = dynamic(() => import('./tag.js'), {
-	loading: () => <p>Loading Tag Template...</p>,
-	ssr: false,
-});
-
-const page = dynamic(() => import('./page.js'), {
-	loading: () => <p>Loading Page Template...</p>,
-	ssr: false,
-});
-
-const single = dynamic(() => import('./single.js'), {
-	loading: () => <p>Loading Single Post Template...</p>,
-	ssr: false,
-});
+const category = dynamic(() => import('./category.js'));
+const tag = dynamic(() => import('./tag.js'));
+const page = dynamic(() => import('./page.js'));
+const single = dynamic(() => import('./single.js'));
 
 export default {
 	category,

--- a/examples/next/faustwp-getting-started/wp-templates/page.js
+++ b/examples/next/faustwp-getting-started/wp-templates/page.js
@@ -26,7 +26,7 @@ const GET_PAGE_QUERY = gql`
 
 export default function Component(props) {
 	// Loading state for previews
-	if (props.loading) {
+	if (props?.loading) {
 		return <>Loading...</>;
 	}
 

--- a/packages/faustwp-core/src/components/WordPressTemplate.tsx
+++ b/packages/faustwp-core/src/components/WordPressTemplate.tsx
@@ -144,6 +144,7 @@ export function WordPressTemplateInternal(
 		unknownTemplate,
 		setQueries,
 		setLoading,
+		isDynamic,
 	]);
 
 	/**
@@ -186,7 +187,15 @@ export function WordPressTemplateInternal(
 
 			setLoading(false);
 		})();
-	}, [data, unknownTemplate, seedNode, isPreview, isAuthenticated, setLoading]);
+	}, [
+		data,
+		unknownTemplate,
+		seedNode,
+		isPreview,
+		isAuthenticated,
+		setLoading,
+		isDynamic,
+	]);
 
 	useEffect(() => {
 		if (!unknownTemplate || !isDynamic) {
@@ -195,7 +204,7 @@ export function WordPressTemplateInternal(
 		void loadDynamicComponent(unknownTemplate).then((template) => {
 			setResolvedTemplate(() => template);
 		});
-	}, [unknownTemplate]);
+	}, [unknownTemplate, isDynamic]);
 
 	if (!unknownTemplate) {
 		return null;

--- a/packages/faustwp-core/src/components/WordPressTemplate.tsx
+++ b/packages/faustwp-core/src/components/WordPressTemplate.tsx
@@ -76,7 +76,10 @@ export function WordPressTemplateInternal(
 		...wordpressTemplateProps
 	} = props;
 	const unknownTemplate = getTemplate(seedNode, templates);
+	const isDynamic = isDynamicComponent(unknownTemplate);
 	const [data, setData] = useState<any | null>(templateQueryDataProp);
+	const [resolvedTemplate, setResolvedTemplate] =
+		useState<WordPressTemplateType | null>(null);
 	const { setQueries } = useContext(FaustContext) || {};
 
 	/**
@@ -88,7 +91,7 @@ export function WordPressTemplateInternal(
 				return;
 			}
 
-			const template = isDynamicComponent(unknownTemplate)
+			const template = isDynamic
 				? await loadDynamicComponent(unknownTemplate)
 				: unknownTemplate;
 
@@ -152,7 +155,7 @@ export function WordPressTemplateInternal(
 				return;
 			}
 
-			const template = isDynamicComponent(unknownTemplate)
+			const template = isDynamic
 				? await loadDynamicComponent(unknownTemplate)
 				: unknownTemplate;
 
@@ -185,11 +188,26 @@ export function WordPressTemplateInternal(
 		})();
 	}, [data, unknownTemplate, seedNode, isPreview, isAuthenticated, setLoading]);
 
+	useEffect(() => {
+		if (!unknownTemplate || !isDynamic) {
+			return;
+		}
+		void loadDynamicComponent(unknownTemplate).then((template) => {
+			setResolvedTemplate(() => template);
+		});
+	}, [unknownTemplate]);
+
 	if (!unknownTemplate) {
 		return null;
 	}
 
-	const Component = unknownTemplate as React.FC<{ [key: string]: any }>;
+	if (isDynamic && !resolvedTemplate) {
+		return null;
+	}
+
+	const Component = (
+		isDynamic ? resolvedTemplate : unknownTemplate
+	) as React.FC<{ [key: string]: any }>;
 	const newProps = {
 		...wordpressTemplateProps,
 		__TEMPLATE_QUERY_DATA__: templateQueryDataProp,


### PR DESCRIPTION
This PR fixes an issue where dynamic template components were rendered via the next/dynamic wrapper directly, causing hydration mismatches and double renders, by resolving the dynamic component to its inner function and storing it in state before rendering.

- [ ] I have signed a [Contributor License Agreement (CLA)](https://github.com/wpengine/faustjs#contributor-license-agreement) with WP Engine.

## Description

Previously, `WordPressTemplateInternal` passed `unknownTemplate` directly to `React.createElement` when rendering dynamic templates. Since `unknownTemplate` in this case is a `next/dynamic()` wrapper (not the actual component function) React was rendering the wrapper itself, which has its own internal loading state and lifecycle. This caused the component to flash its `loading` fallback on the client during hydration, and in some cases trigger double renders as the wrapper's internal resolution competed with Faust's own data-fetching effects.

The fix resolves the dynamic wrapper to its actual inner component via `loadDynamicComponent` and stores it in a separate `resolvedTemplate` state using a function updater (`() => template`) to prevent React from mistakenly invoking the component as a state initializer. 

## Related Issues

https://github.com/wpengine/faustjs/issues/2275

## Testing

<!-- How can this be tested? -->
