### PR TITLE
ci: pin composer/installers path for wpackagist verify arm

### DIFF
--- a/.github/workflows/verify-published-plugin.yml
+++ b/.github/workflows/verify-published-plugin.yml
@@ -149,6 +149,11 @@ jobs:
               "allow-plugins": {
                 "composer/installers": true
               }
+            },
+            "extra": {
+              "installer-paths": {
+                "vendor/{\$vendor}/{\$name}": ["type:wordpress-plugin"]
+              }
             }
           }
           EOF


### PR DESCRIPTION
Overrides the composer/installers default destination so wpackagist-plugin/* packages land at vendor/<vendor>/<name> for the cp step.