### PR TITLE
docs: (#2308) update Node.js version requirement in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Faust.js is a toolkit for building Next.js applications for headless WordPress s
 
 ## System Requirements
 
-- Node.js v16.0.0 or newer (v16.8.0 when using Next.js 13 and v18.17 when using Next.js 14).
+- Node.js v18 or newer. npm v8 or newer.
 - MacOS, Windows (including WSL), and Linux are supported.
 
 ## Documentation


### PR DESCRIPTION
## Description

The README system requirements section lists `Node.js v16.0.0` as the minimum version, but the project actually requires Node.js 18+:

- `.nvmrc` specifies `v18`
- All `package.json` engines fields require `>=18`
- CI runs against Node 18, 20, and 22
- Node 16 has been EOL since September 2023

Updated to `Node.js v18 or newer. npm v8 or newer.` to match the actual project configuration.

## Related Issues

Ref #2308

## Testing

### Confirm the issue (before the fix)

**1. Verify README says Node 16:**
```bash
grep "Node.js" README.md
# Expected on canary: "Node.js v16.0.0 or newer"
```

**2. Verify actual requirement is Node 18:**
```bash
cat .nvmrc
# Expected: v18

grep -A 2 '"engines"' package.json
# Expected: "node": ">=18"
```

### Confirm the fix

**3. Verify README now matches package.json:**
```bash
grep "Node.js" README.md
# Expected: "Node.js v18 or newer. npm v8 or newer."
```