### PR TITLE
chore(faustwp): add WordPress 7.0 to CI matrix and bump Tested up to

### DIFF
--- a/.changeset/faustwp-wp-7.0-support.md
+++ b/.changeset/faustwp-wp-7.0-support.md
@@ -1,0 +1,5 @@
+---
+"@faustwp/wordpress-plugin": patch
+---
+
+Add WordPress 7.0 to the CI test matrix and update the plugin "Tested up to" header to 7.0.

--- a/.github/workflows/unit-test-plugin.yml
+++ b/.github/workflows/unit-test-plugin.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        wordpress: [ '6.9', '6.8', '6.7', '6.6', '6.5', '6.4', '6.3' ]
+        wordpress: [ '7.0', '6.9', '6.8', '6.7', '6.6', '6.5', '6.4', '6.3' ]
     steps:
       - name: Checkout
         uses: actions/checkout@v5

--- a/plugins/faustwp/faustwp.php
+++ b/plugins/faustwp/faustwp.php
@@ -12,7 +12,7 @@
  * Version: 1.8.10
  * Requires PHP: 7.4
  * Requires at least: 5.7
- * Tested up to: 6.9
+ * Tested up to: 7.0
  *
  * @package FaustWP
  */

--- a/plugins/faustwp/readme.txt
+++ b/plugins/faustwp/readme.txt
@@ -2,7 +2,7 @@
 Contributors: antpb, apmatthe, blakewpe, chriswiegman, claygriffiths, colin-murphy, jasonkonen, joefusco, markkelnar, matthewguywright, mindctrl, modernnerd, rfmeier, teresagobble, thdespou, wpengine
 Tags: faustjs, faust, headless, decoupled, composable-architecture
 Requires at least: 5.7
-Tested up to: 6.9
+Tested up to: 7.0
 Stable tag: 1.8.10
 Requires PHP: 7.4
 License: GPLv2 or later


### PR DESCRIPTION
Adds WordPress 7.0 to the unit-test-plugin matrix and updates the plugin "Tested up to" header in both readme.txt and faustwp.php so the next release advertises 7.0 compatibility on wordpress.org.