### PR TITLE
fix[faustwp]: (#1872) add filter for search_pattern in handle_generate_endpoint

### DIFF
--- a/.changeset/filter-generate-endpoint.md
+++ b/.changeset/filter-generate-endpoint.md
@@ -1,0 +1,5 @@
+---
+"@faustwp/wordpress-plugin": patch
+---
+
+fix[faustwp]: add `faustwp_generate_endpoint_search_pattern` filter to handle_generate_endpoint() for non-standard WordPress installations

--- a/plugins/faustwp/includes/auth/callbacks.php
+++ b/plugins/faustwp/includes/auth/callbacks.php
@@ -23,6 +23,17 @@ add_action( 'parse_request', __NAMESPACE__ . '\\handle_generate_endpoint' );
  */
 function handle_generate_endpoint() {
 	$search_pattern = ':^' . site_url( '/generate', 'relative' ) . ':';
+	/**
+	 * Filter the search pattern used to match the generate endpoint.
+	 *
+	 * Useful for non-standard WordPress installations (e.g. Bedrock) where
+	 * site_url() includes a subdirectory that does not appear in REQUEST_URI.
+	 *
+	 * @since 1.8.7
+	 *
+	 * @param string $search_pattern The regex pattern used to match the generate endpoint.
+	 */
+	$search_pattern = apply_filters( 'faustwp_generate_endpoint_search_pattern', $search_pattern );
 
 	if ( ! preg_match( $search_pattern, $_SERVER['REQUEST_URI'] ) ) { // phpcs:ignore WordPress.Security
 		return;


### PR DESCRIPTION
## Description

Non-standard WordPress installations like [Bedrock](https://roots.io/bedrock/) use a different directory structure where `site_url()` returns a path with a `/wp/` prefix (e.g. `/wp/generate`) but `$_SERVER['REQUEST_URI']` contains only `/generate`. This causes the `preg_match` in `handle_generate_endpoint()` to fail, resulting in 404 errors when previewing content.

This PR adds an `apply_filters()` call on `$search_pattern` so sites with non-standard directory structures can adjust the matching pattern without modifying the plugin source.

### Usage example for Bedrock:

```php
add_filter( 'faustwp_generate_endpoint_search_pattern', function ( $pattern ) {
    return str_replace( '/wp/', '/', $pattern );
} );
```

## Related Issues

Closes #1872

## Testing

### Confirm the issue (before the fix)

**1. Verify no filter exists on `$search_pattern`:**
```bash
grep -n 'apply_filters.*search_pattern' plugins/faustwp/includes/auth/callbacks.php
# Expected on canary: no output
```

**2. Verify `$search_pattern` uses `site_url()` which includes subdirectories on Bedrock:**
```bash
sed -n '25,27p' plugins/faustwp/includes/auth/callbacks.php
# Expected: $search_pattern = ':^' . site_url( '/generate', 'relative' ) . ':';
# On Bedrock, site_url() returns /wp/generate, but REQUEST_URI has /generate
```

### Confirm the fix

**3. Verify the filter is applied after `$search_pattern` is constructed:**
```bash
grep -A 12 "search_pattern = ':^'" plugins/faustwp/includes/auth/callbacks.php | head -15
# Expected: apply_filters( 'faustwp_generate_endpoint_search_pattern', $search_pattern )
# between the assignment and the preg_match
```

**4. Verify the docblock follows WordPress standards (@since, @param):**
```bash
grep -B 10 'apply_filters' plugins/faustwp/includes/auth/callbacks.php | grep '@'
# Expected: @since 1.8.7 and @param string $search_pattern
```

### Run the test suites

**phpcs** — confirms the filter follows WordPress coding standards:
```bash
cd plugins/faustwp && composer install && composer phpcs
```

**JS tests** — confirms no regressions:
```bash
npm install && npm run build && npm run test
```

**WordPress PHPUnit** — confirms plugin functionality:
```bash
cd plugins/faustwp
composer run docker:start
docker-compose exec -e COVERAGE=1 wordpress init-testing-environment.sh
docker exec --workdir=/var/www/html/wp-content/plugins/faustwp $(docker-compose ps -q wordpress) wp plugin install wp-graphql --activate --allow-root
docker exec --workdir=/var/www/html/wp-content/plugins/faustwp $(docker-compose ps -q wordpress) composer test
composer run docker:stop
```