### PR TITLE
ci: restore WordPress.org deploy workflow for faustwp

### DIFF
--- a/.github/workflows/release-plugin.yml
+++ b/.github/workflows/release-plugin.yml
@@ -1,0 +1,78 @@
+name: Deploy to WordPress.org
+
+on:
+  push:
+    tags:
+      - '@faustwp/wordpress-plugin@*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to operate on (e.g. @faustwp/wordpress-plugin@1.8.8)'
+        required: true
+        type: string
+      dry_run:
+        description: 'Skip the SVN commit (verifies wp.org credentials without publishing)'
+        required: false
+        default: true
+        type: boolean
+      redeploy:
+        description: 'Delete the existing SVN tag before publishing'
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: write
+
+jobs:
+  release_plugin:
+    name: Publish faustwp to WordPress.org
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.tag || github.ref_name }}
+
+      - name: Compute SVN version from tag
+        id: version
+        env:
+          RAW_REF: ${{ inputs.tag || github.ref_name }}
+        run: |
+          # Strip the Changesets-style "@faustwp/wordpress-plugin@" prefix so VERSION
+          # is just "1.8.8". Upstream 10up deploy.sh only strips refs/tags/ and a leading v.
+          version="${RAW_REF#@faustwp/wordpress-plugin@}"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "Resolved SVN version: $version"
+
+      - name: Delete existing SVN tag
+        if: ${{ inputs.redeploy && !inputs.dry_run }}
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
+          SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
+        run: |
+          svn delete "https://plugins.svn.wordpress.org/faustwp/tags/${VERSION}" \
+            -m "Delete tag ${VERSION} for redeployment" \
+            --username "$SVN_USERNAME" --password "$SVN_PASSWORD" \
+            --non-interactive || echo "Tag ${VERSION} did not exist; continuing"
+
+      - name: WordPress Plugin Deploy
+        id: deploy
+        uses: 10up/action-wordpress-plugin-deploy@54bd289b8525fd23a5c365ec369185f2966529c2 # v2.3.0
+        with:
+          generate-zip: true
+          dry-run: ${{ inputs.dry_run || false }}
+        env:
+          SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
+          SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
+          SLUG: faustwp
+          BUILD_DIR: plugins/faustwp
+          ASSETS_DIR: .wordpress-org
+          VERSION: ${{ steps.version.outputs.version }}
+
+      - name: Attach plugin zip to GitHub Release
+        if: ${{ !inputs.dry_run }}
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.4.0
+        with:
+          tag_name: ${{ inputs.tag || github.ref_name }}
+          files: ${{ steps.deploy.outputs.zip-path }}

--- a/.github/workflows/release-plugin.yml
+++ b/.github/workflows/release-plugin.yml
@@ -38,9 +38,12 @@ jobs:
         env:
           RAW_REF: ${{ inputs.tag || github.ref_name }}
         run: |
-          # Strip the Changesets-style "@faustwp/wordpress-plugin@" prefix so VERSION
-          # is just "1.8.8". Upstream 10up deploy.sh only strips refs/tags/ and a leading v.
-          version="${RAW_REF#@faustwp/wordpress-plugin@}"
+          # Normalize to a tag name (strip refs/tags/), then strip optional leading "v".
+          ref="${RAW_REF#refs/tags/}"
+          ref="${ref#v}"
+
+          # Strip the Changesets-style "@faustwp/wordpress-plugin@" prefix so VERSION is just "1.8.8".
+          version="${ref#@faustwp/wordpress-plugin@}"
           echo "version=$version" >> "$GITHUB_OUTPUT"
           echo "Resolved SVN version: $version"
 

--- a/.github/workflows/release-plugin.yml
+++ b/.github/workflows/release-plugin.yml
@@ -51,10 +51,15 @@ jobs:
           SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
           SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
         run: |
-          svn delete "https://plugins.svn.wordpress.org/faustwp/tags/${VERSION}" \
-            -m "Delete tag ${VERSION} for redeployment" \
-            --username "$SVN_USERNAME" --password "$SVN_PASSWORD" \
-            --non-interactive || echo "Tag ${VERSION} did not exist; continuing"
+          TAG_URL="https://plugins.svn.wordpress.org/faustwp/tags/${VERSION}"
+          if svn info "$TAG_URL" --username "$SVN_USERNAME" --password "$SVN_PASSWORD" --non-interactive >/dev/null 2>&1; then
+            svn delete "$TAG_URL" \
+              -m "Delete tag ${VERSION} for redeployment" \
+              --username "$SVN_USERNAME" --password "$SVN_PASSWORD" \
+              --non-interactive
+          else
+            echo "Tag ${VERSION} did not exist; continuing"
+          fi
 
       - name: WordPress Plugin Deploy
         id: deploy


### PR DESCRIPTION
## Summary

Restores the `Deploy to WordPress.org` workflow for the `faustwp` plugin, removed in late 2024. Triggers on `@faustwp/wordpress-plugin@*` tag pushes and calls `10up/action-wordpress-plugin-deploy` directly.

## Changes from the prior version

- Upstream `10up/action-wordpress-plugin-deploy@v2.3.0` (SHA-pinned) replaces the vendored composite action previously at `.github/actions/release-plugin/`. Upstream now supports the monorepo path via `BUILD_DIR`.
- Adds a `Compute SVN version from tag` step to strip the `@faustwp/wordpress-plugin@` prefix; upstream's deploy script only strips `refs/tags/` and a leading `v`.
- Adds `workflow_dispatch` with `tag`, `dry_run` (default `true`), and `redeploy` inputs. Dry run exercises credentials end-to-end without committing; redeploy deletes the SVN tag before publishing.
- Attaches the generated plugin zip to the matching GitHub Release via `softprops/action-gh-release@v2.4.0` (SHA-pinned).
- `actions/checkout@v5`, `runs-on: ubuntu-22.04`, explicit `ref` on checkout for the dispatch path.

## Test plan

- [ ] Dispatch from the Actions tab with `dry_run: true` and `tag: @faustwp/wordpress-plugin@1.8.0`. Confirm the deploy step authenticates against `plugins.svn.wordpress.org/faustwp/` and exits without committing.
- [ ] If auth fails, rotate `SVN_PASSWORD` and rerun.
- [ ] On the next Changesets release tag, verify SVN trunk and the new tag are updated, and the plugin zip is attached to the GitHub Release.