### PR TITLE
fix[faustwp]: (#2311) clean up uploaded blockset zip when extraction fails

### DIFF
--- a/.changeset/blockset-cleanup-on-failed-extraction.md
+++ b/.changeset/blockset-cleanup-on-failed-extraction.md
@@ -1,0 +1,5 @@
+---
+"@faustwp/wordpress-plugin": patch
+---
+
+fix[faustwp]: clean up uploaded blockset zip when extraction fails

--- a/plugins/faustwp/includes/blocks/functions.php
+++ b/plugins/faustwp/includes/blocks/functions.php
@@ -53,6 +53,7 @@ function process_and_replace_blocks( $wp_filesystem, $file, $dirs ) {
 
 	$unzip_result = unzip_uploaded_file( $target_file, $dirs['target'] );
 	if ( is_wp_error( $unzip_result ) ) {
+		$wp_filesystem->delete( $target_file );
 		return $unzip_result;
 	}
 

--- a/plugins/faustwp/tests/unit/BlockFunctionTests.php
+++ b/plugins/faustwp/tests/unit/BlockFunctionTests.php
@@ -136,4 +136,92 @@ class BlockFunctionTests extends FaustUnitTest {
         $this->assertTrue( Blocks\ensure_directories_exist( $dirs ) );
     }
 
+    /**
+     * Regression guard for #2311: when unzip_uploaded_file() returns a WP_Error,
+     * process_and_replace_blocks() must call $wp_filesystem->delete( $target_file )
+     * before returning, so the orphaned zip doesn't accumulate at the predictable
+     * path under wp-content/uploads/faustwp/blocks/.
+     *
+     * Verified red-on-revert: removing the delete line from
+     * includes/blocks/functions.php fails this test's Mockery once() expectation.
+     */
+    public function test_process_and_replace_blocks_cleans_up_on_unzip_failure() {
+        $file = [
+            'name'     => 'mock.zip',
+            'type'     => 'application/zip',
+            'tmp_name' => '/tmp/mock.zip',
+        ];
+        $dirs = [
+            'target' => '/uploads/blocks',
+            'temp'   => '/uploads/blocks/tmp',
+        ];
+        $target_file = '/uploads/blocks/mock.zip';
+        $error       = new WP_Error( 'unzip_error', 'mock unzip failure' );
+
+        stubs([
+            // Internal helpers: success on move, error on unzip. cleanup must NOT
+            // run on the error path; if it does, fail loudly so we catch a future
+            // regression where the early return is removed.
+            'WPE\FaustWP\Blocks\move_uploaded_file'     => true,
+            'WPE\FaustWP\Blocks\unzip_uploaded_file'    => $error,
+            'WPE\FaustWP\Blocks\cleanup_temp_directory' => function () {
+                throw new \LogicException( 'cleanup_temp_directory must not run on the unzip-failure path' );
+            },
+            // WP global helpers: keep the target-file path deterministic so the
+            // Mockery ->with() expectation matches without depending on Brain
+            // Monkey's default passthroughs.
+            'trailingslashit'    => function ( $s ) { return rtrim( $s, '/' ) . '/'; },
+            'sanitize_file_name' => function ( $s ) { return $s; },
+        ]);
+
+        $filesystem = Mockery::mock( 'WP_Filesystem_Base' );
+        $filesystem->shouldReceive( 'delete' )
+            ->with( $target_file )
+            ->once();
+
+        $result = Blocks\process_and_replace_blocks( $filesystem, $file, $dirs );
+
+        $this->assertInstanceOf( WP_Error::class, $result );
+        $this->assertSame( $error, $result );
+    }
+
+    /**
+     * Success path: when both move and unzip succeed, process_and_replace_blocks()
+     * must NOT call $wp_filesystem->delete( $target_file ) (the extracted blocks
+     * remain in place) and must invoke cleanup_temp_directory() for the staging dir.
+     *
+     * Inverse of the regression-guard test above: catches a future change that
+     * over-aggressively deletes the target on the happy path.
+     */
+    public function test_process_and_replace_blocks_success_path_does_not_delete_target() {
+        $file = [
+            'name'     => 'mock.zip',
+            'type'     => 'application/zip',
+            'tmp_name' => '/tmp/mock.zip',
+        ];
+        $dirs = [
+            'target' => '/uploads/blocks',
+            'temp'   => '/uploads/blocks/tmp',
+        ];
+
+        $cleanup_called = false;
+        stubs([
+            'WPE\FaustWP\Blocks\move_uploaded_file'     => true,
+            'WPE\FaustWP\Blocks\unzip_uploaded_file'    => true,
+            'WPE\FaustWP\Blocks\cleanup_temp_directory' => function () use ( &$cleanup_called ) {
+                $cleanup_called = true;
+            },
+            'trailingslashit'    => function ( $s ) { return rtrim( $s, '/' ) . '/'; },
+            'sanitize_file_name' => function ( $s ) { return $s; },
+        ]);
+
+        $filesystem = Mockery::mock( 'WP_Filesystem_Base' );
+        $filesystem->shouldNotReceive( 'delete' );
+
+        $result = Blocks\process_and_replace_blocks( $filesystem, $file, $dirs );
+
+        $this->assertTrue( $result );
+        $this->assertTrue( $cleanup_called, 'cleanup_temp_directory must run on the success path.' );
+    }
+
 }


### PR DESCRIPTION
## Summary

When `unzip_uploaded_file()` returns a `WP_Error` inside `process_and_replace_blocks()`, the moved-but-never-extracted `.zip` was left on disk at the predictable path `wp-content/uploads/faustwp/blocks/`. Repeated failures accumulate dead files.

This PR deletes the target file before returning the error so the upload slot stays clean. The endpoint is auth-gated by the `x-faustwp-secret` header, so this is hygiene-class rather than directly exploitable, but it's still incorrect cleanup behaviour.

## Related Issue

Closes #2311

Split out from #2312 per @josephfusco's review feedback — the `hash_equals()` security hardening landed via #2312 (merged as `5d73ec86`) so each change could be reviewed and reverted independently.

## Confirm the issue (on canary)

```bash
sed -n '52,58p' plugins/faustwp/includes/blocks/functions.php
# Expected on canary (before fix):
#   $unzip_result = unzip_uploaded_file( $target_file, $dirs['target'] );
#   if ( is_wp_error( $unzip_result ) ) {
#       return $unzip_result;       ← no delete of $target_file
#   }
```

## Confirm the fix (this branch)

```bash
sed -n '52,58p' plugins/faustwp/includes/blocks/functions.php
# Expected:
#   $unzip_result = unzip_uploaded_file( $target_file, $dirs['target'] );
#   if ( is_wp_error( $unzip_result ) ) {
#       $wp_filesystem->delete( $target_file );
#       return $unzip_result;
#   }
```

## Run the test suite (corrected from earlier draft)

> NOTE: there is no `package.json` in `plugins/faustwp/`. The plugin's scripts are Composer scripts, not npm scripts. The commands below mirror what CI runs (`.github/workflows/unit-test-plugin.yml`).

```bash
cd plugins/faustwp
composer install
composer phpcs -- includes/blocks/functions.php tests/unit/BlockFunctionTests.php

WP_VERSION=6.8 composer run docker:start
docker compose exec wordpress init-testing-environment.sh
docker compose exec -w /var/www/html/wp-content/plugins/faustwp wordpress \
  wp plugin install wp-graphql --activate --allow-root

# New unit tests for process_and_replace_blocks (the function the fix touches)
docker compose exec -w /var/www/html/wp-content/plugins/faustwp wordpress \
  ./vendor/bin/phpunit --filter=process_and_replace_blocks
# Expected: OK (2 tests, 6 assertions)

# Full suite (single-site + multisite), what CI runs
docker compose exec -w /var/www/html/wp-content/plugins/faustwp wordpress \
  composer test
# Expected: OK on both runs
```

The `test_process_and_replace_blocks_cleans_up_on_unzip_failure` test is the regression guard — verified to fail when the new `$wp_filesystem->delete()` line is reverted (Mockery reports `delete should be called exactly 1 times but called 0 times`), pass with it in place.

## Checklist

- [x] Targets `canary`
- [x] Changeset added (`@faustwp/wordpress-plugin` patch)
- [x] Regression test added (`tests/unit/BlockFunctionTests.php`) — covers both unzip-failure path and success path
- [x] PHPCS clean on touched files
- [x] PHPUnit green on single-site and multisite

