### PR TITLE
fix(faustwp): exclude updater code from wordpress.org build, add info.json

### DIFF
--- a/plugins/faustwp/.distignore
+++ b/plugins/faustwp/.distignore
@@ -23,3 +23,5 @@ package.json
 coverage
 phpstan.neon.dist
 /phpstan
+includes/updates
+info.json

--- a/plugins/faustwp/CHANGELOG.md
+++ b/plugins/faustwp/CHANGELOG.md
@@ -127,7 +127,7 @@
 
 ### Minor Changes
 
-- 011cd931: - Added a custom PluginUpdater class to enable FaustWP plugin updates from an external API endpoint.
+- 011cd931: - Added a custom PluginUpdater class to enable FaustWP plugin updates from an external API endpoint. Applies to non-wordpress.org distributions only.
 
 ## 1.4.1
 

--- a/plugins/faustwp/faustwp.php
+++ b/plugins/faustwp/faustwp.php
@@ -61,7 +61,9 @@ if ( ! is_php_version_compatible( faustwp_minimum_php_requirement() ) ) {
 	return;
 }
 
-// Loads the updater service, if included in this build.
+// Loads the updater service when present. The files under includes/updates/
+// are excluded from the wordpress.org build, so these requires only execute
+// in distributions that ship the updater.
 if ( file_exists( FAUSTWP_DIR . '/includes/updates/class-plugin-updater.php' ) ) {
 	require FAUSTWP_DIR . '/includes/updates/class-plugin-updater.php';
 }

--- a/plugins/faustwp/info.json
+++ b/plugins/faustwp/info.json
@@ -1,0 +1,201 @@
+{
+  "name": "Faust.js™",
+  "slug": "faustwp",
+  "version": "1.8.9",
+  "requires": "5.7",
+  "tested": "6.9",
+  "requires_php": "7.4",
+  "requires_plugins": [],
+  "rating": 100,
+  "ratings": {
+    "1": 0,
+    "2": 0,
+    "3": 0,
+    "4": 0,
+    "5": 7
+  },
+  "num_ratings": 7,
+  "support_url": "https://wordpress.org/support/plugin/faustwp/",
+  "support_threads": 0,
+  "support_threads_resolved": 0,
+  "active_installs": 1000,
+  "last_updated": "2026-06-03 5:32pm GMT",
+  "added": "2021-12-02",
+  "homepage": "https://faustjs.org/",
+  "sections": {
+    "description": "In conjunction with the [Faust.js™ NPM packages](https://www.npmjs.com/search?q=%40faustwp), the Faust.js™ WordPress plugin enables a decoupled front-end to authenticate with WordPress through GraphQL mutations and REST API endpoints. It is the bridge between a Faust.js™ powered front-end application, and a WordPress backend.\n\n\n\nThe plugin also provides useful options for headless sites, such as the ability to:\n\n\n\n- Hide “theme” admin pages.\n\n- Redirect public route requests to the front-end application.\n\n- Rewrite WordPress URLs to front-end URLs in queried content.",
+    "installation": "1. Search for the plugin in WordPress under \"Plugins -> Add New\".\n\n2. Click the “Install Now” button, followed by \"Activate\".\n\n\n\nThat's it! For more information on getting started with headless WordPress, see [Getting Started with Faust.js](https://faustjs.org/docs/tutorial/dev-env-setup).",
+    "faq": "= If I need more support, where should I ask questions? =\n\nUse one of the channels below to contact the Faust.js team for support.\n\n[GitHub](https://github.com/wpengine/faustjs) - Faust.js GitHub documentation and codebase.\n\n[Discord](https://discord.gg/J2khkF9XYK) - Interactive chat support on Discord.\n\n\n\n= Where can I find more information about development and future features for this plugin? =\n\n\n\nGreat question! The development team posts weekly summaries of sprints related to Faust.js, [here](https://faustjs.org/blog).\n\n\n\n= Why the name “Faust.js”? =\n\n\n\nJohann Faust was a German printer and was instrumental in the invention of the printing press, along with his partner Johann Gutenberg. In the same way the printing press democratized the spread of information, the mission of Faust.js is to support and further the vision of WordPress to democratize publishing on the web.",
+    "changelog": "= 1.8.9 =\n\n\n\n### Patch Changes\n\n\n\n- 139479d: Remove the `Update URI: false` header from `faustwp.php` so WordPress checks wordpress.org for plugin updates. This restores wordpress.org as the canonical update channel for new installs. The 1.8.8 security fix (GHSA-q6pm-r77q-qcv3) — include the IV in the token envelope HMAC to prevent authentication bypass — was reported by ParkHyunWoo (@hwpark6804-gif) via Patchstack.\n\n\n\n= 1.8.8 =\n\n\n\n### Patch Changes\n\n\n\n- cda00de: fix[faustwp]: include the IV in the token envelope HMAC to prevent authentication bypass via IV bit-flipping (GHSA-q6pm-r77q-qcv3)\n\n\n\n= 1.8.7 =\n\n\n\n### Patch Changes\n\n\n\n- ca1e2f4: fix[faustwp]: update documentation links in settings page to use current URL structure\n\n\n\n[View the full changelog](https://github.com/wpengine/faustjs/blob/canary/plugins/faustwp/CHANGELOG.md)",
+    "screenshots": "1. The settings page\n\n2. Portfolio, blog, and basic blueprints for headless sites built with Faust.js\n\n3. A code snippet\n\n\n\nplugins/faustwp/.wordpress-org/screenshot-1.png\n\nplugins/faustwp/.wordpress-org/screenshot-2.png\n\nplugins/faustwp/.wordpress-org/screenshot-3.png"
+  },
+  "download_link": "https://wpe-plugin-updates.wpengine.com/faustwp/faustwp.1.8.9.zip",
+  "upgrade_notice": [],
+  "screenshots": {
+    "1": {
+      "src": "https://ps.w.org/faustwp/assets/screenshot-1.png?rev=2834048",
+      "caption": "The settings page"
+    },
+    "2": {
+      "src": "https://ps.w.org/faustwp/assets/screenshot-2.png?rev=2834048",
+      "caption": "Portfolio, blog, and basic blueprints for headless sites built with Faust.js"
+    },
+    "3": {
+      "src": "https://ps.w.org/faustwp/assets/screenshot-3.png?rev=2834048",
+      "caption": "A code snippet"
+    }
+  },
+  "tags": {
+    "composable-architecture": "composable-architecture",
+    "decoupled": "decoupled",
+    "faust": "faust",
+    "faustjs": "faustjs",
+    "headless": "headless"
+  },
+  "versions": {
+    "1.7.1": "https://wpe-plugin-updates.wpengine.com/faustwp/faustwp.1.7.1.zip",
+    "1.8.0": "https://wpe-plugin-updates.wpengine.com/faustwp/faustwp.1.8.0.zip",
+    "1.8.4": "https://wpe-plugin-updates.wpengine.com/faustwp/faustwp.1.8.4.zip",
+    "1.8.5": "https://wpe-plugin-updates.wpengine.com/faustwp/faustwp.1.8.5.zip",
+    "1.8.6": "https://wpe-plugin-updates.wpengine.com/faustwp/faustwp.1.8.6.zip",
+    "1.8.7": "https://wpe-plugin-updates.wpengine.com/faustwp/faustwp.1.8.7.zip",
+    "1.8.8": "https://wpe-plugin-updates.wpengine.com/faustwp/faustwp.1.8.8.zip",
+    "1.8.9": "https://wpe-plugin-updates.wpengine.com/faustwp/faustwp.1.8.9.zip"
+  },
+  "business_model": false,
+  "repository_url": "",
+  "commercial_support_url": "",
+  "donate_link": "",
+  "banners": {
+    "low": "https://ps.w.org/faustwp/assets/banner-772x250.jpg?rev=2717649",
+    "high": "https://ps.w.org/faustwp/assets/banner-1544x500.jpg?rev=2717649"
+  },
+  "preview_link": "",
+  "short_description": "Plugin for working with Faust.js™, the Headless WordPress Framework.",
+  "contributors": [
+    {
+      "name": "antpb",
+      "type": "wporg",
+      "display_name": "Anthony Burchell",
+      "profile": "https://profiles.wordpress.org/antpb/",
+      "avatar": "https://secure.gravatar.com/avatar/453fbc8dfd108125f351d60fd2c1afe7?s=96&d=monsterid&r=g"
+    },
+    {
+      "name": "apmatthe",
+      "type": "wporg",
+      "display_name": "Andrew Matthews",
+      "profile": "https://profiles.wordpress.org/apmatthe/",
+      "avatar": "https://secure.gravatar.com/avatar/f98249968d900facd762493653a88b55?s=96&d=monsterid&r=g"
+    },
+    {
+      "name": "blakewpe",
+      "type": "wporg",
+      "display_name": "blakewpe",
+      "profile": "https://profiles.wordpress.org/blakewpe/",
+      "avatar": "https://secure.gravatar.com/avatar/f524fa068f734464722879d20ff57c5b?s=96&d=monsterid&r=g"
+    },
+    {
+      "name": "chriswiegman",
+      "type": "wporg",
+      "display_name": "Chris Wiegman",
+      "profile": "https://profiles.wordpress.org/chriswiegman/",
+      "avatar": "https://secure.gravatar.com/avatar/9a6372cbe7f7d32d0d27700862011288?s=96&d=monsterid&r=g"
+    },
+    {
+      "name": "claygriffiths",
+      "type": "wporg",
+      "display_name": "claygriffiths",
+      "profile": "https://profiles.wordpress.org/claygriffiths/",
+      "avatar": "https://secure.gravatar.com/avatar/c0456b3a19468fef8914a2f5371b40d6?s=96&d=monsterid&r=g"
+    },
+    {
+      "name": "colin-murphy",
+      "type": "wporg",
+      "display_name": "Colin Murphy",
+      "profile": "https://profiles.wordpress.org/colin-murphy/",
+      "avatar": "https://secure.gravatar.com/avatar/1ea83a4092e913bc43b099775f29b5b1?s=96&d=monsterid&r=g"
+    },
+    {
+      "name": "jasonkonen",
+      "type": "wporg",
+      "display_name": "Jason Konen",
+      "profile": "https://profiles.wordpress.org/jasonkonen/",
+      "avatar": "https://secure.gravatar.com/avatar/42e19a5a178ec1033215a45a1d683ef3?s=96&d=monsterid&r=g"
+    },
+    {
+      "name": "joefusco",
+      "type": "wporg",
+      "display_name": "Joe Fusco",
+      "profile": "https://profiles.wordpress.org/joefusco/",
+      "avatar": "https://secure.gravatar.com/avatar/11e370caa8ea5e1fb9e6b812d5c409f8?s=96&d=monsterid&r=g"
+    },
+    {
+      "name": "markkelnar",
+      "type": "wporg",
+      "display_name": "markkelnar",
+      "profile": "https://profiles.wordpress.org/markkelnar/",
+      "avatar": "https://secure.gravatar.com/avatar/5f17b8a0d0213ed2bc805ac40e83b1c5?s=96&d=monsterid&r=g"
+    },
+    {
+      "name": "matthewguywright",
+      "type": "wporg",
+      "display_name": "Matthew Wright",
+      "profile": "https://profiles.wordpress.org/matthewguywright/",
+      "avatar": "https://secure.gravatar.com/avatar/fe6a4f9674110c793a2c408d81b5dfae?s=96&d=monsterid&r=g"
+    },
+    {
+      "name": "mindctrl",
+      "type": "wporg",
+      "display_name": "John Parris",
+      "profile": "https://profiles.wordpress.org/mindctrl/",
+      "avatar": "https://secure.gravatar.com/avatar/1b31a4fe3905a88053a566b6037002d5?s=96&d=monsterid&r=g"
+    },
+    {
+      "name": "modernnerd",
+      "type": "wporg",
+      "display_name": "Nick C",
+      "profile": "https://profiles.wordpress.org/modernnerd/",
+      "avatar": "https://secure.gravatar.com/avatar/fb9b76c6ed2685d4bd52a863a3cebdd2?s=96&d=monsterid&r=g"
+    },
+    {
+      "name": "rfmeier",
+      "type": "wporg",
+      "display_name": "rfmeier",
+      "profile": "https://profiles.wordpress.org/rfmeier/",
+      "avatar": "https://secure.gravatar.com/avatar/6272ddb97237615090f42c44eb717389?s=96&d=monsterid&r=g"
+    },
+    {
+      "name": "TeresaGobble",
+      "type": "wporg",
+      "display_name": "Teresa Gobble",
+      "profile": "https://profiles.wordpress.org/teresagobble/",
+      "avatar": "https://secure.gravatar.com/avatar/3533063b820474ca319bf1e1b9774ebb?s=96&d=monsterid&r=g"
+    },
+    {
+      "name": "thdespou",
+      "type": "wporg",
+      "display_name": "Theo",
+      "profile": "https://profiles.wordpress.org/thdespou/",
+      "avatar": "https://secure.gravatar.com/avatar/314c9f734b04106c3d6169547d517e40?s=96&d=monsterid&r=g"
+    },
+    {
+      "name": "wpengine",
+      "type": "wporg",
+      "display_name": "WP Engine",
+      "profile": "https://profiles.wordpress.org/wpengine/",
+      "avatar": "https://secure.gravatar.com/avatar/c49ce4c563ebe19c03fb3af0348f162e?s=96&d=monsterid&r=g"
+    }
+  ],
+  "author": {
+    "name": "wpengine",
+    "type": "wporg",
+    "display_name": "WP Engine",
+    "profile": "https://profiles.wordpress.org/wpengine/",
+    "avatar": "https://secure.gravatar.com/avatar/c49ce4c563ebe19c03fb3af0348f162e?s=96&d=monsterid&r=g"
+  },
+  "icons": {
+    "1x": "https://wpe-plugin-updates.wpengine.com/faustwp/assets/icon.svg",
+    "svg": "https://wpe-plugin-updates.wpengine.com/faustwp/assets/icon.svg"
+  },
+  "downloaded": 65456
+}

--- a/scripts/verify-published-plugin.sh
+++ b/scripts/verify-published-plugin.sh
@@ -44,6 +44,17 @@ if grep -F "Update URI: false" "$PLUGIN_DIR/faustwp.php" >/dev/null 2>&1; then
   fail "\`Update URI: false\` header is present — wordpress.org auto-updates would be suppressed"
 fi
 
+echo "==> Assertion 5b: self-update infrastructure is absent from the wordpress.org distribution"
+# wordpress.org installs must not carry the external updater files — otherwise
+# the plugin would attempt to talk to a non-wordpress.org update channel.
+for forbidden in \
+  "includes/updates/class-plugin-updater.php" \
+  "includes/updates/check-for-updates.php"; do
+  if [ -e "$PLUGIN_DIR/$forbidden" ]; then
+    fail "self-update file present in published artifact: $forbidden"
+  fi
+done
+
 echo "==> Assertion 6: IV-in-HMAC fix is present in encrypt() and decrypt()"
 HMAC_COUNT=$(grep -cF '$iv . $cipher_text' "$PLUGIN_DIR/includes/auth/functions.php" || true)
 [ "$HMAC_COUNT" = "2" ] || fail "expected 2 \`\$iv . \$cipher_text\` occurrences in includes/auth/functions.php, found ${HMAC_COUNT}"

--- a/scripts/versionPlugin.js
+++ b/scripts/versionPlugin.js
@@ -17,13 +17,15 @@ async function versionPlugin() {
   const pluginFile = path.join(pluginPath, 'faustwp.php');
   const readmeTxt  = path.join(pluginPath, 'readme.txt');
   const changelog  = path.join(pluginPath, 'CHANGELOG.md');
+  const infoJson   = path.join(pluginPath, 'info.json');
 
   const version = await getNewVersion(pluginPath);
 
   if ( version ) {
     bumpPluginHeader(pluginFile, version);
     await bumpStableTag(readmeTxt, version);
-    generateReadmeChangelog(readmeTxt, changelog);
+    await generateReadmeChangelog(readmeTxt, changelog);
+    await updateInfoJson(infoJson, readmeTxt, changelog, version);
   }
 }
 
@@ -162,6 +164,101 @@ async function generateReadmeChangelog(readmeTxtFile, changelog) {
   } catch(e) {
     console.warn(e);
   }
+}
+
+/**
+ * Refreshes the release-time fields in the plugin's info.json manifest used by
+ * the non-wordpress.org update channel. Updates version, last_updated, tested,
+ * download_link, the versions map, and the changelog section. Fields that are
+ * not release-driven (contributors, ratings, banners, etc.) are preserved.
+ *
+ * @param {String} infoJsonFile Full path to the plugin's info.json.
+ * @param {String} readmeTxt    Full path to the plugin's readme.txt.
+ * @param {String} changelog    Full path to the plugin's CHANGELOG.md.
+ * @param {String} version      The new version number.
+ */
+async function updateInfoJson(infoJsonFile, readmeTxt, changelog, version) {
+  try {
+    const raw  = await readFile(infoJsonFile);
+    const info = JSON.parse(raw);
+
+    info.version       = version;
+    info.last_updated  = formatLastUpdated(new Date());
+    info.download_link = buildDownloadLink(version);
+    info.versions      = info.versions || {};
+    info.versions[version] = info.download_link;
+
+    const readme = await readFile(readmeTxt);
+    const tested = readme.match(/^Tested up to:\s*([0-9.]+)$/m);
+    if ( tested ) {
+      info.tested = tested[1];
+    }
+
+    info.sections = info.sections || {};
+    info.sections.changelog = await buildInfoJsonChangelog(changelog);
+
+    return writeFile(infoJsonFile, JSON.stringify(info, null, 2) + "\n");
+  } catch (e) {
+    console.warn(e);
+  }
+}
+
+/**
+ * Builds the download URL for a given version. The host matches the value the
+ * shipped updater client already calls in includes/updates/.
+ *
+ * @param {String} version
+ */
+function buildDownloadLink(version) {
+  return `https://wpe-plugin-updates.wpengine.com/faustwp/faustwp.${version}.zip`;
+}
+
+/**
+ * Formats a Date as the "YYYY-MM-DD h:mmam/pm GMT" string the manifest uses.
+ *
+ * @param {Date} d
+ */
+function formatLastUpdated(d) {
+  const y   = d.getUTCFullYear();
+  const mo  = String(d.getUTCMonth() + 1).padStart(2, '0');
+  const day = String(d.getUTCDate()).padStart(2, '0');
+  const min = String(d.getUTCMinutes()).padStart(2, '0');
+  let h = d.getUTCHours();
+  const ampm = h >= 12 ? 'pm' : 'am';
+  h = h % 12;
+  if (h === 0) { h = 12; }
+  return `${y}-${mo}-${day} ${h}:${min}${ampm} GMT`;
+}
+
+/**
+ * Builds the sections.changelog string for info.json from CHANGELOG.md.
+ * Mirrors the readme.txt logic (last 3 versions, "## X" → "= X =") but joins
+ * lines with a blank line so paragraph spacing matches the wordpress.org API
+ * shape that the manifest consumer expects.
+ *
+ * @param {String} changelogFile
+ */
+async function buildInfoJsonChangelog(changelogFile) {
+  const source = (await readFile(changelogFile))
+    .replace(/^# Faust\s*$/m, '')
+    .trim();
+
+  const lines = source.split(/\r?\n/);
+  const out = [];
+  let versionCount = 0;
+
+  for (const raw of lines) {
+    let line = raw;
+    if (line.startsWith('## ')) {
+      if (versionCount === 3) { break; }
+      line = line.replace('## ', '= ') + ' =';
+      versionCount++;
+    }
+    out.push(line);
+  }
+
+  out.push('[View the full changelog](https://github.com/wpengine/faustjs/blob/canary/plugins/faustwp/CHANGELOG.md)');
+  return out.join('\n\n');
 }
 
 versionPlugin();


### PR DESCRIPTION
Excludes the updater PHP files and info.json from the wordpress.org distribution via .distignore, clarifies the conditional require comment, qualifies the 1.5.0 self-update changelog entry, adds an explicit verifier assertion for updater file absence, and wires info.json refresh (version, last_updated, tested, download_link, versions map, changelog section) into scripts/versionPlugin.js so the non-wordpress.org channel manifest stays in sync at every version bump.