### PR TITLE
ci: allow composer/installers plugin in wpackagist verify arm

### DIFF
--- a/.github/workflows/verify-published-plugin.yml
+++ b/.github/workflows/verify-published-plugin.yml
@@ -144,6 +144,11 @@ jobs:
             ],
             "require": {
               "wpackagist-plugin/faustwp": "${VERSION}"
+            },
+            "config": {
+              "allow-plugins": {
+                "composer/installers": true
+              }
             }
           }
           EOF


### PR DESCRIPTION
Allow-lists composer/installers in the throwaway composer.json so Composer 2.2+ does not block the install step in the wpackagist matrix arm.