### PR TITLE
test[faustwp-core]: (#1940) add test coverage for sitemapIndexPath option

### DIFF
--- a/.changeset/sitemap-index-path-tests.md
+++ b/.changeset/sitemap-index-path-tests.md
@@ -1,0 +1,5 @@
+---
+"@faustwp/core": patch
+---
+
+test[faustwp-core]: add test coverage for sitemapIndexPath option in createRootSitemapIndex

--- a/packages/faustwp-core/tests/server/sitemaps/createSitemaps.test.ts
+++ b/packages/faustwp-core/tests/server/sitemaps/createSitemaps.test.ts
@@ -244,15 +244,17 @@ describe('createRootSitemapIndex', () => {
 	});
 
 	it('fetches from custom sitemapIndexPath when provided', async () => {
-		const fetchSpy = jest.spyOn(global, 'fetch').mockImplementationOnce((url) => {
-			// Verify the custom path was used in the fetch URL
-			expect(url).toBe('http://headless.local/custom-sitemap-index.xml');
-			return Promise.resolve({
-				ok: true,
-				status: 200,
-				text: () => Promise.resolve(validSitemapIndex1RecordXML),
-			}) as Promise<Response>;
-		});
+		const fetchSpy = jest
+			.spyOn(global, 'fetch')
+			.mockImplementationOnce((url) => {
+				// Verify the custom path was used in the fetch URL
+				expect(url).toBe('http://headless.local/custom-sitemap-index.xml');
+				return Promise.resolve({
+					ok: true,
+					status: 200,
+					text: () => Promise.resolve(validSitemapIndex1RecordXML),
+				}) as Promise<Response>;
+			});
 
 		const req = {
 			url: 'http://localhost:3000/sitemap.xml',
@@ -289,9 +291,7 @@ describe('createRootSitemapIndex', () => {
 
 		await createSitemaps.createRootSitemapIndex(req, config);
 
-		expect(fetchSpy).toHaveBeenCalledWith(
-			'http://headless.local/sitemap.xml',
-		);
+		expect(fetchSpy).toHaveBeenCalledWith('http://headless.local/sitemap.xml');
 	});
 
 	it('trims slashes from sitemapIndexPath', async () => {
@@ -318,7 +318,6 @@ describe('createRootSitemapIndex', () => {
 			'http://headless.local/yoast-sitemap.xml',
 		);
 	});
-
 });
 
 describe('createPagesSitemap()', () => {

--- a/packages/faustwp-core/tests/server/sitemaps/createSitemaps.test.ts
+++ b/packages/faustwp-core/tests/server/sitemaps/createSitemaps.test.ts
@@ -242,6 +242,83 @@ describe('createRootSitemapIndex', () => {
 
 		expect(createSitemapIndexSpy).toHaveBeenCalledWith(expectedSitemaps);
 	});
+
+	it('fetches from custom sitemapIndexPath when provided', async () => {
+		const fetchSpy = jest.spyOn(global, 'fetch').mockImplementationOnce((url) => {
+			// Verify the custom path was used in the fetch URL
+			expect(url).toBe('http://headless.local/custom-sitemap-index.xml');
+			return Promise.resolve({
+				ok: true,
+				status: 200,
+				text: () => Promise.resolve(validSitemapIndex1RecordXML),
+			}) as Promise<Response>;
+		});
+
+		const req = {
+			url: 'http://localhost:3000/sitemap.xml',
+		} as NextRequest;
+
+		const config: GetSitemapPropsConfig = {
+			frontendUrl: 'http://localhost:3000',
+			sitemapIndexPath: '/custom-sitemap-index.xml',
+		};
+
+		await createSitemaps.createRootSitemapIndex(req, config);
+
+		expect(fetchSpy).toHaveBeenCalledWith(
+			'http://headless.local/custom-sitemap-index.xml',
+		);
+	});
+
+	it('fetches from default /sitemap.xml when sitemapIndexPath is not provided', async () => {
+		const fetchSpy = jest.spyOn(global, 'fetch').mockImplementationOnce(() => {
+			return Promise.resolve({
+				ok: true,
+				status: 200,
+				text: () => Promise.resolve(validSitemapIndex1RecordXML),
+			}) as Promise<Response>;
+		});
+
+		const req = {
+			url: 'http://localhost:3000/sitemap.xml',
+		} as NextRequest;
+
+		const config: GetSitemapPropsConfig = {
+			frontendUrl: 'http://localhost:3000',
+		};
+
+		await createSitemaps.createRootSitemapIndex(req, config);
+
+		expect(fetchSpy).toHaveBeenCalledWith(
+			'http://headless.local/sitemap.xml',
+		);
+	});
+
+	it('trims slashes from sitemapIndexPath', async () => {
+		const fetchSpy = jest.spyOn(global, 'fetch').mockImplementationOnce(() => {
+			return Promise.resolve({
+				ok: true,
+				status: 200,
+				text: () => Promise.resolve(validSitemapIndex1RecordXML),
+			}) as Promise<Response>;
+		});
+
+		const req = {
+			url: 'http://localhost:3000/sitemap.xml',
+		} as NextRequest;
+
+		const config: GetSitemapPropsConfig = {
+			frontendUrl: 'http://localhost:3000',
+			sitemapIndexPath: '/yoast-sitemap.xml/',
+		};
+
+		await createSitemaps.createRootSitemapIndex(req, config);
+
+		expect(fetchSpy).toHaveBeenCalledWith(
+			'http://headless.local/yoast-sitemap.xml',
+		);
+	});
+
 });
 
 describe('createPagesSitemap()', () => {


### PR DESCRIPTION
## Description

The `sitemapIndexPath` configuration option in `createRootSitemapIndex()` had zero test coverage. This PR adds three tests verifying its behavior:

1. **Custom path** — confirms `createRootSitemapIndex` fetches from the custom URL when `sitemapIndexPath` is provided (e.g. `/custom-sitemap-index.xml`)
2. **Default fallback** — confirms it fetches from `/sitemap.xml` when `sitemapIndexPath` is omitted
3. **Slash trimming** — confirms leading/trailing slashes are trimmed from `sitemapIndexPath` before constructing the fetch URL

## Related Issues

Closes #1940

## Testing

### Confirm the issue (before the fix)

**1. Verify no sitemapIndexPath tests exist:**
```bash
grep -n "sitemapIndexPath" packages/faustwp-core/tests/server/sitemaps/createSitemaps.test.ts
# Expected on canary: no output
```

### Confirm the fix

**2. Verify sitemapIndexPath tests are present:**
```bash
grep -n "sitemapIndexPath" packages/faustwp-core/tests/server/sitemaps/createSitemaps.test.ts
# Expected: 3 test cases referencing sitemapIndexPath
```

**3. Run the sitemap tests:**
```bash
npx jest --config packages/faustwp-core/jest.config.js --verbose -- createSitemaps
# Expected: 15 tests pass (12 existing + 3 new)
```

### Run the full test suite

```bash
npm install && npm run build && npm run test
```