### PR TITLE
feat[faustwp]: (#1931) add Requires Plugins header for WPGraphQL

### DIFF
--- a/.changeset/plugin-dependency-header.md
+++ b/.changeset/plugin-dependency-header.md
@@ -1,0 +1,5 @@
+---
+"@faustwp/wordpress-plugin": patch
+---
+
+feat[faustwp]: add Requires Plugins header for WPGraphQL dependency

--- a/plugins/faustwp/faustwp.php
+++ b/plugins/faustwp/faustwp.php
@@ -13,6 +13,7 @@
  * Requires PHP: 7.4
  * Requires at least: 5.7
  * Tested up to: 6.9
+ * Requires Plugins: wp-graphql
  * Update URI: false
  *
  * @package FaustWP

--- a/plugins/faustwp/readme.txt
+++ b/plugins/faustwp/readme.txt
@@ -5,6 +5,7 @@ Requires at least: 5.7
 Tested up to: 6.9
 Stable tag: 1.8.6
 Requires PHP: 7.4
+Requires Plugins: wp-graphql
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 


### PR DESCRIPTION
## Description

WordPress 6.5 introduced the `Requires Plugins` header ([dev note](https://make.wordpress.org/core/2024/03/05/introducing-plugin-dependencies-in-wordpress-6-5/)) which shows dependency relationships on the Plugins screen and prevents activation if required plugins are missing.

FaustWP requires WPGraphQL to function. This PR adds the `Requires Plugins: wp-graphql` header to both `faustwp.php` and `readme.txt` so WordPress can surface this dependency to site administrators.

The header is ignored by WordPress versions older than 6.5, so this is backward-compatible with the existing `Requires at least: 5.7`.

This follows the same pattern [already adopted by WPGraphQL for ACF](https://github.com/wp-graphql/wpgraphql-acf/pull/211).

## Related Issues

Closes #1931

## Testing

### Confirm the issue (before the fix)

**1. Verify no Requires Plugins header exists:**
```bash
grep "Requires Plugins" plugins/faustwp/faustwp.php plugins/faustwp/readme.txt
# Expected on canary: no output
```

### Confirm the fix

**2. Verify the header is present in both files:**
```bash
grep "Requires Plugins" plugins/faustwp/faustwp.php plugins/faustwp/readme.txt
# Expected: "Requires Plugins: wp-graphql" in both files
```

**3. Verify the header is in the correct position in the plugin file header block:**
```bash
sed -n '14,17p' plugins/faustwp/faustwp.php
# Expected: Requires at least, Tested up to, Requires Plugins, Update URI — in that order
```

### Run the test suites

**phpcs:**
```bash
cd plugins/faustwp && composer install && composer phpcs
```