### PR TITLE
test[faustwp]: regression test for hash_equals secret-key comparison (follow-up to #2312)

### DIFF
--- a/plugins/faustwp/tests/integration/RestCallbacksTests.php
+++ b/plugins/faustwp/tests/integration/RestCallbacksTests.php
@@ -147,6 +147,9 @@ class RestCallbacksTests extends \WP_UnitTestCase {
 		$rest_callbacks    = file_get_contents( dirname( __DIR__, 2 ) . '/includes/rest/callbacks.php' );
 		$graphql_callbacks = file_get_contents( dirname( __DIR__, 2 ) . '/includes/graphql/callbacks.php' );
 
+		$this->assertNotFalse( $rest_callbacks, 'Failed to read includes/rest/callbacks.php for regression guard.' );
+		$this->assertNotFalse( $graphql_callbacks, 'Failed to read includes/graphql/callbacks.php for regression guard.' );
+
 		// The three bad patterns this PR replaces:
 		$this->assertStringNotContainsString( '=== $header_key', $rest_callbacks,
 			'rest_authorize_permission_callback must use hash_equals(), not ===.' );

--- a/plugins/faustwp/tests/integration/RestCallbacksTests.php
+++ b/plugins/faustwp/tests/integration/RestCallbacksTests.php
@@ -1,0 +1,167 @@
+<?php
+/**
+ * Class RestCallbacksTests
+ *
+ * @package FaustWP
+ */
+
+namespace WPE\FaustWP\Tests\Integration;
+
+use function WPE\FaustWP\Settings\faustwp_update_setting;
+use function WPE\FaustWP\REST\rest_authorize_permission_callback;
+use function WPE\FaustWP\REST\wpac_authorize_permission_callback;
+
+/**
+ * Regression tests for the REST permission callbacks in
+ * plugins/faustwp/includes/rest/callbacks.php.
+ *
+ * Specifically guards the timing-safe secret-key comparison fix for #2310,
+ * plus provides behavioural coverage for the wider contract (no coverage
+ * existed previously for either callback).
+ *
+ * @group rest
+ * @group auth
+ */
+class RestCallbacksTests extends \WP_UnitTestCase {
+
+	const VALID_SECRET = '00000000-0000-4000-8000-000000000001';
+	const WRONG_SECRET = 'definitely-not-the-right-key';
+
+	public function setUp(): void {
+		parent::setUp();
+		faustwp_update_setting( 'secret_key', self::VALID_SECRET );
+	}
+
+	private function make_request_with_faust_header( $value ): \WP_REST_Request {
+		$request = new \WP_REST_Request( 'POST', '/faustwp/v1/authorize' );
+		if ( null !== $value ) {
+			$request->set_header( 'x-faustwp-secret', $value );
+		}
+		return $request;
+	}
+
+	private function make_request_with_wpe_header( $value ): \WP_REST_Request {
+		$request = new \WP_REST_Request( 'POST', '/wpac/v1/authorize' );
+		if ( null !== $value ) {
+			$request->set_header( 'x-wpe-headless-secret', $value );
+		}
+		return $request;
+	}
+
+	// ----- rest_authorize_permission_callback (the current x-faustwp-secret route) -----
+
+	/**
+	 * Happy path: configured secret matches the request header → authorized.
+	 */
+	public function test_rest_authorize_returns_true_when_header_matches_secret(): void {
+		$request = $this->make_request_with_faust_header( self::VALID_SECRET );
+
+		$this->assertTrue( rest_authorize_permission_callback( $request ) );
+	}
+
+	/**
+	 * Wrong header value must be rejected. With hash_equals() this is a
+	 * constant-time false; the previous `===` check would have returned
+	 * the same boolean but via a fast short-circuit (the bug fixed by #2310).
+	 */
+	public function test_rest_authorize_returns_false_when_header_value_differs(): void {
+		$request = $this->make_request_with_faust_header( self::WRONG_SECRET );
+
+		$this->assertFalse( rest_authorize_permission_callback( $request ) );
+	}
+
+	/**
+	 * Missing x-faustwp-secret header → unauthorized. Guards the early return
+	 * at `if ( $secret_key && $header_key )`.
+	 */
+	public function test_rest_authorize_returns_false_when_header_is_missing(): void {
+		$request = $this->make_request_with_faust_header( null );
+
+		$this->assertFalse( rest_authorize_permission_callback( $request ) );
+	}
+
+	/**
+	 * Empty-string header → unauthorized. Guards against a downstream caller
+	 * sending `x-faustwp-secret: ` and accidentally being treated as authorized.
+	 */
+	public function test_rest_authorize_returns_false_when_header_is_empty_string(): void {
+		$request = $this->make_request_with_faust_header( '' );
+
+		$this->assertFalse( rest_authorize_permission_callback( $request ) );
+	}
+
+	/**
+	 * Server-side secret unset → unauthorized regardless of what the client sends.
+	 * Guards the early return for unconfigured installs.
+	 *
+	 * Note: we delete the option directly rather than calling
+	 * faustwp_update_setting('secret_key', '') because the
+	 * sanitize_option_faustwp_settings filter (at includes/settings/callbacks.php)
+	 * silently restores the previous value when the new one isn't a valid UUID,
+	 * so a string clear wouldn't actually clear it.
+	 */
+	public function test_rest_authorize_returns_false_when_secret_is_unset(): void {
+		delete_option( 'faustwp_settings' );
+		$request = $this->make_request_with_faust_header( self::VALID_SECRET );
+
+		$this->assertFalse( rest_authorize_permission_callback( $request ) );
+	}
+
+	// ----- wpac_authorize_permission_callback (the deprecated x-wpe-headless-secret route) -----
+
+	/**
+	 * The deprecated route still authorizes on a matching x-wpe-headless-secret.
+	 * Kept under test until the route is removed so the deprecation period
+	 * doesn't accidentally break older clients.
+	 */
+	public function test_wpac_authorize_returns_true_when_header_matches_secret(): void {
+		$request = $this->make_request_with_wpe_header( self::VALID_SECRET );
+
+		$this->assertTrue( wpac_authorize_permission_callback( $request ) );
+	}
+
+	/**
+	 * Wrong header value rejected by the deprecated route too.
+	 */
+	public function test_wpac_authorize_returns_false_when_header_value_differs(): void {
+		$request = $this->make_request_with_wpe_header( self::WRONG_SECRET );
+
+		$this->assertFalse( wpac_authorize_permission_callback( $request ) );
+	}
+
+	// ----- timing-safe-comparison regression guard (source-level) -----
+
+	/**
+	 * Source-level guard for #2310: the three secret-key comparisons in this
+	 * codebase must use hash_equals(), not `===`/`!==`. Behavioural tests above
+	 * cannot distinguish hash_equals() from `===` (both return the same boolean
+	 * for valid/invalid inputs); the distinction is timing-safety, which can't
+	 * be reliably asserted in unit tests. So we assert at the source level that
+	 * the known-bad shapes are not present and hash_equals() is.
+	 *
+	 * Narrowly-scoped to the exact patterns that the #2310 fix removed — false
+	 * positives are bounded to a future contributor reintroducing those exact
+	 * literal expressions, which is exactly the regression we want to catch.
+	 */
+	public function test_secret_comparisons_use_constant_time_hash_equals(): void {
+		$rest_callbacks    = file_get_contents( dirname( __DIR__, 2 ) . '/includes/rest/callbacks.php' );
+		$graphql_callbacks = file_get_contents( dirname( __DIR__, 2 ) . '/includes/graphql/callbacks.php' );
+
+		// The three bad patterns this PR replaces:
+		$this->assertStringNotContainsString( '=== $header_key', $rest_callbacks,
+			'rest_authorize_permission_callback must use hash_equals(), not ===.' );
+		$this->assertStringNotContainsString( "!== \$_SERVER['HTTP_X_FAUST_SECRET']", $graphql_callbacks,
+			'filter_introspection must use hash_equals(), not !==.' );
+
+		// And the positive: both files must contain hash_equals(). Use >= 1 rather
+		// than a hardcoded count so a future contributor adding a legitimate third
+		// hash_equals call (e.g. for a new permission callback) doesn't trip a
+		// false-positive "security regression". The not-contains assertions above
+		// are the real revert guards; these are affirmative checks that the timing-
+		// safe primitive is still present somewhere.
+		$this->assertGreaterThanOrEqual( 1, substr_count( $rest_callbacks, 'hash_equals' ),
+			'rest/callbacks.php must contain at least one hash_equals call.' );
+		$this->assertStringContainsString( 'hash_equals', $graphql_callbacks,
+			'filter_introspection must use hash_equals.' );
+	}
+}

--- a/plugins/faustwp/tests/integration/RestCallbacksTests.php
+++ b/plugins/faustwp/tests/integration/RestCallbacksTests.php
@@ -150,7 +150,10 @@ class RestCallbacksTests extends \WP_UnitTestCase {
 		$this->assertNotFalse( $rest_callbacks, 'Failed to read includes/rest/callbacks.php for regression guard.' );
 		$this->assertNotFalse( $graphql_callbacks, 'Failed to read includes/graphql/callbacks.php for regression guard.' );
 
-		// The three bad patterns this PR replaces:
+		// The bad comparison shapes this PR replaces (two distinct patterns, three
+		// call sites: '=== $header_key' covers both rest_authorize_permission_callback
+		// and wpac_authorize_permission_callback; '!== $_SERVER[...]' covers
+		// filter_introspection):
 		$this->assertStringNotContainsString( '=== $header_key', $rest_callbacks,
 			'rest_authorize_permission_callback must use hash_equals(), not ===.' );
 		$this->assertStringNotContainsString( "!== \$_SERVER['HTTP_X_FAUST_SECRET']", $graphql_callbacks,


### PR DESCRIPTION
## Summary

Follow-up to [#2312](https://github.com/wpengine/faustjs/pull/2312) (merged as `5d73ec86`), which landed the `hash_equals()` fix for #2310 without regression test coverage. canary now has the timing-safe secret-key comparison in production code, but no automated guard against a future revert.

This PR adds `plugins/faustwp/tests/integration/RestCallbacksTests.php` — tests-only, no production code changes. Both REST permission callbacks (`rest_authorize_permission_callback` and the deprecated `wpac_authorize_permission_callback`) previously had zero direct test coverage; this brings coverage up plus a source-level guard against the specific revert that would reintroduce the timing-attack vulnerability.

## Why this is a separate PR

The original #2312 had `maintainerCanModify: false`, so I couldn't push the test commit onto the contributor's fork branch. I'd opened this PR (#2362) with the same security fix plus tests, but #2312 merged first — so this PR's production-code commits are now empty against canary. Resetting the branch to a single tests-only commit keeps the safety net we built without re-shipping the already-merged code.

## Scope

| File | Status |
|---|---|
| `plugins/faustwp/tests/integration/RestCallbacksTests.php` | New — 8 tests, 12 assertions |
| No production code changes | — |
| No changeset | — (tests aren't customer-facing) |

## Tests

```bash
cd plugins/faustwp
composer install

WP_VERSION=6.8 composer run docker:start
docker compose exec wordpress init-testing-environment.sh
docker compose exec -w /var/www/html/wp-content/plugins/faustwp wordpress \
  wp plugin install wp-graphql --activate --allow-root

docker compose exec -w /var/www/html/wp-content/plugins/faustwp wordpress \
  ./vendor/bin/phpunit --filter=RestCallbacks
# Expected: OK (8 tests, 12 assertions)

# Full suite (single-site + multisite)
docker compose exec -w /var/www/html/wp-content/plugins/faustwp wordpress \
  composer test
```

## Test inventory

**Behavioural** (`rest_authorize_permission_callback`):
- match → true
- mismatch → false
- missing header → false
- empty-string header → false
- server-side secret unset → false (deletes the `faustwp_settings` option directly, because `sanitize_option_faustwp_settings` would otherwise restore a UUID-shaped value)

**Behavioural** (deprecated `wpac_authorize_permission_callback`):
- match → true
- mismatch → false

**Source-level regression guard** (`test_secret_comparisons_use_constant_time_hash_equals`):
- Asserts `=== $header_key` and `!== $_SERVER['HTTP_X_FAUST_SECRET']` are NOT present in the callbacks files.
- Asserts `hash_equals` IS present (`assertGreaterThanOrEqual(1, ...)` to avoid false positives if a future contributor adds a legitimate third `hash_equals` call).
- Behavioural tests cannot distinguish `hash_equals` from `===` for valid/invalid inputs — both return the same boolean. The security difference is timing, which is impractical to assert in unit tests. The source-level check is the only way to catch a future revert of the #2310 fix.

Verified red-on-revert against today's canary-based branch (HEAD `5f25cae7`, 2026-05-14): with `hash_equals` reverted to `===` / `!==` in `rest/callbacks.php` and `graphql/callbacks.php`, the source guard fails cleanly (`Failed asserting that ... does not contain "=== $header_key"`). Restoring `hash_equals` greens the suite. Full plugin PHPUnit run on WP 6.8: **134 tests, 303 assertions** on both single-site and multisite.

## Related

- Follows up #2312 (merged, closed #2310)
- Sister PR #2338 (still in flight) adds analogous regression coverage for the blockset cleanup
- Sister PR #2339 (merged) added analogous regression coverage for the Bedrock `home_url()` fix (`AuthCallbacksTests.php`)

Together these three test files give `handle_generate_endpoint`, `process_and_replace_blocks`, and the REST permission callbacks their first dedicated regression coverage. (`filter_introspection` is already covered by four pre-existing tests in `GraphQLCallbacksTests.php`.)

Co-authored-by: latenighthackathon <latenighthackathon@users.noreply.github.com>
