### PR TITLE
chore: defer queued changesets until after security release

### DIFF
--- a/.changeset/blockset-cleanup-on-failed-extraction.md
+++ b/.changeset/blockset-cleanup-on-failed-extraction.md
@@ -1,5 +1,0 @@
----
-"@faustwp/wordpress-plugin": patch
----
-
-fix[faustwp]: clean up uploaded blockset zip when extraction fails

--- a/.changeset/handle-generate-home-url.md
+++ b/.changeset/handle-generate-home-url.md
@@ -1,5 +1,0 @@
----
-"@faustwp/wordpress-plugin": patch
----
-
-fix[faustwp]: use home_url() in handle_generate_endpoint so Bedrock-style installs (where WordPress core lives under /wp/) match against the public REQUEST_URI

--- a/.changeset/hash-equals-secret-comparison.md
+++ b/.changeset/hash-equals-secret-comparison.md
@@ -1,5 +1,0 @@
----
-"@faustwp/wordpress-plugin": patch
----
-
-fix[faustwp]: use hash_equals() for constant-time secret key comparison in REST and GraphQL permission callbacks


### PR DESCRIPTION
## Summary

Removes three queued changesets from `canary` so the next Version Packages PR is scoped to the security fix only. The changeset files remain recoverable from git history and will be reintroduced after the security release ships.

## Deferred

- `blockset-cleanup-on-failed-extraction.md`
- `handle-generate-home-url.md`
- `hash-equals-secret-comparison.md`

## Reintroducing post-release

```
git checkout 0598216c -- .changeset/blockset-cleanup-on-failed-extraction.md \
                         .changeset/handle-generate-home-url.md \
                         .changeset/hash-equals-secret-comparison.md
```

## Test plan

- [ ] After merge, confirm the open Version Packages PR (#2361) is updated to reflect no pending changesets.
- [ ] After the security changeset lands, confirm the regenerated Version Packages PR contains only that changeset.