### PR TITLE
chore(deps): pin nanoid to ^3.3.18 in tutorial example (GHSA-2v37-7h3g-55p8)

### DIFF
--- a/examples/next/tutorial/package-lock.json
+++ b/examples/next/tutorial/package-lock.json
@@ -8901,9 +8901,9 @@
 			"license": "MIT"
 		},
 		"node_modules/nanoid": {
-			"version": "3.3.16",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-			"integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+			"version": "3.3.18",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+			"integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
 			"funding": [
 				{
 					"type": "github",

--- a/examples/next/tutorial/package.json
+++ b/examples/next/tutorial/package.json
@@ -34,6 +34,7 @@
 		"fast-xml-parser": "^5.3.4",
 		"js-yaml": ">=4.3.1",
 		"ajv": ">=8.17.2",
+		"nanoid": "^3.3.18",
 		"next": {
 			"postcss": "$postcss"
 		}


### PR DESCRIPTION
## Summary

- Adds an `overrides` entry for `nanoid: ^3.3.18` in `examples/next/tutorial/package.json` to address the open Dependabot alert for **GHSA-2v37-7h3g-55p8** (nanoid < 3.3.18: custom generators can loop indefinitely when size is zero).
- Regenerated `examples/next/tutorial/package-lock.json` — only `nanoid@3.3.16` → `nanoid@3.3.18` changes (3 lines).
- Pinned within `^3.3.18` (not `>=3.3.18`) to stay in the 3.x line and preserve `postcss` compatibility. A bare `>=3.3.18` resolves to `nanoid@6.0.1`, which is a major bump incompatible with postcss's `nanoid: ^3.3.16` requirement.

## Notes

- Root `package-lock.json` and `examples/next/block-support/package-lock.json` are already on `nanoid@3.3.18` (no change needed).
- `nanoid` is a transitive dep of `postcss` in all three lockfiles.

## Test plan

- [ ] `npm install` in `examples/next/tutorial` completes cleanly
- [ ] `npm run build` still succeeds in the tutorial example
- [ ] `grep '"version": "3.3.16"' -A 0 examples/next/tutorial/package-lock.json` returns no nanoid matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)