### PR TITLE
fix[faustwp]: (#2043) update settings page documentation links

### DIFF
--- a/.changeset/update-settings-links.md
+++ b/.changeset/update-settings-links.md
@@ -1,0 +1,5 @@
+---
+"@faustwp/wordpress-plugin": patch
+---
+
+fix[faustwp]: update documentation links in settings page to use current URL structure

--- a/plugins/faustwp/includes/settings/callbacks.php
+++ b/plugins/faustwp/includes/settings/callbacks.php
@@ -44,7 +44,7 @@ function frontend_url_notice() {
 					printf(
 						/* translators: Link text */
 						esc_html__( 'See the %1$s Getting Started Documentation%2$s for more details.', 'faustwp' ),
-						'<a href="https://faustjs.org/docs/getting-started" target="_blank" rel="noopener noreferrer">',
+						'<a href="https://faustjs.org/docs/how-to/basic-setup" target="_blank" rel="noopener noreferrer">',
 						'</a>'
 					);
 					?>
@@ -396,7 +396,7 @@ function display_secret_key_field() {
 		printf(
 			/* translators: %s: Documentation URL. */
 			wp_kses_post( __( 'This key is used to enable <a href="%s" target="_blank" rel="noopener noreferrer">headless post previews</a> and make authenticated GraphQL requests for schema generation.', 'faustwp' ) ),
-			'https://faustjs.org/guide/how-to-setup-post-and-page-previews'
+			'https://faustjs.org/docs/how-to/post-previews'
 		);
 		?>
 	</p>
@@ -442,7 +442,7 @@ function display_enable_disable_fields() {
 				printf(
 				/* translators: %s: Documentation URL. */
 					wp_kses_post( __( 'Learn more about <a href="%s" target="_blank" rel="noopener noreferrer">features</a>.', 'faustwp' ) ),
-					'https://faustjs.org/docs/faustwp/settings'
+					'https://faustjs.org/docs/how-to/basic-setup'
 				);
 				?>
 			</p>

--- a/plugins/faustwp/includes/settings/views/headless-settings.php
+++ b/plugins/faustwp/includes/settings/views/headless-settings.php
@@ -72,18 +72,18 @@
 					<?php endif; ?>
 					<section>
 						<h4><?php esc_html_e( 'Create Your Headless App', 'faustwp' ); ?></h4>
-						<p><a href="https://faustjs.org/docs/next/getting-started" target="_blank" rel="noopener noreferrer">Follow our quick start guide</a>.</p>
+						<p><a href="https://faustjs.org/docs/how-to/basic-setup" target="_blank" rel="noopener noreferrer">Follow our quick start guide</a>.</p>
 					</section>
 				</div>
 				<div class="box docs">
 					<h3>Faust.js Documentation</h3>
 					<section>
 						<ul>
-							<li><a href="https://faustjs.org/guide/how-to-use-the-faust-example-project" target="_blank" rel="noopener noreferrer">In-depth Tutorial</a></li>
-							<li><a href="https://faustjs.org/tutorial/get-started-with-faust" target="_blank" rel="noopener noreferrer">Quick Start</a></li>
-							<li><a href="https://faustjs.org/guide/how-to-use-apollo-in-faust" target="_blank" rel="noopener noreferrer">Fetching Data</a></li>
-							<li><a href="https://faustjs.org/guide/how-to-setup-post-and-page-previews" target="_blank" rel="noopener noreferrer">Previews</a></li>
-							<li><a href="https://faustjs.org/guide/how-to-handle-authentication" target="_blank" rel="noopener noreferrer">Authentication</a></li>
+							<li><a href="https://faustjs.org/docs/tutorial/learn-faust" target="_blank" rel="noopener noreferrer">In-depth Tutorial</a></li>
+							<li><a href="https://faustjs.org/docs/tutorial/learn-faust" target="_blank" rel="noopener noreferrer">Quick Start</a></li>
+							<li><a href="https://faustjs.org/docs/how-to/query-data-in-the-browser" target="_blank" rel="noopener noreferrer">Fetching Data</a></li>
+							<li><a href="https://faustjs.org/docs/how-to/post-previews" target="_blank" rel="noopener noreferrer">Previews</a></li>
+							<li><a href="https://faustjs.org/docs/how-to/authentication" target="_blank" rel="noopener noreferrer">Authentication</a></li>
 						</ul>
 						<p><a class="button-primary" href="https://github.com/wpengine/faustjs/" target="_blank" rel="noopener noreferrer">Faust on GitHub</a></p>
 					</section>


### PR DESCRIPTION
## Description

The FaustWP settings page contains 8 links to faustjs.org using legacy URL patterns (`/guide/*`, `/docs/next/*`, `/docs/faustwp/*`) that rely on redirects to reach the current documentation structure. This updates all links to point directly to the current URLs.

### Link mapping

| Old URL | New URL |
|---------|---------|
| `/docs/getting-started` | `/docs/how-to/basic-setup` |
| `/docs/next/getting-started` | `/docs/how-to/basic-setup` |
| `/docs/faustwp/settings` | `/docs/how-to/basic-setup` |
| `/guide/how-to-setup-post-and-page-previews` | `/docs/how-to/post-previews` |
| `/guide/how-to-use-the-faust-example-project` | `/docs/tutorial/learn-faust` |
| `/tutorial/get-started-with-faust` | `/docs/tutorial/learn-faust` |
| `/guide/how-to-use-apollo-in-faust` | `/docs/how-to/query-data-in-the-browser` |
| `/guide/how-to-handle-authentication` | `/docs/how-to/authentication` |

All replacement URLs verified against the live faustjs.org docs site.

## Related Issues

Closes #2043

## Testing

### Confirm the issue (before the fix)

**1. Check for legacy link patterns in settings files:**
```bash
grep -n "/guide/\|/docs/next/\|/docs/faustwp/" plugins/faustwp/includes/settings/callbacks.php plugins/faustwp/includes/settings/views/headless-settings.php
# Expected on canary: 6+ matches using old URL patterns
```

### Confirm the fix

**2. Verify no legacy patterns remain:**
```bash
grep -n "/guide/\|/docs/next/\|/docs/faustwp/" plugins/faustwp/includes/settings/callbacks.php plugins/faustwp/includes/settings/views/headless-settings.php
# Expected: no output
```

**3. Verify all links now use current docs structure:**
```bash
grep -n "faustjs.org" plugins/faustwp/includes/settings/callbacks.php plugins/faustwp/includes/settings/views/headless-settings.php
# Expected: all links use /docs/how-to/* or /docs/tutorial/* patterns
```

### Run the test suites

**phpcs:**
```bash
cd plugins/faustwp && composer install && composer phpcs
```

**JS tests:**
```bash
npm install && npm run build && npm run test
```