### PR TITLE
chore(deps): drop vulnerable extract-zip from block-support via puppeteer-core bump (GHSA-jmr9-qjv8-65gv, alert #774)

### DIFF
--- a/examples/next/block-support/package-lock.json
+++ b/examples/next/block-support/package-lock.json
@@ -2636,9 +2636,9 @@
 			}
 		},
 		"node_modules/@eslint/plugin-kit": {
-			"version": "0.7.2",
-			"resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.2.tgz",
-			"integrity": "sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==",
+			"version": "0.7.3",
+			"resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.3.tgz",
+			"integrity": "sha512-IkO+/KEUvwbVpiURZg+P7zF74z5Jxe0UgJxVni+RtoHQ6IZieXaO02kmadomap/q+l6bc/jdPGGqTjhuZnuz1Q==",
 			"license": "Apache-2.0",
 			"optional": true,
 			"dependencies": {
@@ -6044,38 +6044,195 @@
 			}
 		},
 		"node_modules/@puppeteer/browsers": {
-			"version": "2.13.2",
-			"resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.13.2.tgz",
-			"integrity": "sha512-5EUZSUIc37H6aIXyWO0Z4y8NlF8NnjgmqeQgOGiswAU7pY0HOo16ho4+alIWmSfdZnjqBRawMsP3I5YqLSn6kw==",
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-3.2.2.tgz",
+			"integrity": "sha512-q2BU4YfO9h/Wt7IcWPcggpOOqLk2Tbs1hDwolvKZrweRjy751OJBKMN9zO5bfD0pzU7X/tvKw/exQds4pM/LOg==",
 			"license": "Apache-2.0",
 			"optional": true,
 			"dependencies": {
-				"debug": "^4.4.3",
-				"extract-zip": "^2.0.1",
-				"progress": "^2.0.3",
-				"proxy-agent": "^6.5.0",
-				"semver": "^7.7.4",
-				"tar-fs": "^3.1.1",
-				"yargs": "^17.7.2"
+				"modern-tar": "^0.8.4",
+				"yargs": "^18.0.0"
 			},
 			"bin": {
-				"browsers": "lib/cjs/main-cli.js"
+				"browsers": "lib/main-cli.js"
+			},
+			"engines": {
+				"node": ">=22.12.0"
+			},
+			"peerDependencies": {
+				"proxy-agent": ">=8.0.1",
+				"yauzl": "^2.10.0 || ^3.4.0"
+			},
+			"peerDependenciesMeta": {
+				"proxy-agent": {
+					"optional": true
+				},
+				"yauzl": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@puppeteer/browsers/node_modules/ansi-regex": {
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.3.0.tgz",
+			"integrity": "sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==",
+			"license": "MIT",
+			"optional": true,
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-regex?sponsor=1"
+			}
+		},
+		"node_modules/@puppeteer/browsers/node_modules/ansi-styles": {
+			"version": "6.2.3",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+			"integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+			"license": "MIT",
+			"optional": true,
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/@puppeteer/browsers/node_modules/cliui": {
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
+			"integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
+			"license": "ISC",
+			"optional": true,
+			"dependencies": {
+				"string-width": "^7.2.0",
+				"strip-ansi": "^7.1.0",
+				"wrap-ansi": "^9.0.0"
+			},
+			"engines": {
+				"node": ">=20"
+			}
+		},
+		"node_modules/@puppeteer/browsers/node_modules/cliui/node_modules/string-width": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+			"integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"emoji-regex": "^10.3.0",
+				"get-east-asian-width": "^1.0.0",
+				"strip-ansi": "^7.1.0"
 			},
 			"engines": {
 				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/@puppeteer/browsers/node_modules/semver": {
-			"version": "7.8.5",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
-			"integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
-			"license": "ISC",
+		"node_modules/@puppeteer/browsers/node_modules/emoji-regex": {
+			"version": "10.6.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+			"integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+			"license": "MIT",
+			"optional": true
+		},
+		"node_modules/@puppeteer/browsers/node_modules/string-width": {
+			"version": "8.2.2",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.2.tgz",
+			"integrity": "sha512-GaPUh5gfdrYzqeVNZvUfT23vYYxXzKYidUcnMtJg/3rxRV63EFZy3k6xfKlmfeJD0176lnUV/Usr3XcwSvFzpg==",
+			"license": "MIT",
 			"optional": true,
-			"bin": {
-				"semver": "bin/semver.js"
+			"dependencies": {
+				"get-east-asian-width": "^1.5.0",
+				"strip-ansi": "^7.1.2"
 			},
 			"engines": {
-				"node": ">=10"
+				"node": ">=20"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@puppeteer/browsers/node_modules/strip-ansi": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+			"integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"ansi-regex": "^6.2.2"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/strip-ansi?sponsor=1"
+			}
+		},
+		"node_modules/@puppeteer/browsers/node_modules/wrap-ansi": {
+			"version": "9.0.2",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+			"integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"ansi-styles": "^6.2.1",
+				"string-width": "^7.0.0",
+				"strip-ansi": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+			}
+		},
+		"node_modules/@puppeteer/browsers/node_modules/wrap-ansi/node_modules/string-width": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+			"integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"emoji-regex": "^10.3.0",
+				"get-east-asian-width": "^1.0.0",
+				"strip-ansi": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@puppeteer/browsers/node_modules/yargs": {
+			"version": "18.1.0",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-18.1.0.tgz",
+			"integrity": "sha512-2rAgRKu54VsHkqI0/tYkmluGXHD4KW7yZoycuqDQ15QOTnc2VVfy0nN/1eMhnQLO00A+dwtK20xuCnc1YGeUyg==",
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"cliui": "^9.0.1",
+				"escalade": "^3.1.1",
+				"get-caller-file": "^2.0.5",
+				"string-width": "^8.2.1",
+				"y18n": "^5.0.5",
+				"yargs-parser": "^22.0.0"
+			},
+			"engines": {
+				"node": "^20.19.0 || ^22.12.0 || >=23"
+			}
+		},
+		"node_modules/@puppeteer/browsers/node_modules/yargs-parser": {
+			"version": "22.0.0",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
+			"integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
+			"license": "ISC",
+			"optional": true,
+			"engines": {
+				"node": "^20.19.0 || ^22.12.0 || >=23"
 			}
 		},
 		"node_modules/@radix-ui/primitive": {
@@ -6873,13 +7030,6 @@
 			"devOptional": true,
 			"license": "MIT"
 		},
-		"node_modules/@tootallnate/quickjs-emscripten": {
-			"version": "0.23.0",
-			"resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
-			"integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
-			"license": "MIT",
-			"optional": true
-		},
 		"node_modules/@tybys/wasm-util": {
 			"version": "0.10.2",
 			"resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
@@ -7398,16 +7548,6 @@
 			"integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
 			"license": "MIT",
 			"optional": true
-		},
-		"node_modules/@types/yauzl": {
-			"version": "2.10.3",
-			"resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
-			"integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"@types/node": "*"
-			}
 		},
 		"node_modules/@typescript-eslint/project-service": {
 			"version": "8.62.1",
@@ -21354,19 +21494,6 @@
 				"node": ">=12.0.0"
 			}
 		},
-		"node_modules/ast-types": {
-			"version": "0.13.4",
-			"resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
-			"integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"tslib": "^2.0.1"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
 		"node_modules/ast-types-flow": {
 			"version": "0.0.8",
 			"resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.8.tgz",
@@ -21754,6 +21881,7 @@
 			"resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.8.2.tgz",
 			"integrity": "sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==",
 			"license": "Apache-2.0",
+			"peer": true,
 			"peerDependencies": {
 				"bare-abort-controller": "*"
 			},
@@ -21850,16 +21978,6 @@
 			},
 			"engines": {
 				"node": ">=6.0.0"
-			}
-		},
-		"node_modules/basic-ftp": {
-			"version": "5.3.1",
-			"resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.1.tgz",
-			"integrity": "sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==",
-			"license": "MIT",
-			"optional": true,
-			"engines": {
-				"node": ">=10.0.0"
 			}
 		},
 		"node_modules/batch": {
@@ -22438,17 +22556,30 @@
 			}
 		},
 		"node_modules/chromium-bidi": {
-			"version": "14.0.0",
-			"resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-14.0.0.tgz",
-			"integrity": "sha512-9gYlLtS6tStdRWzrtXaTMnqcM4dudNegMXJxkR0I/CXObHalYeYcAMPrL19eroNZHtJ8DQmu1E+ZNOYu/IXMXw==",
+			"version": "17.0.2",
+			"resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-17.0.2.tgz",
+			"integrity": "sha512-5v9GQFhTktFvotn/OFNJBmKLKRAb6n9r0bVCwf7sHgWc3/JryK0bj1nn93L3pHFrfgcsu6Be6EWsDi+1XHTGDg==",
 			"license": "Apache-2.0",
 			"optional": true,
 			"dependencies": {
 				"mitt": "^3.0.1",
 				"zod": "^3.24.1"
 			},
+			"engines": {
+				"node": ">=20.19.0 <22.0.0 || >=22.12.0"
+			},
 			"peerDependencies": {
 				"devtools-protocol": "*"
+			}
+		},
+		"node_modules/chromium-bidi/node_modules/zod": {
+			"version": "3.25.76",
+			"resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+			"integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+			"license": "MIT",
+			"optional": true,
+			"funding": {
+				"url": "https://github.com/sponsors/colinhacks"
 			}
 		},
 		"node_modules/ci-info": {
@@ -23333,16 +23464,6 @@
 			"license": "BSD-2-Clause",
 			"optional": true
 		},
-		"node_modules/data-uri-to-buffer": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
-			"integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==",
-			"license": "MIT",
-			"optional": true,
-			"engines": {
-				"node": ">= 14"
-			}
-		},
 		"node_modules/data-urls": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
@@ -23633,21 +23754,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/degenerator": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/degenerator/-/degenerator-5.0.1.tgz",
-			"integrity": "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==",
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"ast-types": "^0.13.4",
-				"escodegen": "^2.1.0",
-				"esprima": "^4.0.1"
-			},
-			"engines": {
-				"node": ">= 14"
 			}
 		},
 		"node_modules/delayed-stream": {
@@ -24033,16 +24139,6 @@
 				"iconv-lite": "^0.6.2"
 			}
 		},
-		"node_modules/end-of-stream": {
-			"version": "1.4.5",
-			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
-			"integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"once": "^1.4.0"
-			}
-		},
 		"node_modules/enhanced-resolve": {
 			"version": "5.21.0",
 			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.21.0.tgz",
@@ -24376,38 +24472,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/escodegen": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
-			"integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
-			"license": "BSD-2-Clause",
-			"optional": true,
-			"dependencies": {
-				"esprima": "^4.0.1",
-				"estraverse": "^5.2.0",
-				"esutils": "^2.0.2"
-			},
-			"bin": {
-				"escodegen": "bin/escodegen.js",
-				"esgenerate": "bin/esgenerate.js"
-			},
-			"engines": {
-				"node": ">=6.0"
-			},
-			"optionalDependencies": {
-				"source-map": "~0.6.1"
-			}
-		},
-		"node_modules/escodegen/node_modules/source-map": {
-			"version": "0.6.1",
-			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-			"license": "BSD-3-Clause",
-			"optional": true,
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/eslint-import-context": {
 			"version": "0.1.9",
 			"resolved": "https://registry.npmjs.org/eslint-import-context/-/eslint-import-context-0.1.9.tgz",
@@ -24653,20 +24717,6 @@
 				"url": "https://opencollective.com/eslint"
 			}
 		},
-		"node_modules/esprima": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-			"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-			"license": "BSD-2-Clause",
-			"optional": true,
-			"bin": {
-				"esparse": "bin/esparse.js",
-				"esvalidate": "bin/esvalidate.js"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
 		"node_modules/esquery": {
 			"version": "1.7.0",
 			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
@@ -24904,43 +24954,6 @@
 			"license": "MIT",
 			"optional": true
 		},
-		"node_modules/extract-zip": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
-			"integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
-			"license": "BSD-2-Clause",
-			"optional": true,
-			"dependencies": {
-				"debug": "^4.1.1",
-				"get-stream": "^5.1.0",
-				"yauzl": "^2.10.0"
-			},
-			"bin": {
-				"extract-zip": "cli.js"
-			},
-			"engines": {
-				"node": ">= 10.17.0"
-			},
-			"optionalDependencies": {
-				"@types/yauzl": "^2.9.1"
-			}
-		},
-		"node_modules/extract-zip/node_modules/get-stream": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-			"integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"pump": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/fast-average-color": {
 			"version": "9.5.2",
 			"resolved": "https://registry.npmjs.org/fast-average-color/-/fast-average-color-9.5.2.tgz",
@@ -25015,9 +25028,9 @@
 			"optional": true
 		},
 		"node_modules/fast-uri": {
-			"version": "3.1.5",
-			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-			"integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+			"version": "3.1.7",
+			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+			"integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
 			"funding": [
 				{
 					"type": "github",
@@ -25107,16 +25120,6 @@
 			"optional": true,
 			"dependencies": {
 				"bser": "2.1.1"
-			}
-		},
-		"node_modules/fd-slicer": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
-			"integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"pend": "~1.2.0"
 			}
 		},
 		"node_modules/file-entry-cache": {
@@ -25764,21 +25767,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
-			}
-		},
-		"node_modules/get-uri": {
-			"version": "6.0.5",
-			"resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.5.tgz",
-			"integrity": "sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==",
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"basic-ftp": "^5.0.2",
-				"data-uri-to-buffer": "^6.0.2",
-				"debug": "^4.3.4"
-			},
-			"engines": {
-				"node": ">= 14"
 			}
 		},
 		"node_modules/gettext-parser": {
@@ -26768,16 +26756,6 @@
 				"@formatjs/fast-memoize": "2.2.7",
 				"@formatjs/icu-messageformat-parser": "2.11.4",
 				"tslib": "^2.8.0"
-			}
-		},
-		"node_modules/ip-address": {
-			"version": "10.4.0",
-			"resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.4.0.tgz",
-			"integrity": "sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==",
-			"license": "MIT",
-			"optional": true,
-			"engines": {
-				"node": ">= 12"
 			}
 		},
 		"node_modules/ipaddr.js": {
@@ -30175,13 +30153,6 @@
 				"node": ">=6"
 			}
 		},
-		"node_modules/json-buffer": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
-			"integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
-			"license": "MIT",
-			"optional": true
-		},
 		"node_modules/json-parse-even-better-errors": {
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
@@ -31923,6 +31894,16 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/modern-tar": {
+			"version": "0.8.5",
+			"resolved": "https://registry.npmjs.org/modern-tar/-/modern-tar-0.8.5.tgz",
+			"integrity": "sha512-snEhs+6G5Tjd4I7tLCDOaoln2RgE0bD19RzEKgvgK2hZ5VKy3MpLhLTZ2fWpXSTg4K2cyPwp+VHATFJhxfnOeA==",
+			"license": "MIT",
+			"optional": true,
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
 		"node_modules/module-details-from-path": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.4.tgz",
@@ -32064,16 +32045,6 @@
 			"resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
 			"integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
 			"license": "MIT"
-		},
-		"node_modules/netmask": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/netmask/-/netmask-2.1.1.tgz",
-			"integrity": "sha512-eonl3sLUha+S1GzTPxychyhnUzKyeQkZ7jLjKrBagJgPla13F+uQ71HgpFefyHgqrjEbCPkDArxYsjY8/+gLKA==",
-			"license": "MIT",
-			"optional": true,
-			"engines": {
-				"node": ">= 0.4.0"
-			}
 		},
 		"node_modules/next": {
 			"version": "16.3.0",
@@ -32795,40 +32766,6 @@
 				"node": ">=6"
 			}
 		},
-		"node_modules/pac-proxy-agent": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.2.0.tgz",
-			"integrity": "sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==",
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"@tootallnate/quickjs-emscripten": "^0.23.0",
-				"agent-base": "^7.1.2",
-				"debug": "^4.3.4",
-				"get-uri": "^6.0.1",
-				"http-proxy-agent": "^7.0.0",
-				"https-proxy-agent": "^7.0.6",
-				"pac-resolver": "^7.0.1",
-				"socks-proxy-agent": "^8.0.5"
-			},
-			"engines": {
-				"node": ">= 14"
-			}
-		},
-		"node_modules/pac-resolver": {
-			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-7.0.1.tgz",
-			"integrity": "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==",
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"degenerator": "^5.0.0",
-				"netmask": "^2.0.2"
-			},
-			"engines": {
-				"node": ">= 14"
-			}
-		},
 		"node_modules/package-json-from-dist": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
@@ -33094,13 +33031,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/pend": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
-			"integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
-			"license": "MIT",
-			"optional": true
-		},
 		"node_modules/pg-int8": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
@@ -33297,28 +33227,25 @@
 			}
 		},
 		"node_modules/playwright": {
-			"version": "1.62.1",
-			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
-			"integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+			"version": "1.63.0",
+			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.63.0.tgz",
+			"integrity": "sha512-+7ziBLidS4NaNCdt57SUDT+wYmmd5fmiQejUic/kb+YsYSCPyOOE9sebzMjNmQrsnNpDJqd4WHvV/8lfKfUDUg==",
 			"license": "Apache-2.0",
 			"optional": true,
 			"dependencies": {
-				"playwright-core": "1.62.1"
+				"playwright-core": "1.63.0"
 			},
 			"bin": {
 				"playwright": "cli.js"
 			},
 			"engines": {
 				"node": ">=20"
-			},
-			"optionalDependencies": {
-				"fsevents": "2.3.2"
 			}
 		},
 		"node_modules/playwright-core": {
-			"version": "1.62.1",
-			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
-			"integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+			"version": "1.63.0",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.63.0.tgz",
+			"integrity": "sha512-rYCsBF/M5HjUch52bbtVONEFjv6Xu8sm8h72dNlR5bzIE1fvC/bxgspzkjSfU+MweEMmPM8KJebG6nnyxo5mCg==",
 			"license": "Apache-2.0",
 			"optional": true,
 			"bin": {
@@ -33326,20 +33253,6 @@
 			},
 			"engines": {
 				"node": ">=20"
-			}
-		},
-		"node_modules/playwright/node_modules/fsevents": {
-			"version": "2.3.2",
-			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-			"integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-			"hasInstallScript": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
 			}
 		},
 		"node_modules/plur": {
@@ -34227,16 +34140,6 @@
 			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
 			"license": "MIT"
 		},
-		"node_modules/progress": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
-			"integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
-			"license": "MIT",
-			"optional": true,
-			"engines": {
-				"node": ">=0.4.0"
-			}
-		},
 		"node_modules/prompts": {
 			"version": "2.4.2",
 			"resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
@@ -34292,60 +34195,12 @@
 				"node": ">= 0.10"
 			}
 		},
-		"node_modules/proxy-agent": {
-			"version": "6.5.0",
-			"resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.5.0.tgz",
-			"integrity": "sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==",
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"agent-base": "^7.1.2",
-				"debug": "^4.3.4",
-				"http-proxy-agent": "^7.0.1",
-				"https-proxy-agent": "^7.0.6",
-				"lru-cache": "^7.14.1",
-				"pac-proxy-agent": "^7.1.0",
-				"proxy-from-env": "^1.1.0",
-				"socks-proxy-agent": "^8.0.5"
-			},
-			"engines": {
-				"node": ">= 14"
-			}
-		},
-		"node_modules/proxy-agent/node_modules/lru-cache": {
-			"version": "7.18.3",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
-			"integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
-			"license": "ISC",
-			"optional": true,
-			"engines": {
-				"node": ">=12"
-			}
-		},
 		"node_modules/proxy-compare": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/proxy-compare/-/proxy-compare-2.3.0.tgz",
 			"integrity": "sha512-c3L2CcAi7f7pvlD0D7xsF+2CQIW8C3HaYx2Pfgq8eA4HAl3GAH6/dVYsyBbYF/0XJs2ziGLrzmz5fmzPm6A0pQ==",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/proxy-from-env": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-			"integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-			"license": "MIT",
-			"optional": true
-		},
-		"node_modules/pump": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
-			"integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"end-of-stream": "^1.1.0",
-				"once": "^1.3.1"
-			}
 		},
 		"node_modules/punycode": {
 			"version": "2.3.1",
@@ -34368,30 +34223,22 @@
 			}
 		},
 		"node_modules/puppeteer-core": {
-			"version": "24.43.1",
-			"resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.43.1.tgz",
-			"integrity": "sha512-T5ScUMAsmhdNbgDR41AGESYeS6V9MSgetkSnVhhW+gXvzC42VesKCn5ld87gAZDJ6vLHL9GkRvY9WtQWSnwFbw==",
+			"version": "25.10.0",
+			"resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-25.10.0.tgz",
+			"integrity": "sha512-Hy5eMQshOEMil4JUUx03h5pw1HYkYCso1RG/gcpPlFSd4cYPOcopxcXEAxpLPOkOPJb9LIJtwxuj66bSdvknFg==",
 			"license": "Apache-2.0",
 			"optional": true,
 			"dependencies": {
-				"@puppeteer/browsers": "2.13.2",
-				"chromium-bidi": "14.0.0",
-				"debug": "^4.4.3",
-				"devtools-protocol": "0.0.1608973",
+				"@puppeteer/browsers": "3.2.2",
+				"chromium-bidi": "17.0.2",
+				"devtools-protocol": "0.0.1666840",
 				"typed-query-selector": "^2.12.2",
-				"webdriver-bidi-protocol": "0.4.1",
-				"ws": "^8.20.0"
+				"webdriver-bidi-protocol": "0.4.3",
+				"ws": "^8.21.3"
 			},
 			"engines": {
-				"node": ">=18"
+				"node": ">=22.12.0"
 			}
-		},
-		"node_modules/puppeteer-core/node_modules/devtools-protocol": {
-			"version": "0.0.1608973",
-			"resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1608973.tgz",
-			"integrity": "sha512-Tpm17fxYzt+J7VrGdc1k8YdRqS3YV7se/M6KeemEqvUbq/n7At1rWVuXMxQgpWkdwSdIEKYbU//Bve+Shm4YNQ==",
-			"license": "BSD-3-Clause",
-			"optional": true
 		},
 		"node_modules/pure-rand": {
 			"version": "6.1.0",
@@ -36448,17 +36295,6 @@
 				"url": "https://github.com/chalk/slice-ansi?sponsor=1"
 			}
 		},
-		"node_modules/smart-buffer": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
-			"integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
-			"license": "MIT",
-			"optional": true,
-			"engines": {
-				"node": ">= 6.0.0",
-				"npm": ">= 3.0.0"
-			}
-		},
 		"node_modules/smol-toml": {
 			"version": "1.6.1",
 			"resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.6.1.tgz",
@@ -36492,36 +36328,6 @@
 				"faye-websocket": "^0.11.3",
 				"uuid": "^8.3.2",
 				"websocket-driver": "^0.7.4"
-			}
-		},
-		"node_modules/socks": {
-			"version": "2.8.9",
-			"resolved": "https://registry.npmjs.org/socks/-/socks-2.8.9.tgz",
-			"integrity": "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==",
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"ip-address": "^10.1.1",
-				"smart-buffer": "^4.2.0"
-			},
-			"engines": {
-				"node": ">= 10.0.0",
-				"npm": ">= 3.0.0"
-			}
-		},
-		"node_modules/socks-proxy-agent": {
-			"version": "8.0.5",
-			"resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
-			"integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"agent-base": "^7.1.2",
-				"debug": "^4.3.4",
-				"socks": "^2.8.3"
-			},
-			"engines": {
-				"node": ">= 14"
 			}
 		},
 		"node_modules/source-map": {
@@ -37492,21 +37298,6 @@
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/webpack"
-			}
-		},
-		"node_modules/tar-fs": {
-			"version": "3.1.3",
-			"resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.3.tgz",
-			"integrity": "sha512-/hU4AXnIdZu+Gvl1pk0oI5f5HxWsCJRtY2aFaJdk9VvyL48DWU6iU5WAIPG+wIi1YvWA6eTJvIviP/tMAZZNwQ==",
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"pump": "^3.0.0",
-				"tar-stream": "^3.1.5"
-			},
-			"optionalDependencies": {
-				"bare-fs": "^4.0.1",
-				"bare-path": "^3.0.0"
 			}
 		},
 		"node_modules/tar-stream": {
@@ -38719,9 +38510,9 @@
 			"optional": true
 		},
 		"node_modules/webdriver-bidi-protocol": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/webdriver-bidi-protocol/-/webdriver-bidi-protocol-0.4.1.tgz",
-			"integrity": "sha512-ARrjNjtWRRs2w4Tk7nqrf2gBI0QXWuOmMCx2hU+1jUt6d00MjMxURrhxhGbrsoiZKJrhTSTzbIrc554iKI10qw==",
+			"version": "0.4.3",
+			"resolved": "https://registry.npmjs.org/webdriver-bidi-protocol/-/webdriver-bidi-protocol-0.4.3.tgz",
+			"integrity": "sha512-uuN0goWfxP22B7J/uAgBpOYNPttC+XVseYE+rSY5+rQ+YBeVz/VORw8WbmLVcqW78zNg5A4qnjNXYUWR3il2ig==",
 			"license": "Apache-2.0",
 			"optional": true
 		},
@@ -39307,9 +39098,9 @@
 			"optional": true
 		},
 		"node_modules/ws": {
-			"version": "8.21.0",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
-			"integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+			"version": "8.21.3",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+			"integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
 			"license": "MIT",
 			"optional": true,
 			"engines": {
@@ -39490,17 +39281,6 @@
 			"optional": true,
 			"engines": {
 				"node": ">=12"
-			}
-		},
-		"node_modules/yauzl": {
-			"version": "2.10.0",
-			"resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
-			"integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"buffer-crc32": "~0.2.3",
-				"fd-slicer": "~1.1.0"
 			}
 		},
 		"node_modules/yjs": {

--- a/examples/next/block-support/package.json
+++ b/examples/next/block-support/package.json
@@ -37,7 +37,7 @@
 	},
 	"overrides": {
 		"@babel/runtime": "7.27.0",
-		"puppeteer-core": "^24.10",
+		"puppeteer-core": "^25.10.0",
 		"webpack-dev-server": "^5.2",
 		"qs": "^6.14.1",
 		"fast-xml-parser": "^5.3.4",


### PR DESCRIPTION
## Summary

Fixes Dependabot alert **#774** — `extract-zip` unvalidated symlink path traversal (GHSA-jmr9-qjv8-65gv) in `examples/next/block-support/package-lock.json`.

The advisory has **no upstream fix** for `extract-zip` (`first_patched_version: null`), so we drop the dependency chain instead:

**Chain before**: `@wordpress/scripts` (optional) → `@wordpress/e2e-test-utils-playwright` → `lighthouse` → `puppeteer-core@24.x` → `@puppeteer/browsers@2.x` → `extract-zip@2.0.1`

`puppeteer-core@25.x` uses `@puppeteer/browsers@3.x`, which replaced `extract-zip` with `modern-tar`. Bumping the existing `puppeteer-core` override from `^24.10` → `^25.10.0` removes `extract-zip` from the lockfile entirely (verified with `grep -c '"extract-zip"' package-lock.json` → `0`).

## Notes

- `puppeteer-core` is only reached via `@wordpress/scripts` (an `optionalDependency` used by the `faust blockset` script). No source code in the example imports it directly.
- Lockfile diff is large because upgrading `@puppeteer/browsers` cascades several sub-dep updates; the primary payoff is that the vulnerable `extract-zip` chain is gone.

## Test plan

- [ ] `npm install` in `examples/next/block-support` completes cleanly
- [ ] `npm run blockset` still works (wp-scripts is fetched on demand via `npm exec --package=@wordpress/scripts`)
- [ ] `grep -c '"extract-zip"' examples/next/block-support/package-lock.json` returns `0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)