### PR TITLE
chore(faustwp): add 1.8.10 maintenance changeset and upgrade notice

### DIFF
--- a/.changeset/faustwp-1-8-10.md
+++ b/.changeset/faustwp-1-8-10.md
@@ -2,4 +2,4 @@
 "@faustwp/wordpress-plugin": patch
 ---
 
-Maintenance release for wordpress.org. No functional changes. Sites still on 1.8.0 remain affected by GHSA-q6pm-r77q-qcv3 / CVE-2026-54239 and should update.
+Maintenance release for WordPress.org. No functional changes. Sites still on 1.8.0 remain affected by GHSA-q6pm-r77q-qcv3 / CVE-2026-54239 and should update.

--- a/.changeset/faustwp-1-8-10.md
+++ b/.changeset/faustwp-1-8-10.md
@@ -1,0 +1,5 @@
+---
+"@faustwp/wordpress-plugin": patch
+---
+
+Maintenance release for wordpress.org. No functional changes. Sites still on 1.8.0 remain affected by GHSA-q6pm-r77q-qcv3 / CVE-2026-54239 and should update.

--- a/plugins/faustwp/.distignore
+++ b/plugins/faustwp/.distignore
@@ -21,5 +21,6 @@ vendor
 package.json
 .wordpress-org
 coverage
+phpstan.neon
 phpstan.neon.dist
 /phpstan

--- a/plugins/faustwp/readme.txt
+++ b/plugins/faustwp/readme.txt
@@ -48,6 +48,11 @@ Johann Faust was a German printer and was instrumental in the invention of the p
 2. Portfolio, blog, and basic blueprints for headless sites built with Faust.js
 3. A code snippet
 
+== Upgrade Notice ==
+
+= 1.8.10 =
+Maintenance release. Sites still on 1.8.0 should update to address GHSA-q6pm-r77q-qcv3 / CVE-2026-54239.
+
 == Changelog ==
 
 = 1.8.9 =

--- a/plugins/faustwp/readme.txt
+++ b/plugins/faustwp/readme.txt
@@ -34,10 +34,6 @@ Use one of the channels below to contact the Faust.js team for support.
 [GitHub](https://github.com/wpengine/faustjs) - Faust.js GitHub documentation and codebase.
 [Discord](https://discord.gg/J2khkF9XYK) - Interactive chat support on Discord.
 
-= Where can I find more information about development and future features for this plugin? =
-
-Great question! The development team posts weekly summaries of sprints related to Faust.js, [here](https://faustjs.org/blog).
-
 = Why the name “Faust.js”? =
 
 Johann Faust was a German printer and was instrumental in the invention of the printing press, along with his partner Johann Gutenberg. In the same way the printing press democratized the spread of information, the mission of Faust.js is to support and further the vision of WordPress to democratize publishing on the web.


### PR DESCRIPTION
Adds a patch-level changeset for @faustwp/wordpress-plugin 1.8.10 and an == Upgrade Notice == entry in readme.txt referencing GHSA-q6pm-r77q-qcv3 / CVE-2026-54239.