### PR TITLE
ci: add GitHub releases step to npm-publish workflow

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -67,3 +67,13 @@ jobs:
       - name: Push tags
         if: inputs.push-tags
         run: git push origin --tags
+
+      - name: Create GitHub Releases
+        if: inputs.push-tags
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git tag --points-at HEAD | while IFS= read -r tag; do
+            echo "Creating GitHub release for $tag"
+            gh release create "$tag" --title "$tag" --generate-notes || true
+          done


### PR DESCRIPTION
- [ ] I have signed a [Contributor License Agreement (CLA)](https://github.com/wpengine/faustjs#contributor-license-agreement) with WP Engine.

## Description

This PR adds a Create GitHub Releases step to npm-publish.yml and restores GitHub Release creation lost in #2264.

When #2264 migrated to OIDC and replaced changesets/action publish flow with npx changeset publish, GitHub Release creation silently stopped.

## Related Issues

- #2344 

## Testing

<!-- How can this be tested? -->
