### PR TITLE
docs: (#2075) add Template Hierarchy to Main Features section

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -13,11 +13,12 @@ From data fetching to Block components, Faust.js® has you covered. Build your h
 
 Some of the main Faust.js® features include:
 
-| Feature                                            | Description                                                        |
-| -------------------------------------------------- | ------------------------------------------------------------------ |
-| [Authentication](/docs/how-to/authentication/)     | Authenticate users in your Next.js app with WordPress              |
-| [Block Components](/docs/how-to/rendering-blocks/) | Render WordPress blocks in your Next.js app                        |
-| [Post Preview](/docs/how-to/post-previews/)        | Preview posts and pages in your Next.js app before publishing them |
+| Feature                                            | Description                                                                          |
+| -------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| [Template Hierarchy](/docs/explanation/seed-query/) | Automatically resolve WordPress content to the right template, just like classic PHP  |
+| [Authentication](/docs/how-to/authentication/)     | Authenticate users in your Next.js app with WordPress                                |
+| [Block Components](/docs/how-to/rendering-blocks/) | Render WordPress blocks in your Next.js app                                          |
+| [Post Preview](/docs/how-to/post-previews/)        | Preview posts and pages in your Next.js app before publishing them                   |
 
 ## How to Use These Docs
 


### PR DESCRIPTION
## Description

The Main Features table on the introduction page (`docs/index.md`) lists Authentication, Block Components, and Post Preview — but not Template Hierarchy, which is arguably the backbone of Faust.js. As the issue author noted, it's the main reason many developers use Faust and the best way for existing WordPress developers to understand the framework.

Added Template Hierarchy as the first row in the table, linking to the seed query explanation doc which covers how Faust resolves WordPress content to Next.js templates.

## Related Issues

Closes #2075

## Testing

### Confirm the issue (before the fix)

**1. Verify Template Hierarchy is missing from the features table:**
```bash
grep -i "template" docs/index.md
# Expected on canary: no output
```

### Confirm the fix

**2. Verify Template Hierarchy is now listed:**
```bash
grep -i "template" docs/index.md
# Expected: "Template Hierarchy" row in the features table
```

**3. Verify the link target exists:**
```bash
ls docs/explanation/seed-query/index.md
# Expected: file exists
```