### PR TITLE
fix(faustwp): restore wordpress.org as plugin update channel

### DIFF
--- a/.changeset/restore-wp-org-updates.md
+++ b/.changeset/restore-wp-org-updates.md
@@ -1,0 +1,5 @@
+---
+"@faustwp/wordpress-plugin": patch
+---
+
+Remove the `Update URI: false` header from `faustwp.php` so WordPress checks wordpress.org for plugin updates. This restores wordpress.org as the canonical update channel for new installs. The 1.8.8 security fix (GHSA-q6pm-r77q-qcv3) — include the IV in the token envelope HMAC to prevent authentication bypass — was reported by ParkHyunWoo (@hwpark6804-gif) via Patchstack.

--- a/plugins/faustwp/faustwp.php
+++ b/plugins/faustwp/faustwp.php
@@ -13,7 +13,6 @@
  * Requires PHP: 7.4
  * Requires at least: 5.7
  * Tested up to: 6.9
- * Update URI: false
  *
  * @package FaustWP
  */


### PR DESCRIPTION
## Summary

Removes the `Update URI: false` header from `faustwp.php` so WordPress checks wordpress.org for `faustwp` plugin updates. The header was added in #1964 (2024-10) alongside the embedded `PluginUpdater`; restoring the default behaviour makes wordpress.org the canonical update channel.

Includes a changeset crediting ParkHyunWoo (@hwpark6804-gif) for the 1.8.8 security fix reported via Patchstack (GHSA-q6pm-r77q-qcv3).

## Scope

- Affects future installs and reinstalls.
- Sites already running 1.8.0 retain `Update URI: false` in their installed `faustwp.php` until they update to a version shipped after this change. Reaching those sites still requires either the `PluginUpdater` endpoint or a manual install.

## Test plan

- [ ] After merge, the regenerated Version Packages PR bumps `@faustwp/wordpress-plugin` to 1.8.9.
- [ ] On release, verify the published `faustwp.php` on wordpress.org SVN does not contain `Update URI:`.
- [ ] On a fresh WordPress install of `faustwp` from wordpress.org, confirm the standard plugin update flow detects updates.