### PR TITLE
ci: Add a workaround for npm install -g issue

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -40,6 +40,9 @@ jobs:
       - name: Install Dependencies
         run: npm ci
 
+      - name: Install legacy npm first, as a workaround for https://github.com/nodejs/node/issues/62425
+        run: npm install -g npm@10.9.8
+
       - name: Upgrade npm for OIDC support
         run: npm install -g npm@11.13.0
 


### PR DESCRIPTION

- [ ] I have signed a [Contributor License Agreement (CLA)](https://github.com/wpengine/faustjs#contributor-license-agreement) with WP Engine.

## Description
This PR adds a temporary workaround to the [known issue ](https://github.com/nodejs/node/issues/62425) of npm install -g npm@latest eagerly requiring promise-retry.

## Related Issues

<!-- Link related issues: #1234 -->

## Testing

<!-- How can this be tested? -->
