### PR TITLE
ci: wire wordpress.org deploy through the existing release-plugin action

### DIFF
--- a/.github/actions/release-plugin/action.yml
+++ b/.github/actions/release-plugin/action.yml
@@ -8,6 +8,10 @@ inputs:
   github_token:
     description: 'GitHub Token'
     required: true
+  upload-artifacts:
+    description: 'Upload generated artifacts to the matching GitHub Release. Set to false for dry-run builds.'
+    required: false
+    default: 'true'
 
 outputs:
   zip-path:
@@ -56,11 +60,9 @@ runs:
         rm -rf dist
         # Create dist folder and copy files while excluding .distignore items
         mkdir -p dist
-        # Copy plugin files to dist folder and exclude external updater
-        rsync -av --exclude-from="${{ env.PLUGIN_DIR }}/.distignore" --exclude="includes/updates/check-for-updates.php" --exclude="includes/updates/class-plugin-updater.php" "${{ env.PLUGIN_DIR }}/" "dist/${{ env.SLUG }}"
-
-        # Updates for the CHANGELOG file
-        sed -i -e '/## 1.6.0/,+4d' "dist/${{ env.SLUG }}/CHANGELOG.md"
+        # Copy plugin files to dist folder; exclude the embedded updater code
+        # and CHANGELOG.md (wp.org users see release history via readme.txt).
+        rsync -av --exclude-from="${{ env.PLUGIN_DIR }}/.distignore" --exclude="includes/updates/check-for-updates.php" --exclude="includes/updates/class-plugin-updater.php" --exclude="CHANGELOG.md" "${{ env.PLUGIN_DIR }}/" "dist/${{ env.SLUG }}"
 
         # Allow updates for .org
         sed -i -e '/\* Update URI: false/d' "dist/${{ env.SLUG }}/faustwp.php"
@@ -75,6 +77,7 @@ runs:
 
     - id: upload-main-release-to-github
       name: Uploads the main release zip file to GitHub
+      if: inputs.upload-artifacts == 'true'
       uses: softprops/action-gh-release@v2
       with:
         token: ${{ inputs.github_token }}
@@ -85,6 +88,7 @@ runs:
 
     - id: upload-org-release-to-github
       name: Uploads the non wpe-updater release zip file to GitHub
+      if: inputs.upload-artifacts == 'true'
       uses: softprops/action-gh-release@v2
       with:
         token: ${{ inputs.github_token }}
@@ -95,6 +99,7 @@ runs:
 
     - id: generate-info-json
       name: Fetch and update info.json for WPE release
+      if: inputs.upload-artifacts == 'true'
       run: |
         bash .github/scripts/add-wpe-version-info-file.sh ${{ env.VERSION }}
         echo "info-json-path=$PWD/info.json" >> $GITHUB_ENV
@@ -102,6 +107,7 @@ runs:
 
     - id: upload-info-json-to-github
       name: Upload info.json to GitHub Releases
+      if: inputs.upload-artifacts == 'true'
       uses: softprops/action-gh-release@v2
       with:
         token: ${{ inputs.github_token }}
@@ -109,3 +115,19 @@ runs:
         asset_name: info.json
         tag_name: "@faustwp/wordpress-plugin@${{ env.ASSET_RELEASE_VERSION }}"
         overwrite: true
+
+    - id: release-summary
+      name: Print release summary
+      if: inputs.upload-artifacts == 'true'
+      shell: bash
+      run: |
+        base="https://github.com/wpengine/faustjs/releases/download/@faustwp/wordpress-plugin@${ASSET_RELEASE_VERSION}"
+        zip_name="${SLUG}.${VERSION}.zip"
+        {
+          echo "## ${SLUG} ${ASSET_RELEASE_VERSION}"
+          echo
+          echo "- Slug: \`${SLUG}\`"
+          echo "- Version: \`${ASSET_RELEASE_VERSION}\`"
+          echo "- Plugin zip: [${zip_name}](${base}/${zip_name})"
+          echo "- info.json: [info.json](${base}/info.json)"
+        } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release-plugin.yml
+++ b/.github/workflows/release-plugin.yml
@@ -11,7 +11,7 @@ on:
         required: true
         type: string
       dry_run:
-        description: 'Skip the SVN commit (verifies wp.org credentials without publishing)'
+        description: 'Build artifacts but skip the wordpress.org deploy job'
         required: false
         default: true
         type: boolean
@@ -25,9 +25,11 @@ permissions:
   contents: write
 
 jobs:
-  release_plugin:
-    name: Publish faustwp to WordPress.org
+  build_artifacts:
+    name: Build distribution artifacts
     runs-on: ubuntu-22.04
+    outputs:
+      version: ${{ steps.version.outputs.version }}
     steps:
       - uses: actions/checkout@v5
         with:
@@ -47,10 +49,53 @@ jobs:
           echo "version=$version" >> "$GITHUB_OUTPUT"
           echo "Resolved SVN version: $version"
 
-      - name: Delete existing SVN tag
-        if: ${{ inputs.redeploy && !inputs.dry_run }}
+      - name: Build distribution artifacts
+        # The local composite action is the single source of truth for what the
+        # wordpress.org distribution contains: it rsyncs the plugin source into
+        # dist/<slug>/ with the .org-specific exclusions applied, and (when
+        # upload-artifacts is true) uploads the main zip, the .org zip, and
+        # info.json to the matching GitHub Release.
+        uses: ./.github/actions/release-plugin
         env:
           VERSION: ${{ steps.version.outputs.version }}
+          PLUGIN_DIR: plugins/faustwp
+          SLUG: faustwp
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          upload-artifacts: ${{ !inputs.dry_run }}
+
+      - name: Upload .org payload for the deploy job
+        if: ${{ !inputs.dry_run }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: faustwp-org-payload
+          path: dist/faustwp
+          retention-days: 1
+          include-hidden-files: true
+
+  deploy_to_wordpress_org:
+    name: Deploy to WordPress.org
+    if: ${{ !inputs.dry_run }}
+    needs: build_artifacts
+    runs-on: ubuntu-22.04
+    environment:
+      name: wordpress-org
+      url: https://wordpress.org/plugins/faustwp/
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.tag || github.ref_name }}
+
+      - name: Download .org payload
+        uses: actions/download-artifact@v4
+        with:
+          name: faustwp-org-payload
+          path: dist/faustwp
+
+      - name: Delete existing SVN tag
+        if: ${{ inputs.redeploy }}
+        env:
+          VERSION: ${{ needs.build_artifacts.outputs.version }}
           SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
           SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
         run: |
@@ -64,38 +109,14 @@ jobs:
             echo "Tag ${VERSION} did not exist; continuing"
           fi
 
-      - name: Stage clean plugin payload
-        # Upstream 10up skips .distignore when BUILD_DIR is set, so apply the
-        # exclusion rules here by rsyncing plugins/faustwp/ into a staging
-        # directory through .distignore. The 10up step then ships the staging
-        # directory as-is.
-        run: |
-          mkdir -p plugin-build/faustwp
-          rsync -rc \
-            --exclude-from=plugins/faustwp/.distignore \
-            --exclude=plugin-build \
-            plugins/faustwp/ plugin-build/faustwp/ \
-            --delete --delete-excluded
-
       - name: WordPress Plugin Deploy
-        id: deploy
         uses: 10up/action-wordpress-plugin-deploy@54bd289b8525fd23a5c365ec369185f2966529c2 # v2.3.0
-        with:
-          generate-zip: true
-          dry-run: ${{ inputs.dry_run || false }}
         env:
           SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
           SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
           SLUG: faustwp
-          BUILD_DIR: plugin-build/faustwp
-          # ASSETS_DIR is resolved against GITHUB_WORKSPACE, not BUILD_DIR,
-          # so it must be the full workspace-relative path.
+          # The build_artifacts job produced the .org-stripped payload at dist/faustwp.
+          BUILD_DIR: dist/faustwp
+          # ASSETS_DIR is resolved against GITHUB_WORKSPACE, not BUILD_DIR.
           ASSETS_DIR: plugins/faustwp/.wordpress-org
-          VERSION: ${{ steps.version.outputs.version }}
-
-      - name: Attach plugin zip to GitHub Release
-        if: ${{ !inputs.dry_run }}
-        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.4.0
-        with:
-          tag_name: ${{ inputs.tag || github.ref_name }}
-          files: ${{ steps.deploy.outputs.zip-path }}
+          VERSION: ${{ needs.build_artifacts.outputs.version }}


### PR DESCRIPTION
Routes the wordpress.org deploy through the existing local action, excludes CHANGELOG.md from the .org payload at the file level, and splits the workflow into a build job and an environment-gated deploy job.