### PR TITLE
fix(faustwp): clarify wp.org updater-exclusion intent in code and verifier

### DIFF
--- a/plugins/faustwp/CHANGELOG.md
+++ b/plugins/faustwp/CHANGELOG.md
@@ -127,7 +127,7 @@
 
 ### Minor Changes
 
-- 011cd931: - Added a custom PluginUpdater class to enable FaustWP plugin updates from an external API endpoint.
+- 011cd931: - Added a custom PluginUpdater class to enable FaustWP plugin updates from an external API endpoint. Applies to non-wordpress.org distributions only.
 
 ## 1.4.1
 

--- a/plugins/faustwp/CHANGELOG.md
+++ b/plugins/faustwp/CHANGELOG.md
@@ -127,7 +127,7 @@
 
 ### Minor Changes
 
-- 011cd931: - Added a custom PluginUpdater class to enable FaustWP plugin updates from an external API endpoint. Applies to non-wordpress.org distributions only.
+- 011cd931: Added a custom PluginUpdater class to enable FaustWP plugin updates from an external API endpoint. Applies to non-wordpress.org distributions only.
 
 ## 1.4.1
 

--- a/plugins/faustwp/faustwp.php
+++ b/plugins/faustwp/faustwp.php
@@ -61,9 +61,10 @@ if ( ! is_php_version_compatible( faustwp_minimum_php_requirement() ) ) {
 	return;
 }
 
-// Loads the updater service when present. The files under includes/updates/
-// are excluded from the wordpress.org build, so these requires only execute
-// in distributions that ship the updater.
+// Loads the updater service when present. The embedded self-updater files
+// (includes/updates/class-plugin-updater.php and includes/updates/check-for-updates.php)
+// are excluded from the WordPress.org distribution, so the requires below only execute
+// in distributions that ship the external updater.
 if ( file_exists( FAUSTWP_DIR . '/includes/updates/class-plugin-updater.php' ) ) {
 	require FAUSTWP_DIR . '/includes/updates/class-plugin-updater.php';
 }

--- a/plugins/faustwp/faustwp.php
+++ b/plugins/faustwp/faustwp.php
@@ -61,7 +61,9 @@ if ( ! is_php_version_compatible( faustwp_minimum_php_requirement() ) ) {
 	return;
 }
 
-// Loads the updater service, if included in this build.
+// Loads the updater service when present. The files under includes/updates/
+// are excluded from the wordpress.org build, so these requires only execute
+// in distributions that ship the updater.
 if ( file_exists( FAUSTWP_DIR . '/includes/updates/class-plugin-updater.php' ) ) {
 	require FAUSTWP_DIR . '/includes/updates/class-plugin-updater.php';
 }

--- a/scripts/verify-published-plugin.sh
+++ b/scripts/verify-published-plugin.sh
@@ -44,6 +44,17 @@ if grep -F "Update URI: false" "$PLUGIN_DIR/faustwp.php" >/dev/null 2>&1; then
   fail "\`Update URI: false\` header is present — wordpress.org auto-updates would be suppressed"
 fi
 
+echo "==> Assertion 5b: self-update infrastructure is absent from the wordpress.org distribution"
+# wordpress.org installs must not carry the external updater files — the build
+# pipeline strips them, and this catches a regression where that strip is lost.
+for forbidden in \
+  "includes/updates/class-plugin-updater.php" \
+  "includes/updates/check-for-updates.php"; do
+  if [ -e "$PLUGIN_DIR/$forbidden" ]; then
+    fail "self-update file present in published artifact: $forbidden"
+  fi
+done
+
 echo "==> Assertion 6: IV-in-HMAC fix is present in encrypt() and decrypt()"
 HMAC_COUNT=$(grep -cF '$iv . $cipher_text' "$PLUGIN_DIR/includes/auth/functions.php" || true)
 [ "$HMAC_COUNT" = "2" ] || fail "expected 2 \`\$iv . \$cipher_text\` occurrences in includes/auth/functions.php, found ${HMAC_COUNT}"


### PR DESCRIPTION
Rewords the conditional require comment in `faustwp.php` to state the wp.org-only execution rule explicitly, qualifies the 1.5.0 self-update CHANGELOG entry as non-wordpress.org-only so it stays correctly scoped if it rotates into `readme.txt`, and adds a defense-in-depth assertion in `verify-published-plugin.sh` that the wp.org-published artifact contains no self-update files.