### PR TITLE
ci(faustwp): wrap release zips in a faustwp/ top-level directory

### DIFF
--- a/.github/actions/release-plugin/action.yml
+++ b/.github/actions/release-plugin/action.yml
@@ -46,8 +46,8 @@ runs:
         rsync -av --exclude-from="${{ env.PLUGIN_DIR }}/.distignore" ${{ env.PLUGIN_DIR }}/ dist/${{ env.SLUG }}
 
         zip_file="faustwp.${{ env.VERSION }}.zip"
-        cd "dist/${{ env.SLUG }}"
-        zip -r "../../$zip_file" .
+        cd "dist"
+        zip -r "../$zip_file" "${{ env.SLUG }}"
         cd -
 
         echo "zip-path=$PWD/$zip_file" >> $GITHUB_ENV
@@ -68,8 +68,8 @@ runs:
         sed -i -e '/\* Update URI: false/d' "dist/${{ env.SLUG }}/faustwp.php"
 
         org_zip_file="faustwp.${{ env.VERSION }}.org.zip"
-        cd "dist/${{ env.SLUG }}"
-        zip -r "../../$org_zip_file" .
+        cd "dist"
+        zip -r "../$org_zip_file" "${{ env.SLUG }}"
         cd -
 
         echo "org-zip-path=$PWD/$org_zip_file" >> $GITHUB_ENV


### PR DESCRIPTION
Restores the wrapping `faustwp/` directory at the top of both `faustwp.X.Y.Z.zip` and `faustwp.X.Y.Z.org.zip` so manual installs and debugging downloads from GitHub Releases extract correctly; should be merged before #2437 so the 1.8.11 tag picks up the fix.