### PR TITLE
ci: Fix npm publishing and GitHub release creation

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -41,7 +41,7 @@ jobs:
         run: npm ci
 
       - name: Upgrade npm for OIDC support
-        run: npm install -g npm@^11.5.1
+        run: npm install -g npm@11.13.0
 
       - name: Verify OIDC token availability
         run: |
@@ -63,4 +63,4 @@ jobs:
 
       - name: Push tags
         if: inputs.push-tags
-        run: git push --follow-tags
+        run: git push origin --tags


### PR DESCRIPTION
- [ ] I have signed a [Contributor License Agreement (CLA)](https://github.com/wpengine/faustjs#contributor-license-agreement) with WP Engine.

## Description
This PR fixes the issues below:
- npm upgrade failure: Pin npm to 11.13.0 instead of ^11.5.1 to avoid "Cannot find module 'promise-retry'" error that caused recent workflow failures
- Tags not pushed: Change from `git push --follow-tags` to `git push origin --tags` to ensure tags created by changeset publish are actually pushed to GitHub, enabling release creation

## Related Issues

https://github.com/wpengine/faustjs/issues/2344

## Testing

<!-- How can this be tested? -->
