### PR TITLE
fix[faustwp-cli]: (#1850) detect HTTP Basic Auth and show accurate error

### DIFF
--- a/.changeset/basic-auth-error-message.md
+++ b/.changeset/basic-auth-error-message.md
@@ -1,0 +1,5 @@
+---
+"@faustwp/cli": patch
+---
+
+fix[faustwp-cli]: detect HTTP Basic Auth on 401 response and show accurate error message instead of misleading secret key mismatch

--- a/packages/faustwp-cli/src/healthCheck/validateFaustEnvVars.ts
+++ b/packages/faustwp-cli/src/healthCheck/validateFaustEnvVars.ts
@@ -58,10 +58,19 @@ export const validateFaustEnvVars = async () => {
 				method: 'POST',
 			});
 			if (response.status === 401) {
-				// Unauthorized: User receives a 401 status code AND the message below
-				errorLog(
-					'Ensure your FAUST_SECRET_KEY environment variable matches your Secret Key in the Faust WordPress plugin settings',
-				);
+				const wwwAuth = response.headers.get('www-authenticate') || '';
+				if (wwwAuth.toLowerCase().includes('basic')) {
+					errorLog(
+						'Your WordPress site appears to be protected with HTTP Basic Authentication.',
+					);
+					errorLog(
+						'Faust cannot validate the secret key until Basic Auth credentials are provided or the protection is removed.',
+					);
+				} else {
+					errorLog(
+						'Ensure your FAUST_SECRET_KEY environment variable matches your Secret Key in the Faust WordPress plugin settings',
+					);
+				}
 				process.exit(1);
 			}
 			await validateNextWordPressUrl();

--- a/packages/faustwp-cli/tests/healthCheck/validateFaustEnvVars.test.ts
+++ b/packages/faustwp-cli/tests/healthCheck/validateFaustEnvVars.test.ts
@@ -71,8 +71,6 @@ describe('healthCheck/validateFaustEnvVars', () => {
 			`Ensure your FAUST_SECRET_KEY environment variable matches your Secret Key in the Faust WordPress plugin settings`,
 		);
 	});
-});
-
 
 	it('logs a Basic Auth error when the site returns 401 with WWW-Authenticate: Basic', async () => {
 		// @ts-ignore
@@ -107,6 +105,7 @@ describe('healthCheck/validateFaustEnvVars', () => {
 
 		mockLog.mockRestore();
 	});
+});
 
 describe('isWPEngineComTLD', () => {
 	it('matches subdomains on wpengine.com', () => {

--- a/packages/faustwp-cli/tests/healthCheck/validateFaustEnvVars.test.ts
+++ b/packages/faustwp-cli/tests/healthCheck/validateFaustEnvVars.test.ts
@@ -73,6 +73,41 @@ describe('healthCheck/validateFaustEnvVars', () => {
 	});
 });
 
+
+	it('logs a Basic Auth error when the site returns 401 with WWW-Authenticate: Basic', async () => {
+		// @ts-ignore
+		const mockExit = jest.spyOn(process, 'exit').mockImplementation((code) => {
+			if (code && code !== 0) {
+				throw new Error(`Exit code: ${code}`);
+			}
+		});
+		const mockLog = jest.spyOn(console, 'log').mockImplementation(() => {});
+
+		process.env.NEXT_PUBLIC_WORDPRESS_URL = 'https://basicauth.local';
+		process.env.FAUST_SECRET_KEY = 'valid-secret-key';
+
+		fetchMock.post(
+			'https://basicauth.local/?rest_route=/faustwp/v1/validate_secret_key',
+			{
+				status: 401,
+				headers: { 'WWW-Authenticate': 'Basic realm="Restricted"' },
+			},
+		);
+
+		try {
+			await validateFaustEnvVars();
+		} catch (err) {
+			// Expected exit
+		}
+
+		expect(mockExit).toHaveBeenCalledWith(1);
+		expect(mockLog).toHaveBeenCalledWith(
+			expect.stringContaining('HTTP Basic Authentication'),
+		);
+
+		mockLog.mockRestore();
+	});
+
 describe('isWPEngineComTLD', () => {
 	it('matches subdomains on wpengine.com', () => {
 		expect(isWPEngineComSubdomain('https://my-site.wpengine.com')).toBeTruthy();


### PR DESCRIPTION
## Description

When a WordPress site is protected with HTTP Basic Authentication, the secret key validation request returns a 401 from the web server (Apache/Nginx), not from FaustWP. The health check assumed any 401 meant the secret key was wrong, showing a misleading error:

> `Ensure your FAUST_SECRET_KEY environment variable matches your Secret Key in the Faust WordPress plugin settings`

This PR checks the `WWW-Authenticate` response header for `Basic` to distinguish between HTTP Basic Auth (web server blocking the request) and a genuine secret key mismatch (FaustWP rejecting the key). Each case now shows an accurate error message.

## Related Issues

Closes #1850

## Testing

### Confirm the issue (before the fix)

**1. Verify the health check does not distinguish Basic Auth from secret key mismatch:**
```bash
grep -A 5 'response.status === 401' packages/faustwp-cli/src/healthCheck/validateFaustEnvVars.ts
# Expected on canary: single error message about FAUST_SECRET_KEY, no WWW-Authenticate check
```

### Confirm the fix

**2. Verify the health check now checks WWW-Authenticate header:**
```bash
grep -A 12 'response.status === 401' packages/faustwp-cli/src/healthCheck/validateFaustEnvVars.ts
# Expected: wwwAuth check for 'basic', two different error paths
```

**3. Verify the new test case passes:**
```bash
npx jest --config packages/faustwp-cli/jest.config.js --verbose -- validateFaustEnvVars
# Expected: 6 tests pass, including "logs a Basic Auth error when the site returns 401 with WWW-Authenticate: Basic"
```

**4. Verify the existing 401 test still passes (secret key mismatch without Basic Auth):**
```bash
npx jest --config packages/faustwp-cli/jest.config.js --verbose -- validateFaustEnvVars
# Expected: "logs an error when the secret key validation fails" still passes
```

### Run the test suites

**CLI tests:**
```bash
npx jest --config packages/faustwp-cli/jest.config.js
```

**Full JS tests:**
```bash
npm install && npm run build && npm run test
```