### PR TITLE
fix[faustwp-core]: (#2313) add security flags to removeCookie()

### DIFF
--- a/.changeset/cookie-removal-flags.md
+++ b/.changeset/cookie-removal-flags.md
@@ -1,0 +1,5 @@
+---
+"@faustwp/core": patch
+---
+
+fix[faustwp-core]: add path, sameSite, secure, and httpOnly flags to removeCookie() to match setCookie() attributes

--- a/packages/faustwp-core/src/server/auth/cookie.ts
+++ b/packages/faustwp-core/src/server/auth/cookie.ts
@@ -70,6 +70,10 @@ export class Cookies {
 		this.response?.setHeader(
 			'Set-Cookie',
 			cookie.serialize(key, '', {
+				path: '/',
+				sameSite: 'strict',
+				secure: true,
+				httpOnly: true,
 				expires: new Date(0),
 			}),
 		);


### PR DESCRIPTION
## Description

`removeCookie()` in `packages/faustwp-core/src/server/auth/cookie.ts` expires the refresh token cookie with only `expires: new Date(0)`, missing the `path`, `sameSite`, `secure`, and `httpOnly` flags that `setCookie()` uses when setting it.

Per RFC 6265, a `Set-Cookie` header without a `path` attribute defaults to the current request path. If the logout request comes from a different path than `/`, the browser won't match and delete the original cookie — it persists after what the application considers a successful logout.

### Before

```typescript
cookie.serialize(key, '', {
    expires: new Date(0),
})
```

### After

```typescript
cookie.serialize(key, '', {
    path: '/',
    sameSite: 'strict',
    secure: true,
    httpOnly: true,
    expires: new Date(0),
})
```

These flags match the attributes used in `setRefreshToken()` (`token.ts:51-58`).

## Related Issues

Closes #2313

## Testing

### Confirm the issue (before the fix)

**1. Verify `removeCookie()` is missing security flags:**
```bash
sed -n '67,76p' packages/faustwp-core/src/server/auth/cookie.ts
# Expected on canary: only "expires: new Date(0)" — no path, sameSite, secure, or httpOnly
```

**2. Compare with `setCookie()` which has the correct flags:**
```bash
grep -A 7 'this.cookies.setCookie' packages/faustwp-core/src/server/auth/token.ts
# Expected: path: '/', sameSite: 'strict', secure: true, httpOnly: true
# These are the flags that removeCookie() should also have
```

### Confirm the fix

**3. Verify `removeCookie()` now includes all security flags:**
```bash
sed -n '67,80p' packages/faustwp-core/src/server/auth/cookie.ts
# Expected: path, sameSite, secure, httpOnly all present before expires
```

**4. Verify flags match the setCookie() call in token.ts:**
```bash
# Both should use: path: '/', sameSite: 'strict', secure: true, httpOnly: true
diff <(grep -A 4 "path:" packages/faustwp-core/src/server/auth/cookie.ts) \
     <(grep -A 4 "path:" packages/faustwp-core/src/server/auth/token.ts)
# Expected: identical flag values (only expires/maxAge will differ)
```

### Run the test suite

**JS tests** — confirms no regressions:
```bash
npm install && npm run build && npm run test
```