### PR TITLE
ci: apply .distignore and correct ASSETS_DIR in faustwp deploy

### DIFF
--- a/.github/workflows/release-plugin.yml
+++ b/.github/workflows/release-plugin.yml
@@ -64,6 +64,19 @@ jobs:
             echo "Tag ${VERSION} did not exist; continuing"
           fi
 
+      - name: Stage clean plugin payload
+        # Upstream 10up skips .distignore when BUILD_DIR is set, so apply the
+        # exclusion rules here by rsyncing plugins/faustwp/ into a staging
+        # directory through .distignore. The 10up step then ships the staging
+        # directory as-is.
+        run: |
+          mkdir -p plugin-build/faustwp
+          rsync -rc \
+            --exclude-from=plugins/faustwp/.distignore \
+            --exclude=plugin-build \
+            plugins/faustwp/ plugin-build/faustwp/ \
+            --delete --delete-excluded
+
       - name: WordPress Plugin Deploy
         id: deploy
         uses: 10up/action-wordpress-plugin-deploy@54bd289b8525fd23a5c365ec369185f2966529c2 # v2.3.0
@@ -74,8 +87,10 @@ jobs:
           SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
           SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
           SLUG: faustwp
-          BUILD_DIR: plugins/faustwp
-          ASSETS_DIR: .wordpress-org
+          BUILD_DIR: plugin-build/faustwp
+          # ASSETS_DIR is resolved against GITHUB_WORKSPACE, not BUILD_DIR,
+          # so it must be the full workspace-relative path.
+          ASSETS_DIR: plugins/faustwp/.wordpress-org
           VERSION: ${{ steps.version.outputs.version }}
 
       - name: Attach plugin zip to GitHub Release


### PR DESCRIPTION
## Summary

Two defects in the WordPress.org deploy left the published payload bloated. The shipped `faustwp 1.8.8` zip is ~1.77 MB; with these fixes a clean payload is roughly one-tenth that size and excludes dev-only files. The plugin still functions correctly today — these are payload hygiene fixes, not a security regression — and a redeploy will replace the SVN tag with a clean copy.

## Defects

- Upstream `10up/action-wordpress-plugin-deploy` skips `.distignore` when `BUILD_DIR` is set. The `deploy.sh` branch that uses `--exclude-from $GITHUB_WORKSPACE/.distignore` runs only for the no-`BUILD_DIR` case; the `BUILD_DIR` branch is a plain `rsync` without exclusions.
- `ASSETS_DIR` is resolved against `$GITHUB_WORKSPACE`, not `$BUILD_DIR`. The previous value `.wordpress-org` pointed at the repo root (non-existent), so wp.org assets fell through to the trunk rsync and shipped to user sites.

## Changes

- New `Stage clean plugin payload` step rsyncs `plugins/faustwp/` into `plugin-build/faustwp/` applying `plugins/faustwp/.distignore`.
- `BUILD_DIR` updated to `plugin-build/faustwp`.
- `ASSETS_DIR` updated to `plugins/faustwp/.wordpress-org` (workspace-relative).

## Test plan

- [ ] Dispatch with `dry_run: true`, `tag: @faustwp/wordpress-plugin@1.8.8`. Confirm the staging step runs, the deploy log shows expected files only, and no `tests/`, `phpstan/`, `composer.*`, or `.wordpress-org/` content appears under `trunk/`.
- [ ] Dispatch with `dry_run: false`, `redeploy: true`, `tag: @faustwp/wordpress-plugin@1.8.8`. Verify the new SVN commit reflects the clean payload and `.wordpress-org/` content lands under `assets/`, not `trunk/`.