### PR TITLE
Update CODEOWNERS - use @wpengine/spcs only

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 # Code Owners
-*       @wpengine/headless-open-source @wpengine/spcs
+*       @wpengine/spcs 
 
 # jira:[18721] is where issues related to this repository should be ticketed


### PR DESCRIPTION
Set CODEOWNERS to use @wpengine/spcs only

- [ ] I have signed a [Contributor License Agreement (CLA)](https://github.com/wpengine/faustjs#contributor-license-agreement) with WP Engine.

## Description

<!-- What does this PR do and why? -->

## Related Issues

<!-- Link related issues: #1234 -->

## Testing

<!-- How can this be tested? -->
