### PR TITLE
chore: add @wpengine/spcs as a code owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 # Code Owners
-*       @wpengine/headless-open-source @wpengine/spcs
+*       @wpengine/headless-open-source @wpengine/spcs
 
 # jira:[18721] is where issues related to this repository should be ticketed

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 # Code Owners
-*       @wpengine/headless-open-source
+*       @wpengine/headless-open-source @wpengine/spcs
 
 # jira:[18721] is where issues related to this repository should be ticketed


### PR DESCRIPTION
Adds the @wpengine/spcs team as a CODEOWNER so Dependabot and other PRs route to the SPCS Jira board.